### PR TITLE
Fix istream to bool cast in GCC 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,109 @@ sudo: false
 
 language: cpp
 
-compiler:
-  - clang
-  - gcc
+matrix:
+  include:
+    # Clang 3.5
+    - compiler: clang
+      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+          packages:
+            - clang-3.5
+            - clang++-3.5
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
+    
+    # Clang 3.6
+    - compiler: clang
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+            - clang++-3.6
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
+    
+    # Clang 3.7
+    - compiler: clang
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+            - clang++-3.7
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
+    
+    # GCC 4.8
+    - compiler: gcc
+      env: C_COMPILER=gcc-4.8 CXX_COMPILER=g++-4.8
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+            - g++-4.8
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
+  
+    # GCC 4.9
+    - compiler: gcc
+      env: C_COMPILER=gcc-4.9 CXX_COMPILER=g++-4.9
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.9
+            - g++-4.9
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
 
-addons:
-  apt:
-    sources:
-      - boost-latest
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - libboost1.55-dev
-      - libboost-filesystem1.55-dev
-      - libboost-program-options1.55-dev
-      - libboost-regex1.55-dev
-
-install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    # GCC 5
+    - compiler: gcc
+      env: C_COMPILER=gcc-5 CXX_COMPILER=g++-5
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-5
+            - g++-5
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
 
 before_script:
-  - cmake -G "Unix Makefiles" 
+  - cmake -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_C_COMPILER=${C_COMPILER} -G "Unix Makefiles" 
 
 script:
   - make

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ If you are using Ubuntu, the required packages names will be `libboost-dev`, `li
 
 ## Build
 
+The build has been tested on the following compilers:
+* Clang 3.5 to 3.7
+* GCC 4.8 to 5.0
+
 In order to create the build scripts, please run `cmake` with your preferred generator. For instance, `cmake -G "Unix Makefiles"` will create Makefiles, and to build the binaries, you will need to run `make`. For those users who need static linkage, the option `-DBUILD_STATIC=1` must be provided to the `cmake` command.
 
 In any case, two binaries will be created in the `bin` subfolder: `vcf_validator` (the main application) and `test_validator` (unit tests).

--- a/src/vcf/main.cpp
+++ b/src/vcf/main.cpp
@@ -90,14 +90,13 @@ namespace
     std::istream & readline(std::istream & stream, Container & container)
     {
         char c;
-        bool not_eof;
 
         container.clear();
 
         do {
-            not_eof = stream.get(c);
+            stream.get(c);
             container.push_back(c);
-        } while (not_eof && c != '\n');
+        } while (!stream.eof() && c != '\n');
 
         return stream;
     }

--- a/test/vcf/input_files_test.cpp
+++ b/test/vcf/input_files_test.cpp
@@ -18,15 +18,14 @@ namespace ebi
     std::istream & readline(std::istream & stream, Container & container)
     {
         char c;
-        bool not_eof;
 
         container.clear();
 
         do {
-            not_eof = stream.get(c);
+            stream.get(c);
             container.push_back(c);
-        } while (not_eof && c != '\n');
-
+        } while (!stream.eof() && c != '\n');
+        
         return stream;
     }
     


### PR DESCRIPTION
#11 reported that GCC 5 raises an error when trying to cast from std::istream to bool the return value of istream.get(c).

This has been changed in the code, and the Travis file prepared for compile using Clang 3.5-3.7 and GCC 4.8-5.0.