### PR TITLE
Error class hierarchy

### DIFF
--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -28,10 +28,13 @@ namespace ebi
     class Error : public std::runtime_error
     {
       public:
+        Error(size_t line) : Error(line, "Error, invalid file.") {}
+
         Error(size_t line, const std::string &message)
                 : runtime_error(std::string("Line ") + std::to_string(line) + ": " + message),
                   line(line),
                   message(message) {}
+
 
         // TODO: leave here or extract? if we will allow several levels of conservative-risky fixes
 //        virtual void fix(Error, ParsingState &state);
@@ -54,65 +57,94 @@ namespace ebi
     // inheritance siblings depending on file location
     class MetaSectionError : public Error
     {
+      public:
         using Error::Error;
+        MetaSectionError(size_t line) : MetaSectionError(line, "Error in meta-data section") { }
     };
 
     class HeaderSectionError : public Error
     {
+      public:
         using Error::Error;
+        HeaderSectionError(size_t line) : HeaderSectionError(line, "Error in header section") { }
     };
 
     class BodySectionError : public Error
     {
+      public:
         using Error::Error;
+        BodySectionError(size_t line) : BodySectionError(line, "Error in body section") { }
     };
 
     // inheritance siblings about detailed errors
     class FileformatError : public MetaSectionError
     {
+      public:
         using MetaSectionError::MetaSectionError;
+        FileformatError(size_t line) : FileformatError(line, "Error in file format section") { }
     };
 
     class ChromosomeBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        ChromosomeBodyError(size_t line) : ChromosomeBodyError(line,
+            "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)") { }
     };
 
     class PositionBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        PositionBodyError(size_t line) : PositionBodyError(line, "Position is not a positive number") { }
     };
     class IdBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        IdBodyError(size_t line) : IdBodyError(line, "ID is not a single dot or a list of strings without semicolons or whitespaces") { }
     };
     class ReferenceAlleleBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        ReferenceAlleleBodyError(size_t line) : ReferenceAlleleBodyError(line, "Reference is not a string of bases") { }
     };
     class AlternateAllelesBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        AlternateAllelesBodyError(size_t line) : AlternateAllelesBodyError(line, "Alternate is not a single dot or a comma-separated list of bases") { }
     };
     class QualityBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        QualityBodyError(size_t line) : QualityBodyError(line, "Quality is not a single dot or a positive number") { }
     };
     class FilterBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        FilterBodyError(size_t line) : FilterBodyError(line, "Filter is not a single dot or a semicolon-separated list of strings") { }
     };
     class InfoBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        InfoBodyError(size_t line) : InfoBodyError(line, "Error in info column, in body section") { }
     };
     class FormatBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        FormatBodyError(size_t line) : FormatBodyError(line, "Format is not a colon-separated list of alphanumeric strings") { }
     };
     class SamplesBodyError : public BodySectionError
     {
+      public:
         using BodySectionError::BodySectionError;
+        SamplesBodyError(size_t line) : SamplesBodyError(line, "Error in samples columns, in body section") { }
     };
 
   }

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -36,7 +36,7 @@ namespace ebi
                   message(message) {}
 
 
-        // TODO: leave here or extract? if we will allow several levels of conservative-risky fixes
+        // TODO: leave here or extract? if we will allow several levels of conservative-risky fixes, it's better to extract
 //        virtual void fix(Error, ParsingState &state);
 //        virtual void fix(MetaError, ParsingState &state);
 

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VCF_ERROR_HPP
+#define VCF_ERROR_HPP
+
+namespace ebi
+{
+  namespace vcf
+  {
+    // parent of vcf errors
+    class Error : public std::runtime_error
+    {
+      public:
+        Error(size_t line, const std::string &message)
+                : runtime_error(std::string("Line ") + std::to_string(line) + ": " + message),
+                  line(line) {}
+
+        // TODO: leave here or extract? if we will allow several levels of conservative-risky fixes
+//        virtual void fix(Error, ParsingState &state);
+//        virtual void fix(MetaError, ParsingState &state);
+      private:
+        size_t line;
+    };
+
+    // inheritance siblings depending on file location
+    class MetaSectionError : public Error
+    {
+        using Error::Error;
+    };
+
+    class HeaderSectionError : public Error
+    {
+        using Error::Error;
+    };
+
+    class BodySectionError : public Error
+    {
+        using Error::Error;
+    };
+
+    // inheritance siblings about detailed errors
+    class FileformatError : public MetaSectionError
+    {
+        using MetaSectionError::MetaSectionError;
+    };
+
+    class ChromosomeBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+
+    class PositionBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class IdBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class ReferenceAlleleBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class AlternateAllelesBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class QualityBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class FilterBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class InfoBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class FormatBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+    class SamplesBodyError : public BodySectionError
+    {
+        using BodySectionError::BodySectionError;
+    };
+
+  }
+}
+
+#endif //VCF_ERROR_HPP

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -28,12 +28,12 @@ namespace ebi
     class Error : public std::runtime_error
     {
       public:
-        Error(size_t line) : Error(line, "Error, invalid file.") {}
+        Error(size_t line) : Error{line, "Error, invalid file."} {}
 
         Error(size_t line, const std::string &message)
-                : runtime_error(std::string("Line ") + std::to_string(line) + ": " + message),
-                  line(line),
-                  message(message) {}
+                : runtime_error{std::string{"Line "} + std::to_string(line) + ": " + message},
+                  line{line},
+                  message{message} {}
 
 
         // TODO: leave here or extract? if we will allow several levels of conservative-risky fixes, it's better to extract
@@ -59,21 +59,21 @@ namespace ebi
     {
       public:
         using Error::Error;
-        MetaSectionError(size_t line) : MetaSectionError(line, "Error in meta-data section") { }
+        MetaSectionError(size_t line) : MetaSectionError{line, "Error in meta-data section"} { }
     };
 
     class HeaderSectionError : public Error
     {
       public:
         using Error::Error;
-        HeaderSectionError(size_t line) : HeaderSectionError(line, "Error in header section") { }
+        HeaderSectionError(size_t line) : HeaderSectionError{line, "Error in header section"} { }
     };
 
     class BodySectionError : public Error
     {
       public:
         using Error::Error;
-        BodySectionError(size_t line) : BodySectionError(line, "Error in body section") { }
+        BodySectionError(size_t line) : BodySectionError{line, "Error in body section"} { }
     };
 
     // inheritance siblings about detailed errors
@@ -81,70 +81,70 @@ namespace ebi
     {
       public:
         using MetaSectionError::MetaSectionError;
-        FileformatError(size_t line) : FileformatError(line, "Error in file format section") { }
+        FileformatError(size_t line) : FileformatError{line, "Error in file format section"} { }
     };
 
     class ChromosomeBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        ChromosomeBodyError(size_t line) : ChromosomeBodyError(line,
-            "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)") { }
+        ChromosomeBodyError(size_t line) : ChromosomeBodyError{line,
+            "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)"} { }
     };
 
     class PositionBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        PositionBodyError(size_t line) : PositionBodyError(line, "Position is not a positive number") { }
+        PositionBodyError(size_t line) : PositionBodyError{line, "Position is not a positive number"} { }
     };
     class IdBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        IdBodyError(size_t line) : IdBodyError(line, "ID is not a single dot or a list of strings without semicolons or whitespaces") { }
+        IdBodyError(size_t line) : IdBodyError{line, "ID is not a single dot or a list of strings without semicolons or whitespaces"} { }
     };
     class ReferenceAlleleBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        ReferenceAlleleBodyError(size_t line) : ReferenceAlleleBodyError(line, "Reference is not a string of bases") { }
+        ReferenceAlleleBodyError(size_t line) : ReferenceAlleleBodyError{line, "Reference is not a string of bases"} { }
     };
     class AlternateAllelesBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        AlternateAllelesBodyError(size_t line) : AlternateAllelesBodyError(line, "Alternate is not a single dot or a comma-separated list of bases") { }
+        AlternateAllelesBodyError(size_t line) : AlternateAllelesBodyError{line, "Alternate is not a single dot or a comma-separated list of bases"} { }
     };
     class QualityBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        QualityBodyError(size_t line) : QualityBodyError(line, "Quality is not a single dot or a positive number") { }
+        QualityBodyError(size_t line) : QualityBodyError{line, "Quality is not a single dot or a positive number"} { }
     };
     class FilterBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        FilterBodyError(size_t line) : FilterBodyError(line, "Filter is not a single dot or a semicolon-separated list of strings") { }
+        FilterBodyError(size_t line) : FilterBodyError{line, "Filter is not a single dot or a semicolon-separated list of strings"} { }
     };
     class InfoBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        InfoBodyError(size_t line) : InfoBodyError(line, "Error in info column, in body section") { }
+        InfoBodyError(size_t line) : InfoBodyError{line, "Error in info column, in body section"} { }
     };
     class FormatBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        FormatBodyError(size_t line) : FormatBodyError(line, "Format is not a colon-separated list of alphanumeric strings") { }
+        FormatBodyError(size_t line) : FormatBodyError{line, "Format is not a colon-separated list of alphanumeric strings"} { }
     };
     class SamplesBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
-        SamplesBodyError(size_t line) : SamplesBodyError(line, "Error in samples columns, in body section") { }
+        SamplesBodyError(size_t line) : SamplesBodyError{line, "Error in samples columns, in body section"} { }
     };
 
   }

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -17,6 +17,9 @@
 #ifndef VCF_ERROR_HPP
 #define VCF_ERROR_HPP
 
+#include <string>
+#include <stdexcept>
+
 namespace ebi
 {
   namespace vcf
@@ -27,13 +30,25 @@ namespace ebi
       public:
         Error(size_t line, const std::string &message)
                 : runtime_error(std::string("Line ") + std::to_string(line) + ": " + message),
-                  line(line) {}
+                  line(line),
+                  message(message) {}
 
         // TODO: leave here or extract? if we will allow several levels of conservative-risky fixes
 //        virtual void fix(Error, ParsingState &state);
 //        virtual void fix(MetaError, ParsingState &state);
+
+        size_t get_line() const
+        {
+          return line;
+        }
+        const std::string &get_raw_message() const
+        {
+          return message;
+        }
+
       private:
         size_t line;
+        std::string message;
     };
 
     // inheritance siblings depending on file location

--- a/inc/vcf/error_policy.hpp
+++ b/inc/vcf/error_policy.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "parsing_utils.hpp"
+#include "error.hpp"
 
 namespace ebi
 {

--- a/inc/vcf/error_policy.hpp
+++ b/inc/vcf/error_policy.hpp
@@ -19,7 +19,7 @@
 
 #include <string>
 
-#include "parsing_utils.hpp"
+#include "parsing_state.hpp"
 #include "error.hpp"
 
 namespace ebi

--- a/inc/vcf/error_policy.hpp
+++ b/inc/vcf/error_policy.hpp
@@ -35,31 +35,6 @@ namespace ebi
       public:
         void handle_error(ParsingState &state, const Error &error);
         void handle_warning(ParsingState &state, const Error &error);
-
-        void handle_fileformat_section_error(ParsingState & state, 
-                std::string message = "Error in file format section");
-        
-        void handle_meta_section_error(ParsingState & state, 
-                std::string message = "Error in meta-data section");
-        
-        void handle_header_section_error(ParsingState & state, 
-                std::string message = "Error in header section");
-        
-        void handle_body_section_error(ParsingState & state, 
-                std::string message = "Error in body section");
-        
-        
-        void handle_fileformat_section_warning(ParsingState const & state, 
-                std::string message = "Warning in file format section");
-        
-        void handle_meta_section_warning(ParsingState const & state, 
-                std::string message = "Warning in meta-data section");
-        
-        void handle_header_section_warning(ParsingState const & state, 
-                std::string message = "Warning in header section");
-        
-        void handle_body_section_warning(ParsingState const & state, 
-                std::string message = "Warning in body section");
     };
 
     /**
@@ -70,31 +45,6 @@ namespace ebi
       public:
         void handle_error(ParsingState &state, const Error &error);
         void handle_warning(ParsingState &state, const Error &error);
-
-        void handle_fileformat_section_error(ParsingState & state, 
-                std::string message = "Error in file format section");
-        
-        void handle_meta_section_error(ParsingState & state, 
-                std::string message = "Error in meta-data section");
-        
-        void handle_header_section_error(ParsingState & state, 
-                std::string message = "Error in header section");
-        
-        void handle_body_section_error(ParsingState & state, 
-                std::string message = "Error in body section");
-        
-        
-        void handle_fileformat_section_warning(ParsingState const & state, 
-                std::string message = "Warning in file format section");
-        
-        void handle_meta_section_warning(ParsingState const & state, 
-                std::string message = "Warning in fmeta-data section");
-        
-        void handle_header_section_warning(ParsingState const & state, 
-                std::string message = "Warning in header section");
-        
-        void handle_body_section_warning(ParsingState const & state, 
-                std::string message = "Warning in body section");
     };
 
   }

--- a/inc/vcf/error_policy.hpp
+++ b/inc/vcf/error_policy.hpp
@@ -33,6 +33,9 @@ namespace ebi
     class AbortErrorPolicy
     {
       public:
+        void handle_error(ParsingState &state, const Error &error);
+        void handle_warning(ParsingState &state, const Error &error);
+
         void handle_fileformat_section_error(ParsingState & state, 
                 std::string message = "Error in file format section");
         
@@ -65,6 +68,9 @@ namespace ebi
     class ReportErrorPolicy
     {
       public:
+        void handle_error(ParsingState &state, const Error &error);
+        void handle_warning(ParsingState &state, const Error &error);
+
         void handle_fileformat_section_error(ParsingState & state, 
                 std::string message = "Error in file format section");
         

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -35,7 +35,7 @@ namespace ebi
     struct Record;
     
     typedef std::multimap<std::string, MetaEntry>::iterator meta_iterator;
-    
+
     enum InputFormat 
     {
         VCF_FILE_VCF    = 0x01,
@@ -138,13 +138,13 @@ namespace ebi
         std::shared_ptr<Source> source;
         
 
-        Record(size_t const line,
+        Record(size_t line,
                 std::string const & chromosome,
-                size_t const position,
+                size_t position,
                 std::vector<std::string> const & ids,
                 std::string const & reference_allele,
                 std::vector<std::string> const & alternate_alleles,
-                float const quality,
+                float quality,
                 std::vector<std::string> const & filters,
                 std::map<std::string, std::string> const & info,
                 std::vector<std::string> const & format,

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -66,6 +66,8 @@ namespace ebi
     struct MetaEntry
     {
         enum class Structure { NoValue, PlainValue, KeyValue };
+
+        size_t line;
         
         std::string id;
         Structure structure; // Union discriminant
@@ -73,12 +75,15 @@ namespace ebi
         boost::variant< std::string, 
                         std::map<std::string, std::string> > value;
         
-        MetaEntry(std::string const & id);
+        MetaEntry(size_t line,
+                  std::string const & id);
         
-        MetaEntry(std::string const & id,
+        MetaEntry(size_t line,
+                  std::string const & id,
                   std::string const & plain_value);
         
-        MetaEntry(std::string const & id,
+        MetaEntry(size_t line,
+                  std::string const & id,
                   std::map<std::string, std::string> const & key_values);
         
         bool operator==(MetaEntry const &) const;

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -113,6 +113,8 @@ namespace ebi
     
     struct Record 
     {
+        size_t line;
+
         std::string chromosome;
         size_t position;
         std::vector<std::string> ids;
@@ -131,17 +133,18 @@ namespace ebi
         std::shared_ptr<Source> source;
         
 
-        Record(std::string const & chromosome, 
-               size_t const position, 
-               std::vector<std::string> const & ids, 
-               std::string const & reference_allele, 
-               std::vector<std::string> const & alternate_alleles, 
-               float const quality, 
-               std::vector<std::string> const & filters, 
-               std::map<std::string, std::string> const & info, 
-               std::vector<std::string> const & format, 
-               std::vector<std::string> const & samples,
-               std::shared_ptr<Source> const & source);
+        Record(size_t const line,
+                std::string const & chromosome,
+                size_t const position,
+                std::vector<std::string> const & ids,
+                std::string const & reference_allele,
+                std::vector<std::string> const & alternate_alleles,
+                float const quality,
+                std::vector<std::string> const & filters,
+                std::map<std::string, std::string> const & info,
+                std::vector<std::string> const & format,
+                std::vector<std::string> const & samples,
+                std::shared_ptr<Source> const & source);
         
         bool operator==(Record const &) const;
 

--- a/inc/vcf/optional_policy.hpp
+++ b/inc/vcf/optional_policy.hpp
@@ -18,8 +18,9 @@
 #define	VCF_OPTIONAL_POLICY_HPP
 
 #include "file_structure.hpp"
-#include "parsing_utils.hpp"
+#include "parsing_state.hpp"
 #include "record.hpp"
+#include "error.hpp"
 
 namespace ebi
 {

--- a/inc/vcf/parse_policy.hpp
+++ b/inc/vcf/parse_policy.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-#include "parsing_utils.hpp"
+#include "parsing_state.hpp"
 #include "file_structure.hpp"
 #include "util/string_utils.hpp"
 #include "error.hpp"

--- a/inc/vcf/parse_policy.hpp
+++ b/inc/vcf/parse_policy.hpp
@@ -24,6 +24,7 @@
 #include "parsing_utils.hpp"
 #include "file_structure.hpp"
 #include "util/string_utils.hpp"
+#include "error.hpp"
 
 namespace ebi
 {

--- a/inc/vcf/parsing_state.hpp
+++ b/inc/vcf/parsing_state.hpp
@@ -67,17 +67,6 @@ namespace ebi
         
         void add_bad_defined_meta(std::string const & meta_type, std::string const & id);
     };
-
-    class ParsingError : public std::runtime_error
-    {
-        using runtime_error::runtime_error;
-    };
-
-    class ParsingWarning : public std::runtime_error
-    {
-        using runtime_error::runtime_error;
-    };
-
   }
 }
 

--- a/inc/vcf/validator.hpp
+++ b/inc/vcf/validator.hpp
@@ -30,7 +30,7 @@
 #include "error_policy.hpp"
 #include "optional_policy.hpp"
 #include "parse_policy.hpp"
-#include "parsing_utils.hpp"
+#include "parsing_state.hpp"
 #include "util/string_utils.hpp"
 
 

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 759 "src/vcf/vcf_v41.ragel"
+#line 761 "src/vcf/vcf_v41.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v41_en_meta_section_skip = 656;
 static const int vcf_v41_en_body_section_skip = 657;
 
 
-#line 765 "src/vcf/vcf_v41.ragel"
+#line 767 "src/vcf/vcf_v41.ragel"
 
 }
 
@@ -60,7 +60,7 @@ namespace ebi
 	cs = vcf_v41_start;
 	}
 
-#line 781 "src/vcf/vcf_v41.ragel"
+#line 783 "src/vcf/vcf_v41.ragel"
 
     }
 
@@ -81,56 +81,57 @@ case 1:
 tr0:
 #line 60 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr14:
 #line 219 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.1'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         p--; {goto st656;}
     }
 #line 60 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr23:
 #line 60 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
-#line 331 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
@@ -139,31 +140,32 @@ tr23:
 tr25:
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
-#line 331 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
@@ -172,616 +174,618 @@ tr25:
 tr28:
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 238 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st656;}
     }
-#line 243 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
-#line 287 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st656;}
     }
-#line 293 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr38:
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr121:
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr129:
 #line 231 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st656;}
     }
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr147:
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr158:
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr161:
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr171:
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr190:
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr200:
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr210:
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr223:
-#line 260 "src/vcf/vcf_v41.ragel"
+#line 261 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr232:
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 282 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr249:
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr260:
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr269:
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr282:
-#line 276 "src/vcf/vcf_v41.ragel"
+#line 277 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr291:
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 282 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr308:
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr319:
-#line 287 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr329:
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 287 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr341:
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr352:
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr357:
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 304 "src/vcf/vcf_v41.ragel"
+#line 305 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr359:
-#line 304 "src/vcf/vcf_v41.ragel"
+#line 305 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr369:
-#line 304 "src/vcf/vcf_v41.ragel"
+#line 305 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 310 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr372:
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 310 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr382:
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 310 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr385:
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr408:
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 238 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr417:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 326 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st656;}
     }
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 238 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr424:
-#line 243 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr435:
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 243 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr474:
-#line 293 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr486:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 326 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st656;}
     }
-#line 293 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	goto st0;
 tr494:
-#line 331 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
@@ -790,647 +794,647 @@ tr494:
 tr533:
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 	goto st0;
 tr545:
-#line 347 "src/vcf/vcf_v41.ragel"
+#line 349 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr549:
-#line 353 "src/vcf/vcf_v41.ragel"
+#line 355 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr554:
-#line 359 "src/vcf/vcf_v41.ragel"
+#line 361 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr559:
-#line 365 "src/vcf/vcf_v41.ragel"
+#line 367 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr563:
-#line 371 "src/vcf/vcf_v41.ragel"
+#line 373 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr572:
-#line 377 "src/vcf/vcf_v41.ragel"
+#line 379 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr584:
-#line 383 "src/vcf/vcf_v41.ragel"
+#line 385 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr592:
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr613:
-#line 495 "src/vcf/vcf_v41.ragel"
+#line 497 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr618:
-#line 508 "src/vcf/vcf_v41.ragel"
+#line 510 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st657;}
     }
-#line 501 "src/vcf/vcf_v41.ragel"
+#line 503 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr630:
-#line 501 "src/vcf/vcf_v41.ragel"
+#line 503 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr636:
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 401 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr638:
-#line 489 "src/vcf/vcf_v41.ragel"
+#line 491 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr640:
-#line 489 "src/vcf/vcf_v41.ragel"
+#line 491 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr647:
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 406 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr651:
-#line 409 "src/vcf/vcf_v41.ragel"
+#line 411 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr655:
-#line 414 "src/vcf/vcf_v41.ragel"
+#line 416 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr669:
-#line 419 "src/vcf/vcf_v41.ragel"
+#line 421 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr674:
-#line 424 "src/vcf/vcf_v41.ragel"
+#line 426 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr692:
-#line 429 "src/vcf/vcf_v41.ragel"
+#line 431 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr696:
-#line 434 "src/vcf/vcf_v41.ragel"
+#line 436 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr698:
-#line 434 "src/vcf/vcf_v41.ragel"
+#line 436 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr701:
-#line 439 "src/vcf/vcf_v41.ragel"
+#line 441 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr707:
-#line 444 "src/vcf/vcf_v41.ragel"
+#line 446 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr712:
-#line 449 "src/vcf/vcf_v41.ragel"
+#line 451 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr714:
-#line 449 "src/vcf/vcf_v41.ragel"
+#line 451 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr716:
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 456 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr718:
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 456 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr724:
-#line 464 "src/vcf/vcf_v41.ragel"
+#line 466 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr727:
-#line 459 "src/vcf/vcf_v41.ragel"
+#line 461 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr742:
-#line 469 "src/vcf/vcf_v41.ragel"
+#line 471 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr748:
-#line 474 "src/vcf/vcf_v41.ragel"
+#line 476 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr766:
-#line 479 "src/vcf/vcf_v41.ragel"
+#line 481 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr768:
-#line 479 "src/vcf/vcf_v41.ragel"
+#line 481 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr778:
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 486 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr780:
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 486 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
 tr844:
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
-#line 347 "src/vcf/vcf_v41.ragel"
+#line 349 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	goto st0;
-#line 1434 "inc/vcf/validator_detail_v41.hpp"
+#line 1438 "inc/vcf/validator_detail_v41.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1539,7 +1543,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1543 "inc/vcf/validator_detail_v41.hpp"
+#line 1547 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1553,7 +1557,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1557 "inc/vcf/validator_detail_v41.hpp"
+#line 1561 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1567,7 +1571,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1571 "inc/vcf/validator_detail_v41.hpp"
+#line 1575 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1581,7 +1585,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1585 "inc/vcf/validator_detail_v41.hpp"
+#line 1589 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1595,7 +1599,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1599 "inc/vcf/validator_detail_v41.hpp"
+#line 1603 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1609,7 +1613,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1613 "inc/vcf/validator_detail_v41.hpp"
+#line 1617 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 49 )
 		goto tr21;
 	goto tr14;
@@ -1623,7 +1627,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1627 "inc/vcf/validator_detail_v41.hpp"
+#line 1631 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto tr22;
 	goto tr14;
@@ -1632,8 +1636,8 @@ tr22:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError error) {
-          ErrorPolicy::handle_meta_section_error(*this, error.get_raw_message());
+        } catch (FileformatError &error) {
+          ErrorPolicy::handle_error(*this, error);
           p--; {goto st656;}
         }  
     }
@@ -1652,7 +1656,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1656 "inc/vcf/validator_detail_v41.hpp"
+#line 1660 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr23;
@@ -1705,7 +1709,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1709 "inc/vcf/validator_detail_v41.hpp"
+#line 1713 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr40;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1721,7 +1725,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1725 "inc/vcf/validator_detail_v41.hpp"
+#line 1729 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto st29;
 		case 60: goto st34;
@@ -1749,7 +1753,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 1753 "inc/vcf/validator_detail_v41.hpp"
+#line 1757 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto tr44;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1764,8 +1768,8 @@ tr44:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -1784,8 +1788,8 @@ tr52:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -1803,7 +1807,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 1807 "inc/vcf/validator_detail_v41.hpp"
+#line 1811 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr25;
@@ -1838,7 +1842,7 @@ st30:
 	if ( ++p == pe )
 		goto _test_eof30;
 case 30:
-#line 1842 "inc/vcf/validator_detail_v41.hpp"
+#line 1846 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr50;
 		case 92: goto tr51;
@@ -1866,7 +1870,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 1870 "inc/vcf/validator_detail_v41.hpp"
+#line 1874 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto tr52;
 	goto tr38;
@@ -1890,7 +1894,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 1894 "inc/vcf/validator_detail_v41.hpp"
+#line 1898 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr51;
@@ -1912,7 +1916,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 1916 "inc/vcf/validator_detail_v41.hpp"
+#line 1920 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr50;
@@ -1972,7 +1976,7 @@ st36:
 	if ( ++p == pe )
 		goto _test_eof36;
 case 36:
-#line 1976 "inc/vcf/validator_detail_v41.hpp"
+#line 1980 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr61;
 		case 92: goto tr62;
@@ -2000,7 +2004,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2004 "inc/vcf/validator_detail_v41.hpp"
+#line 2008 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st31;
 	goto tr38;
@@ -2024,7 +2028,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2028 "inc/vcf/validator_detail_v41.hpp"
+#line 2032 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr64;
 		case 92: goto tr62;
@@ -2046,7 +2050,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2050 "inc/vcf/validator_detail_v41.hpp"
+#line 2054 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr61;
 		case 62: goto tr65;
@@ -2065,7 +2069,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2069 "inc/vcf/validator_detail_v41.hpp"
+#line 2073 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr61;
@@ -2084,7 +2088,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2088 "inc/vcf/validator_detail_v41.hpp"
+#line 2092 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st41;
 	if ( (*p) < 48 ) {
@@ -2119,7 +2123,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2123 "inc/vcf/validator_detail_v41.hpp"
+#line 2127 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr68;
 		case 95: goto tr67;
@@ -2146,7 +2150,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2150 "inc/vcf/validator_detail_v41.hpp"
+#line 2154 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st62;
 	if ( (*p) < 45 ) {
@@ -2178,7 +2182,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2182 "inc/vcf/validator_detail_v41.hpp"
+#line 2186 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr72;
 		case 62: goto tr50;
@@ -2199,7 +2203,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2203 "inc/vcf/validator_detail_v41.hpp"
+#line 2207 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr73;
 	if ( (*p) < 48 ) {
@@ -2224,7 +2228,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2228 "inc/vcf/validator_detail_v41.hpp"
+#line 2232 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st46;
 	if ( (*p) < 48 ) {
@@ -2259,7 +2263,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2263 "inc/vcf/validator_detail_v41.hpp"
+#line 2267 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr77;
 		case 95: goto tr76;
@@ -2286,7 +2290,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2290 "inc/vcf/validator_detail_v41.hpp"
+#line 2294 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st49;
 	if ( (*p) < 45 ) {
@@ -2329,7 +2333,7 @@ st50:
 	if ( ++p == pe )
 		goto _test_eof50;
 case 50:
-#line 2333 "inc/vcf/validator_detail_v41.hpp"
+#line 2337 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 92: goto tr84;
@@ -2357,7 +2361,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2361 "inc/vcf/validator_detail_v41.hpp"
+#line 2365 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st45;
 		case 62: goto st31;
@@ -2383,7 +2387,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2387 "inc/vcf/validator_detail_v41.hpp"
+#line 2391 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr86;
 		case 92: goto tr84;
@@ -2405,7 +2409,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2409 "inc/vcf/validator_detail_v41.hpp"
+#line 2413 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr87;
@@ -2445,7 +2449,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2449 "inc/vcf/validator_detail_v41.hpp"
+#line 2453 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr82;
@@ -2496,7 +2500,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2500 "inc/vcf/validator_detail_v41.hpp"
+#line 2504 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr82;
@@ -2547,7 +2551,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2551 "inc/vcf/validator_detail_v41.hpp"
+#line 2555 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr82;
@@ -2590,7 +2594,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2594 "inc/vcf/validator_detail_v41.hpp"
+#line 2598 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr95;
 		case 44: goto tr82;
@@ -2620,7 +2624,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2624 "inc/vcf/validator_detail_v41.hpp"
+#line 2628 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr98;
@@ -2660,7 +2664,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2664 "inc/vcf/validator_detail_v41.hpp"
+#line 2668 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr83;
@@ -2689,7 +2693,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2693 "inc/vcf/validator_detail_v41.hpp"
+#line 2697 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr86;
 		case 44: goto tr98;
@@ -2709,7 +2713,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 2713 "inc/vcf/validator_detail_v41.hpp"
+#line 2717 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr80;
 		case 44: goto tr101;
@@ -2750,7 +2754,7 @@ st63:
 	if ( ++p == pe )
 		goto _test_eof63;
 case 63:
-#line 2754 "inc/vcf/validator_detail_v41.hpp"
+#line 2758 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 92: goto tr106;
@@ -2778,7 +2782,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 2782 "inc/vcf/validator_detail_v41.hpp"
+#line 2786 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr107;
 		case 92: goto tr106;
@@ -2800,7 +2804,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 2804 "inc/vcf/validator_detail_v41.hpp"
+#line 2808 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr108;
@@ -2830,7 +2834,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 2834 "inc/vcf/validator_detail_v41.hpp"
+#line 2838 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr105;
@@ -2881,7 +2885,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 2885 "inc/vcf/validator_detail_v41.hpp"
+#line 2889 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr105;
@@ -2932,7 +2936,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 2936 "inc/vcf/validator_detail_v41.hpp"
+#line 2940 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr105;
@@ -2975,7 +2979,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 2979 "inc/vcf/validator_detail_v41.hpp"
+#line 2983 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr95;
 		case 44: goto tr105;
@@ -3005,7 +3009,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3009 "inc/vcf/validator_detail_v41.hpp"
+#line 3013 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr118;
@@ -3035,7 +3039,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3039 "inc/vcf/validator_detail_v41.hpp"
+#line 3043 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr83;
@@ -3064,7 +3068,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3068 "inc/vcf/validator_detail_v41.hpp"
+#line 3072 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr107;
 		case 44: goto tr118;
@@ -3088,7 +3092,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3092 "inc/vcf/validator_detail_v41.hpp"
+#line 3096 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 76: goto tr122;
@@ -3106,7 +3110,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3110 "inc/vcf/validator_detail_v41.hpp"
+#line 3114 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 84: goto st75;
@@ -3133,7 +3137,7 @@ st76:
 	if ( ++p == pe )
 		goto _test_eof76;
 case 76:
-#line 3137 "inc/vcf/validator_detail_v41.hpp"
+#line 3141 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st77;
 	goto tr121;
@@ -3199,7 +3203,7 @@ st81:
 	if ( ++p == pe )
 		goto _test_eof81;
 case 81:
-#line 3203 "inc/vcf/validator_detail_v41.hpp"
+#line 3207 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr132;
 		case 95: goto tr133;
@@ -3223,7 +3227,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3227 "inc/vcf/validator_detail_v41.hpp"
+#line 3231 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st83;
 	goto tr121;
@@ -3321,7 +3325,7 @@ st95:
 	if ( ++p == pe )
 		goto _test_eof95;
 case 95:
-#line 3325 "inc/vcf/validator_detail_v41.hpp"
+#line 3329 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr149;
 		case 92: goto tr150;
@@ -3349,7 +3353,7 @@ st96:
 	if ( ++p == pe )
 		goto _test_eof96;
 case 96:
-#line 3353 "inc/vcf/validator_detail_v41.hpp"
+#line 3357 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 92: goto tr153;
@@ -3377,7 +3381,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3381 "inc/vcf/validator_detail_v41.hpp"
+#line 3385 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st98;
 	goto tr147;
@@ -3408,7 +3412,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3412 "inc/vcf/validator_detail_v41.hpp"
+#line 3416 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 92: goto tr153;
@@ -3430,7 +3434,7 @@ st100:
 	if ( ++p == pe )
 		goto _test_eof100;
 case 100:
-#line 3434 "inc/vcf/validator_detail_v41.hpp"
+#line 3438 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 62: goto tr156;
@@ -3449,7 +3453,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3453 "inc/vcf/validator_detail_v41.hpp"
+#line 3457 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr152;
@@ -3472,7 +3476,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3476 "inc/vcf/validator_detail_v41.hpp"
+#line 3480 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto st102;
 		case 95: goto st102;
@@ -3500,7 +3504,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3504 "inc/vcf/validator_detail_v41.hpp"
+#line 3508 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 73: goto tr159;
@@ -3519,7 +3523,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3523 "inc/vcf/validator_detail_v41.hpp"
+#line 3527 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 76: goto tr162;
@@ -3537,7 +3541,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3541 "inc/vcf/validator_detail_v41.hpp"
+#line 3545 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 84: goto tr163;
@@ -3555,7 +3559,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3559 "inc/vcf/validator_detail_v41.hpp"
+#line 3563 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto tr164;
@@ -3573,7 +3577,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3577 "inc/vcf/validator_detail_v41.hpp"
+#line 3581 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 82: goto st108;
@@ -3600,7 +3604,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 3604 "inc/vcf/validator_detail_v41.hpp"
+#line 3608 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st110;
 	goto tr161;
@@ -3657,7 +3661,7 @@ st114:
 	if ( ++p == pe )
 		goto _test_eof114;
 case 114:
-#line 3661 "inc/vcf/validator_detail_v41.hpp"
+#line 3665 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st114;
 	if ( (*p) < 48 ) {
@@ -3696,7 +3700,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 3700 "inc/vcf/validator_detail_v41.hpp"
+#line 3704 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr176;
 		case 95: goto tr175;
@@ -3723,7 +3727,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 3727 "inc/vcf/validator_detail_v41.hpp"
+#line 3731 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st117;
 	goto tr161;
@@ -3821,7 +3825,7 @@ st129:
 	if ( ++p == pe )
 		goto _test_eof129;
 case 129:
-#line 3825 "inc/vcf/validator_detail_v41.hpp"
+#line 3829 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr192;
 		case 92: goto tr193;
@@ -3849,7 +3853,7 @@ st130:
 	if ( ++p == pe )
 		goto _test_eof130;
 case 130:
-#line 3853 "inc/vcf/validator_detail_v41.hpp"
+#line 3857 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr195;
 		case 92: goto tr196;
@@ -3877,7 +3881,7 @@ st131:
 	if ( ++p == pe )
 		goto _test_eof131;
 case 131:
-#line 3881 "inc/vcf/validator_detail_v41.hpp"
+#line 3885 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st132;
 	goto tr190;
@@ -3908,7 +3912,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 3912 "inc/vcf/validator_detail_v41.hpp"
+#line 3916 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr198;
 		case 92: goto tr196;
@@ -3930,7 +3934,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 3934 "inc/vcf/validator_detail_v41.hpp"
+#line 3938 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr195;
 		case 62: goto tr199;
@@ -3949,7 +3953,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 3953 "inc/vcf/validator_detail_v41.hpp"
+#line 3957 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr195;
@@ -3968,7 +3972,7 @@ st136:
 	if ( ++p == pe )
 		goto _test_eof136;
 case 136:
-#line 3972 "inc/vcf/validator_detail_v41.hpp"
+#line 3976 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 82: goto tr201;
@@ -3986,7 +3990,7 @@ st137:
 	if ( ++p == pe )
 		goto _test_eof137;
 case 137:
-#line 3990 "inc/vcf/validator_detail_v41.hpp"
+#line 3994 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 77: goto tr202;
@@ -4004,7 +4008,7 @@ st138:
 	if ( ++p == pe )
 		goto _test_eof138;
 case 138:
-#line 4008 "inc/vcf/validator_detail_v41.hpp"
+#line 4012 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 65: goto tr203;
@@ -4022,7 +4026,7 @@ st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 4026 "inc/vcf/validator_detail_v41.hpp"
+#line 4030 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 84: goto st140;
@@ -4049,7 +4053,7 @@ st141:
 	if ( ++p == pe )
 		goto _test_eof141;
 case 141:
-#line 4053 "inc/vcf/validator_detail_v41.hpp"
+#line 4057 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st142;
 	goto tr200;
@@ -4106,7 +4110,7 @@ st146:
 	if ( ++p == pe )
 		goto _test_eof146;
 case 146:
-#line 4110 "inc/vcf/validator_detail_v41.hpp"
+#line 4114 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st146;
 	if ( (*p) < 48 ) {
@@ -4145,7 +4149,7 @@ st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 4149 "inc/vcf/validator_detail_v41.hpp"
+#line 4153 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr215;
 		case 95: goto tr214;
@@ -4172,7 +4176,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4176 "inc/vcf/validator_detail_v41.hpp"
+#line 4180 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st149;
 	goto tr200;
@@ -4248,7 +4252,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 4252 "inc/vcf/validator_detail_v41.hpp"
+#line 4256 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr226;
 	goto tr223;
@@ -4262,7 +4266,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4266 "inc/vcf/validator_detail_v41.hpp"
+#line 4270 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st158;
 	goto tr200;
@@ -4328,7 +4332,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 4332 "inc/vcf/validator_detail_v41.hpp"
+#line 4336 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr234;
 	if ( (*p) > 90 ) {
@@ -4347,7 +4351,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 4351 "inc/vcf/validator_detail_v41.hpp"
+#line 4355 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st165;
 	goto tr200;
@@ -4445,7 +4449,7 @@ st177:
 	if ( ++p == pe )
 		goto _test_eof177;
 case 177:
-#line 4449 "inc/vcf/validator_detail_v41.hpp"
+#line 4453 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr251;
 		case 92: goto tr252;
@@ -4473,7 +4477,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 4477 "inc/vcf/validator_detail_v41.hpp"
+#line 4481 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr255;
@@ -4501,7 +4505,7 @@ st179:
 	if ( ++p == pe )
 		goto _test_eof179;
 case 179:
-#line 4505 "inc/vcf/validator_detail_v41.hpp"
+#line 4509 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st180;
 	goto tr249;
@@ -4532,7 +4536,7 @@ st181:
 	if ( ++p == pe )
 		goto _test_eof181;
 case 181:
-#line 4536 "inc/vcf/validator_detail_v41.hpp"
+#line 4540 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr257;
 		case 92: goto tr255;
@@ -4554,7 +4558,7 @@ st182:
 	if ( ++p == pe )
 		goto _test_eof182;
 case 182:
-#line 4558 "inc/vcf/validator_detail_v41.hpp"
+#line 4562 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 62: goto tr258;
@@ -4573,7 +4577,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 4577 "inc/vcf/validator_detail_v41.hpp"
+#line 4581 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr254;
@@ -4606,7 +4610,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 4610 "inc/vcf/validator_detail_v41.hpp"
+#line 4614 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr226;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -4626,7 +4630,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 4630 "inc/vcf/validator_detail_v41.hpp"
+#line 4634 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 78: goto tr261;
@@ -4644,7 +4648,7 @@ st186:
 	if ( ++p == pe )
 		goto _test_eof186;
 case 186:
-#line 4648 "inc/vcf/validator_detail_v41.hpp"
+#line 4652 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 70: goto tr262;
@@ -4662,7 +4666,7 @@ st187:
 	if ( ++p == pe )
 		goto _test_eof187;
 case 187:
-#line 4666 "inc/vcf/validator_detail_v41.hpp"
+#line 4670 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 79: goto st188;
@@ -4689,7 +4693,7 @@ st189:
 	if ( ++p == pe )
 		goto _test_eof189;
 case 189:
-#line 4693 "inc/vcf/validator_detail_v41.hpp"
+#line 4697 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st190;
 	goto tr260;
@@ -4746,7 +4750,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 4750 "inc/vcf/validator_detail_v41.hpp"
+#line 4754 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st194;
 	if ( (*p) < 48 ) {
@@ -4785,7 +4789,7 @@ st195:
 	if ( ++p == pe )
 		goto _test_eof195;
 case 195:
-#line 4789 "inc/vcf/validator_detail_v41.hpp"
+#line 4793 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr274;
 		case 95: goto tr273;
@@ -4812,7 +4816,7 @@ st196:
 	if ( ++p == pe )
 		goto _test_eof196;
 case 196:
-#line 4816 "inc/vcf/validator_detail_v41.hpp"
+#line 4820 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st197;
 	goto tr260;
@@ -4888,7 +4892,7 @@ st204:
 	if ( ++p == pe )
 		goto _test_eof204;
 case 204:
-#line 4892 "inc/vcf/validator_detail_v41.hpp"
+#line 4896 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr285;
 	goto tr282;
@@ -4902,7 +4906,7 @@ st205:
 	if ( ++p == pe )
 		goto _test_eof205;
 case 205:
-#line 4906 "inc/vcf/validator_detail_v41.hpp"
+#line 4910 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st206;
 	goto tr260;
@@ -4968,7 +4972,7 @@ st211:
 	if ( ++p == pe )
 		goto _test_eof211;
 case 211:
-#line 4972 "inc/vcf/validator_detail_v41.hpp"
+#line 4976 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr293;
 	if ( (*p) > 90 ) {
@@ -4987,7 +4991,7 @@ st212:
 	if ( ++p == pe )
 		goto _test_eof212;
 case 212:
-#line 4991 "inc/vcf/validator_detail_v41.hpp"
+#line 4995 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st213;
 	goto tr260;
@@ -5085,7 +5089,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 5089 "inc/vcf/validator_detail_v41.hpp"
+#line 5093 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr310;
 		case 92: goto tr311;
@@ -5113,7 +5117,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 5117 "inc/vcf/validator_detail_v41.hpp"
+#line 5121 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr313;
 		case 92: goto tr314;
@@ -5141,7 +5145,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 5145 "inc/vcf/validator_detail_v41.hpp"
+#line 5149 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st228;
 	goto tr308;
@@ -5172,7 +5176,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 5176 "inc/vcf/validator_detail_v41.hpp"
+#line 5180 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 92: goto tr314;
@@ -5194,7 +5198,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 5198 "inc/vcf/validator_detail_v41.hpp"
+#line 5202 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr313;
 		case 62: goto tr317;
@@ -5213,7 +5217,7 @@ st231:
 	if ( ++p == pe )
 		goto _test_eof231;
 case 231:
-#line 5217 "inc/vcf/validator_detail_v41.hpp"
+#line 5221 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr313;
@@ -5246,7 +5250,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 5250 "inc/vcf/validator_detail_v41.hpp"
+#line 5254 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr285;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -5266,7 +5270,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 5270 "inc/vcf/validator_detail_v41.hpp"
+#line 5274 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto tr320;
@@ -5284,7 +5288,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 5288 "inc/vcf/validator_detail_v41.hpp"
+#line 5292 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 68: goto tr321;
@@ -5302,7 +5306,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 5306 "inc/vcf/validator_detail_v41.hpp"
+#line 5310 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 73: goto tr322;
@@ -5320,7 +5324,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 5324 "inc/vcf/validator_detail_v41.hpp"
+#line 5328 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 71: goto tr323;
@@ -5338,7 +5342,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 5342 "inc/vcf/validator_detail_v41.hpp"
+#line 5346 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 82: goto tr324;
@@ -5356,7 +5360,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 5360 "inc/vcf/validator_detail_v41.hpp"
+#line 5364 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto tr325;
@@ -5374,7 +5378,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 5378 "inc/vcf/validator_detail_v41.hpp"
+#line 5382 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto st240;
@@ -5401,7 +5405,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 5405 "inc/vcf/validator_detail_v41.hpp"
+#line 5409 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st242;
 	goto tr319;
@@ -5415,7 +5419,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 5419 "inc/vcf/validator_detail_v41.hpp"
+#line 5423 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr330;
 	if ( (*p) < 48 ) {
@@ -5440,7 +5444,7 @@ st243:
 	if ( ++p == pe )
 		goto _test_eof243;
 case 243:
-#line 5444 "inc/vcf/validator_detail_v41.hpp"
+#line 5448 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st243;
 	if ( (*p) < 48 ) {
@@ -5475,7 +5479,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 5479 "inc/vcf/validator_detail_v41.hpp"
+#line 5483 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr334;
 		case 95: goto tr333;
@@ -5502,7 +5506,7 @@ st245:
 	if ( ++p == pe )
 		goto _test_eof245;
 case 245:
-#line 5506 "inc/vcf/validator_detail_v41.hpp"
+#line 5510 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr335;
 	if ( (*p) < 48 ) {
@@ -5527,7 +5531,7 @@ st246:
 	if ( ++p == pe )
 		goto _test_eof246;
 case 246:
-#line 5531 "inc/vcf/validator_detail_v41.hpp"
+#line 5535 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st246;
 	if ( (*p) < 48 ) {
@@ -5562,7 +5566,7 @@ st247:
 	if ( ++p == pe )
 		goto _test_eof247;
 case 247:
-#line 5566 "inc/vcf/validator_detail_v41.hpp"
+#line 5570 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr339;
 		case 62: goto tr340;
@@ -5590,7 +5594,7 @@ st248:
 	if ( ++p == pe )
 		goto _test_eof248;
 case 248:
-#line 5594 "inc/vcf/validator_detail_v41.hpp"
+#line 5598 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto tr52;
 	goto tr319;
@@ -5608,7 +5612,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 5612 "inc/vcf/validator_detail_v41.hpp"
+#line 5616 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 65: goto tr342;
@@ -5626,7 +5630,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 5630 "inc/vcf/validator_detail_v41.hpp"
+#line 5634 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 77: goto tr343;
@@ -5644,7 +5648,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 5648 "inc/vcf/validator_detail_v41.hpp"
+#line 5652 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 80: goto tr344;
@@ -5662,7 +5666,7 @@ st252:
 	if ( ++p == pe )
 		goto _test_eof252;
 case 252:
-#line 5666 "inc/vcf/validator_detail_v41.hpp"
+#line 5670 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 76: goto tr345;
@@ -5680,7 +5684,7 @@ st253:
 	if ( ++p == pe )
 		goto _test_eof253;
 case 253:
-#line 5684 "inc/vcf/validator_detail_v41.hpp"
+#line 5688 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto st254;
@@ -5707,7 +5711,7 @@ st255:
 	if ( ++p == pe )
 		goto _test_eof255;
 case 255:
-#line 5711 "inc/vcf/validator_detail_v41.hpp"
+#line 5715 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st256;
 	goto tr341;
@@ -5764,7 +5768,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 5768 "inc/vcf/validator_detail_v41.hpp"
+#line 5772 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st260;
 	if ( (*p) < 48 ) {
@@ -5803,7 +5807,7 @@ st261:
 	if ( ++p == pe )
 		goto _test_eof261;
 case 261:
-#line 5807 "inc/vcf/validator_detail_v41.hpp"
+#line 5811 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr358;
 		case 95: goto tr356;
@@ -5830,7 +5834,7 @@ st262:
 	if ( ++p == pe )
 		goto _test_eof262;
 case 262:
-#line 5834 "inc/vcf/validator_detail_v41.hpp"
+#line 5838 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 71 )
 		goto st263;
 	goto tr359;
@@ -5923,7 +5927,7 @@ st271:
 	if ( ++p == pe )
 		goto _test_eof271;
 case 271:
-#line 5927 "inc/vcf/validator_detail_v41.hpp"
+#line 5931 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr371;
 	if ( (*p) < 35 ) {
@@ -5945,7 +5949,7 @@ st272:
 	if ( ++p == pe )
 		goto _test_eof272;
 case 272:
-#line 5949 "inc/vcf/validator_detail_v41.hpp"
+#line 5953 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 77 )
 		goto st273;
 	goto tr372;
@@ -6038,7 +6042,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 6042 "inc/vcf/validator_detail_v41.hpp"
+#line 6046 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr384;
 	if ( (*p) < 35 ) {
@@ -6060,7 +6064,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 6064 "inc/vcf/validator_detail_v41.hpp"
+#line 6068 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st283;
 	goto tr385;
@@ -6158,7 +6162,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 6162 "inc/vcf/validator_detail_v41.hpp"
+#line 6166 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr400;
 		case 92: goto tr401;
@@ -6186,7 +6190,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 6190 "inc/vcf/validator_detail_v41.hpp"
+#line 6194 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr403;
 		case 92: goto tr404;
@@ -6214,7 +6218,7 @@ st297:
 	if ( ++p == pe )
 		goto _test_eof297;
 case 297:
-#line 6218 "inc/vcf/validator_detail_v41.hpp"
+#line 6222 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st298;
 	goto tr385;
@@ -6245,7 +6249,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 6249 "inc/vcf/validator_detail_v41.hpp"
+#line 6253 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 92: goto tr404;
@@ -6267,7 +6271,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 6271 "inc/vcf/validator_detail_v41.hpp"
+#line 6275 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr403;
 		case 62: goto tr407;
@@ -6286,7 +6290,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 6290 "inc/vcf/validator_detail_v41.hpp"
+#line 6294 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr403;
@@ -6309,7 +6313,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 6313 "inc/vcf/validator_detail_v41.hpp"
+#line 6317 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 115: goto tr409;
@@ -6327,7 +6331,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 6331 "inc/vcf/validator_detail_v41.hpp"
+#line 6335 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 115: goto tr410;
@@ -6345,7 +6349,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 6349 "inc/vcf/validator_detail_v41.hpp"
+#line 6353 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr411;
@@ -6363,7 +6367,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 6367 "inc/vcf/validator_detail_v41.hpp"
+#line 6371 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 109: goto tr412;
@@ -6381,7 +6385,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 6385 "inc/vcf/validator_detail_v41.hpp"
+#line 6389 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 98: goto tr413;
@@ -6399,7 +6403,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 6403 "inc/vcf/validator_detail_v41.hpp"
+#line 6407 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 108: goto tr414;
@@ -6417,7 +6421,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 6421 "inc/vcf/validator_detail_v41.hpp"
+#line 6425 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 121: goto st309;
@@ -6444,7 +6448,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 6448 "inc/vcf/validator_detail_v41.hpp"
+#line 6452 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr418;
@@ -6461,7 +6465,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 6465 "inc/vcf/validator_detail_v41.hpp"
+#line 6469 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr417;
 		case 35: goto tr417;
@@ -6516,7 +6520,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 6520 "inc/vcf/validator_detail_v41.hpp"
+#line 6524 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto tr44;
 	goto tr423;
@@ -6534,7 +6538,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 6538 "inc/vcf/validator_detail_v41.hpp"
+#line 6542 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 111: goto tr425;
@@ -6552,7 +6556,7 @@ st318:
 	if ( ++p == pe )
 		goto _test_eof318;
 case 318:
-#line 6556 "inc/vcf/validator_detail_v41.hpp"
+#line 6560 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 110: goto tr426;
@@ -6570,7 +6574,7 @@ st319:
 	if ( ++p == pe )
 		goto _test_eof319;
 case 319:
-#line 6574 "inc/vcf/validator_detail_v41.hpp"
+#line 6578 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 116: goto tr427;
@@ -6588,7 +6592,7 @@ st320:
 	if ( ++p == pe )
 		goto _test_eof320;
 case 320:
-#line 6592 "inc/vcf/validator_detail_v41.hpp"
+#line 6596 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 105: goto tr428;
@@ -6606,7 +6610,7 @@ st321:
 	if ( ++p == pe )
 		goto _test_eof321;
 case 321:
-#line 6610 "inc/vcf/validator_detail_v41.hpp"
+#line 6614 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 103: goto st322;
@@ -6633,7 +6637,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 6637 "inc/vcf/validator_detail_v41.hpp"
+#line 6641 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st324;
 	goto tr424;
@@ -6689,7 +6693,7 @@ st328:
 	if ( ++p == pe )
 		goto _test_eof328;
 case 328:
-#line 6693 "inc/vcf/validator_detail_v41.hpp"
+#line 6697 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr438;
 		case 59: goto tr437;
@@ -6726,7 +6730,7 @@ st329:
 	if ( ++p == pe )
 		goto _test_eof329;
 case 329:
-#line 6730 "inc/vcf/validator_detail_v41.hpp"
+#line 6734 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr437;
 		case 61: goto tr437;
@@ -6765,7 +6769,7 @@ st330:
 	if ( ++p == pe )
 		goto _test_eof330;
 case 330:
-#line 6769 "inc/vcf/validator_detail_v41.hpp"
+#line 6773 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr438;
 		case 59: goto tr439;
@@ -6787,7 +6791,7 @@ st331:
 	if ( ++p == pe )
 		goto _test_eof331;
 case 331:
-#line 6791 "inc/vcf/validator_detail_v41.hpp"
+#line 6795 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr441;
 	if ( (*p) < 48 ) {
@@ -6812,7 +6816,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 6816 "inc/vcf/validator_detail_v41.hpp"
+#line 6820 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st332;
 	if ( (*p) < 48 ) {
@@ -6847,7 +6851,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 6851 "inc/vcf/validator_detail_v41.hpp"
+#line 6855 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr445;
 		case 95: goto tr444;
@@ -6874,7 +6878,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 6878 "inc/vcf/validator_detail_v41.hpp"
+#line 6882 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st337;
 	if ( (*p) < 45 ) {
@@ -6906,7 +6910,7 @@ st335:
 	if ( ++p == pe )
 		goto _test_eof335;
 case 335:
-#line 6910 "inc/vcf/validator_detail_v41.hpp"
+#line 6914 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr438;
 		case 62: goto tr440;
@@ -6927,7 +6931,7 @@ st336:
 	if ( ++p == pe )
 		goto _test_eof336;
 case 336:
-#line 6931 "inc/vcf/validator_detail_v41.hpp"
+#line 6935 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto tr52;
 	goto tr424;
@@ -6962,7 +6966,7 @@ st338:
 	if ( ++p == pe )
 		goto _test_eof338;
 case 338:
-#line 6966 "inc/vcf/validator_detail_v41.hpp"
+#line 6970 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr453;
 		case 92: goto tr454;
@@ -6990,7 +6994,7 @@ st339:
 	if ( ++p == pe )
 		goto _test_eof339;
 case 339:
-#line 6994 "inc/vcf/validator_detail_v41.hpp"
+#line 6998 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st331;
 		case 62: goto st336;
@@ -7016,7 +7020,7 @@ st340:
 	if ( ++p == pe )
 		goto _test_eof340;
 case 340:
-#line 7020 "inc/vcf/validator_detail_v41.hpp"
+#line 7024 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr457;
 		case 92: goto tr454;
@@ -7038,7 +7042,7 @@ st341:
 	if ( ++p == pe )
 		goto _test_eof341;
 case 341:
-#line 7042 "inc/vcf/validator_detail_v41.hpp"
+#line 7046 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr453;
 		case 44: goto tr458;
@@ -7078,7 +7082,7 @@ st342:
 	if ( ++p == pe )
 		goto _test_eof342;
 case 342:
-#line 7082 "inc/vcf/validator_detail_v41.hpp"
+#line 7086 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr453;
 		case 47: goto tr452;
@@ -7129,7 +7133,7 @@ st343:
 	if ( ++p == pe )
 		goto _test_eof343;
 case 343:
-#line 7133 "inc/vcf/validator_detail_v41.hpp"
+#line 7137 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr453;
 		case 47: goto tr452;
@@ -7180,7 +7184,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 7184 "inc/vcf/validator_detail_v41.hpp"
+#line 7188 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr453;
 		case 47: goto tr452;
@@ -7223,7 +7227,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 7227 "inc/vcf/validator_detail_v41.hpp"
+#line 7231 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr466;
 		case 44: goto tr452;
@@ -7253,7 +7257,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 7257 "inc/vcf/validator_detail_v41.hpp"
+#line 7261 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr453;
 		case 44: goto tr469;
@@ -7293,7 +7297,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 7297 "inc/vcf/validator_detail_v41.hpp"
+#line 7301 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr453;
@@ -7322,7 +7326,7 @@ st348:
 	if ( ++p == pe )
 		goto _test_eof348;
 case 348:
-#line 7326 "inc/vcf/validator_detail_v41.hpp"
+#line 7330 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr457;
 		case 44: goto tr469;
@@ -7342,7 +7346,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 7346 "inc/vcf/validator_detail_v41.hpp"
+#line 7350 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr450;
 		case 44: goto tr472;
@@ -7366,7 +7370,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 7370 "inc/vcf/validator_detail_v41.hpp"
+#line 7374 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr475;
@@ -7384,7 +7388,7 @@ st351:
 	if ( ++p == pe )
 		goto _test_eof351;
 case 351:
-#line 7388 "inc/vcf/validator_detail_v41.hpp"
+#line 7392 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 100: goto tr476;
@@ -7402,7 +7406,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 7406 "inc/vcf/validator_detail_v41.hpp"
+#line 7410 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 105: goto tr477;
@@ -7420,7 +7424,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 7424 "inc/vcf/validator_detail_v41.hpp"
+#line 7428 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 103: goto tr478;
@@ -7438,7 +7442,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 7442 "inc/vcf/validator_detail_v41.hpp"
+#line 7446 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 114: goto tr479;
@@ -7456,7 +7460,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 7460 "inc/vcf/validator_detail_v41.hpp"
+#line 7464 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr480;
@@ -7474,7 +7478,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 7478 "inc/vcf/validator_detail_v41.hpp"
+#line 7482 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr481;
@@ -7492,7 +7496,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 7496 "inc/vcf/validator_detail_v41.hpp"
+#line 7500 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 68: goto tr482;
@@ -7510,7 +7514,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 7514 "inc/vcf/validator_detail_v41.hpp"
+#line 7518 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 66: goto st359;
@@ -7537,7 +7541,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 7541 "inc/vcf/validator_detail_v41.hpp"
+#line 7545 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st361;
 	goto tr474;
@@ -7561,7 +7565,7 @@ st362:
 	if ( ++p == pe )
 		goto _test_eof362;
 case 362:
-#line 7565 "inc/vcf/validator_detail_v41.hpp"
+#line 7569 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr486;
 		case 35: goto tr486;
@@ -7616,7 +7620,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 7620 "inc/vcf/validator_detail_v41.hpp"
+#line 7624 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr486;
 		case 62: goto tr493;
@@ -7636,7 +7640,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 7640 "inc/vcf/validator_detail_v41.hpp"
+#line 7644 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 62: goto tr493;
@@ -7962,7 +7966,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 7966 "inc/vcf/validator_detail_v41.hpp"
+#line 7970 "inc/vcf/validator_detail_v41.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr541;
 	goto tr533;
@@ -7986,7 +7990,7 @@ st414:
 	if ( ++p == pe )
 		goto _test_eof414;
 case 414:
-#line 7990 "inc/vcf/validator_detail_v41.hpp"
+#line 7994 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr542;
 		case 10: goto tr543;
@@ -8034,7 +8038,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 8038 "inc/vcf/validator_detail_v41.hpp"
+#line 8042 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr846;
 	if ( (*p) < 65 ) {
@@ -8061,8 +8065,8 @@ tr845:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 #line 31 "src/vcf/vcf_v41.ragel"
@@ -8078,7 +8082,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 8082 "inc/vcf/validator_detail_v41.hpp"
+#line 8086 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr546;
 		case 59: goto tr547;
@@ -8133,7 +8137,7 @@ st416:
 	if ( ++p == pe )
 		goto _test_eof416;
 case 416:
-#line 8137 "inc/vcf/validator_detail_v41.hpp"
+#line 8141 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr550;
 		case 45: goto tr550;
@@ -8151,7 +8155,7 @@ st417:
 	if ( ++p == pe )
 		goto _test_eof417;
 case 417:
-#line 8155 "inc/vcf/validator_detail_v41.hpp"
+#line 8159 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr552;
 	goto tr549;
@@ -8175,7 +8179,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 8179 "inc/vcf/validator_detail_v41.hpp"
+#line 8183 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr553;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8205,7 +8209,7 @@ st419:
 	if ( ++p == pe )
 		goto _test_eof419;
 case 419:
-#line 8209 "inc/vcf/validator_detail_v41.hpp"
+#line 8213 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr555;
@@ -8232,7 +8236,7 @@ st420:
 	if ( ++p == pe )
 		goto _test_eof420;
 case 420:
-#line 8236 "inc/vcf/validator_detail_v41.hpp"
+#line 8240 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr556;
 		case 59: goto tr558;
@@ -8258,7 +8262,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 8262 "inc/vcf/validator_detail_v41.hpp"
+#line 8266 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr560;
 		case 67: goto tr560;
@@ -8292,7 +8296,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 8296 "inc/vcf/validator_detail_v41.hpp"
+#line 8300 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr561;
 		case 65: goto tr562;
@@ -8325,7 +8329,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 8329 "inc/vcf/validator_detail_v41.hpp"
+#line 8333 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr564;
 		case 46: goto tr565;
@@ -8364,7 +8368,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 8368 "inc/vcf/validator_detail_v41.hpp"
+#line 8372 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr570;
 		case 44: goto tr571;
@@ -8388,7 +8392,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 8392 "inc/vcf/validator_detail_v41.hpp"
+#line 8396 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr573;
 		case 45: goto tr573;
@@ -8413,7 +8417,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 8417 "inc/vcf/validator_detail_v41.hpp"
+#line 8421 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr578;
 		case 73: goto tr580;
@@ -8431,7 +8435,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 8435 "inc/vcf/validator_detail_v41.hpp"
+#line 8439 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr581;
 	goto tr572;
@@ -8445,7 +8449,7 @@ st428:
 	if ( ++p == pe )
 		goto _test_eof428;
 case 428:
-#line 8449 "inc/vcf/validator_detail_v41.hpp"
+#line 8453 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr582;
 		case 69: goto tr583;
@@ -8472,7 +8476,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 8476 "inc/vcf/validator_detail_v41.hpp"
+#line 8480 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr586;
 		case 58: goto tr585;
@@ -8508,7 +8512,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 8512 "inc/vcf/validator_detail_v41.hpp"
+#line 8516 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto st430;
 	if ( (*p) < 65 ) {
@@ -8552,7 +8556,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 8556 "inc/vcf/validator_detail_v41.hpp"
+#line 8560 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr590;
 		case 59: goto tr591;
@@ -8578,7 +8582,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 8582 "inc/vcf/validator_detail_v41.hpp"
+#line 8586 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr594;
 		case 49: goto tr596;
@@ -8636,7 +8640,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 8640 "inc/vcf/validator_detail_v41.hpp"
+#line 8644 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr607;
 		case 60: goto tr607;
@@ -8682,7 +8686,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 8686 "inc/vcf/validator_detail_v41.hpp"
+#line 8690 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -8716,7 +8720,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 8720 "inc/vcf/validator_detail_v41.hpp"
+#line 8724 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr614;
 	if ( (*p) > 90 ) {
@@ -8745,7 +8749,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 8749 "inc/vcf/validator_detail_v41.hpp"
+#line 8753 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr615;
 		case 46: goto tr616;
@@ -8779,7 +8783,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 8783 "inc/vcf/validator_detail_v41.hpp"
+#line 8787 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr619;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8805,7 +8809,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 8809 "inc/vcf/validator_detail_v41.hpp"
+#line 8813 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr615;
 		case 10: goto tr610;
@@ -8831,13 +8835,13 @@ tr610:
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-            } catch (MetaSectionError &ex) {
-                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
-            } catch (BodySectionError &ex) {
-                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            } catch (MetaSectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
+            } catch (BodySectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError ex) {
-            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
+        } catch (BodySectionError &error) {
+            ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -8855,7 +8859,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 8859 "inc/vcf/validator_detail_v41.hpp"
+#line 8863 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st439;
 	if ( (*p) < 65 ) {
@@ -8872,8 +8876,8 @@ tr846:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 	goto st439;
@@ -8881,7 +8885,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 8885 "inc/vcf/validator_detail_v41.hpp"
+#line 8889 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr623;
@@ -8905,7 +8909,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 8909 "inc/vcf/validator_detail_v41.hpp"
+#line 8913 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr624;
 		case 62: goto tr626;
@@ -8941,7 +8945,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 8945 "inc/vcf/validator_detail_v41.hpp"
+#line 8949 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr624;
 		case 61: goto tr624;
@@ -8977,7 +8981,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 8981 "inc/vcf/validator_detail_v41.hpp"
+#line 8985 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr625;
 		case 62: goto tr626;
@@ -8998,7 +9002,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 9002 "inc/vcf/validator_detail_v41.hpp"
+#line 9006 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr627;
 	goto tr545;
@@ -9012,7 +9016,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 9016 "inc/vcf/validator_detail_v41.hpp"
+#line 9020 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr628;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9038,7 +9042,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 9042 "inc/vcf/validator_detail_v41.hpp"
+#line 9046 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr615;
 		case 10: goto tr610;
@@ -9059,7 +9063,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 9063 "inc/vcf/validator_detail_v41.hpp"
+#line 9067 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr631;
@@ -9076,7 +9080,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 9080 "inc/vcf/validator_detail_v41.hpp"
+#line 9084 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr615;
 		case 10: goto tr610;
@@ -9095,7 +9099,7 @@ st448:
 	if ( ++p == pe )
 		goto _test_eof448;
 case 448:
-#line 9099 "inc/vcf/validator_detail_v41.hpp"
+#line 9103 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 49: goto tr596;
 		case 58: goto tr593;
@@ -9146,7 +9150,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 9150 "inc/vcf/validator_detail_v41.hpp"
+#line 9154 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9167,7 +9171,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 9171 "inc/vcf/validator_detail_v41.hpp"
+#line 9175 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9188,7 +9192,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 9192 "inc/vcf/validator_detail_v41.hpp"
+#line 9196 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9209,7 +9213,7 @@ st452:
 	if ( ++p == pe )
 		goto _test_eof452;
 case 452:
-#line 9213 "inc/vcf/validator_detail_v41.hpp"
+#line 9217 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9230,7 +9234,7 @@ st453:
 	if ( ++p == pe )
 		goto _test_eof453;
 case 453:
-#line 9234 "inc/vcf/validator_detail_v41.hpp"
+#line 9238 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr637;
@@ -9247,7 +9251,7 @@ st454:
 	if ( ++p == pe )
 		goto _test_eof454;
 case 454:
-#line 9251 "inc/vcf/validator_detail_v41.hpp"
+#line 9255 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9266,7 +9270,7 @@ st455:
 	if ( ++p == pe )
 		goto _test_eof455;
 case 455:
-#line 9270 "inc/vcf/validator_detail_v41.hpp"
+#line 9274 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9286,7 +9290,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 9290 "inc/vcf/validator_detail_v41.hpp"
+#line 9294 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr641;
 	goto tr640;
@@ -9300,7 +9304,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 9304 "inc/vcf/validator_detail_v41.hpp"
+#line 9308 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9321,7 +9325,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 9325 "inc/vcf/validator_detail_v41.hpp"
+#line 9329 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9345,7 +9349,7 @@ st459:
 	if ( ++p == pe )
 		goto _test_eof459;
 case 459:
-#line 9349 "inc/vcf/validator_detail_v41.hpp"
+#line 9353 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr646;
 	if ( (*p) > 58 ) {
@@ -9364,7 +9368,7 @@ st460:
 	if ( ++p == pe )
 		goto _test_eof460;
 case 460:
-#line 9368 "inc/vcf/validator_detail_v41.hpp"
+#line 9372 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr649;
 		case 67: goto tr649;
@@ -9390,7 +9394,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 9394 "inc/vcf/validator_detail_v41.hpp"
+#line 9398 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9407,7 +9411,7 @@ st462:
 	if ( ++p == pe )
 		goto _test_eof462;
 case 462:
-#line 9411 "inc/vcf/validator_detail_v41.hpp"
+#line 9415 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9434,7 +9438,7 @@ st463:
 	if ( ++p == pe )
 		goto _test_eof463;
 case 463:
-#line 9438 "inc/vcf/validator_detail_v41.hpp"
+#line 9442 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr650;
 	if ( (*p) > 58 ) {
@@ -9453,7 +9457,7 @@ st464:
 	if ( ++p == pe )
 		goto _test_eof464;
 case 464:
-#line 9457 "inc/vcf/validator_detail_v41.hpp"
+#line 9461 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr652;
 		case 45: goto tr652;
@@ -9471,7 +9475,7 @@ st465:
 	if ( ++p == pe )
 		goto _test_eof465;
 case 465:
-#line 9475 "inc/vcf/validator_detail_v41.hpp"
+#line 9479 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr653;
 	goto tr651;
@@ -9485,7 +9489,7 @@ st466:
 	if ( ++p == pe )
 		goto _test_eof466;
 case 466:
-#line 9489 "inc/vcf/validator_detail_v41.hpp"
+#line 9493 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9505,7 +9509,7 @@ st467:
 	if ( ++p == pe )
 		goto _test_eof467;
 case 467:
-#line 9509 "inc/vcf/validator_detail_v41.hpp"
+#line 9513 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr654;
 	if ( (*p) > 58 ) {
@@ -9524,7 +9528,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 9528 "inc/vcf/validator_detail_v41.hpp"
+#line 9532 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr656;
 		case 45: goto tr656;
@@ -9545,7 +9549,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 9549 "inc/vcf/validator_detail_v41.hpp"
+#line 9553 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr657;
 		case 73: goto tr659;
@@ -9563,7 +9567,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 9567 "inc/vcf/validator_detail_v41.hpp"
+#line 9571 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr661;
 	goto tr655;
@@ -9577,7 +9581,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 9581 "inc/vcf/validator_detail_v41.hpp"
+#line 9585 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9599,7 +9603,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 9603 "inc/vcf/validator_detail_v41.hpp"
+#line 9607 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr663;
 		case 45: goto tr663;
@@ -9617,7 +9621,7 @@ st473:
 	if ( ++p == pe )
 		goto _test_eof473;
 case 473:
-#line 9621 "inc/vcf/validator_detail_v41.hpp"
+#line 9625 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr664;
 	goto tr655;
@@ -9631,7 +9635,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 9635 "inc/vcf/validator_detail_v41.hpp"
+#line 9639 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9651,7 +9655,7 @@ st475:
 	if ( ++p == pe )
 		goto _test_eof475;
 case 475:
-#line 9655 "inc/vcf/validator_detail_v41.hpp"
+#line 9659 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9674,7 +9678,7 @@ st476:
 	if ( ++p == pe )
 		goto _test_eof476;
 case 476:
-#line 9678 "inc/vcf/validator_detail_v41.hpp"
+#line 9682 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr665;
 	goto tr655;
@@ -9688,7 +9692,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 9692 "inc/vcf/validator_detail_v41.hpp"
+#line 9696 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr666;
 	goto tr655;
@@ -9702,7 +9706,7 @@ st478:
 	if ( ++p == pe )
 		goto _test_eof478;
 case 478:
-#line 9706 "inc/vcf/validator_detail_v41.hpp"
+#line 9710 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9720,7 +9724,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 9724 "inc/vcf/validator_detail_v41.hpp"
+#line 9728 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr667;
 	goto tr655;
@@ -9734,7 +9738,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 9738 "inc/vcf/validator_detail_v41.hpp"
+#line 9742 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr666;
 	goto tr655;
@@ -9748,7 +9752,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 9752 "inc/vcf/validator_detail_v41.hpp"
+#line 9756 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr668;
 	if ( (*p) > 58 ) {
@@ -9767,7 +9771,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 9771 "inc/vcf/validator_detail_v41.hpp"
+#line 9775 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr670;
 		case 45: goto tr670;
@@ -9785,7 +9789,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 9789 "inc/vcf/validator_detail_v41.hpp"
+#line 9793 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr671;
 	goto tr669;
@@ -9799,7 +9803,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 9803 "inc/vcf/validator_detail_v41.hpp"
+#line 9807 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9822,7 +9826,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 9826 "inc/vcf/validator_detail_v41.hpp"
+#line 9830 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9843,7 +9847,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 9847 "inc/vcf/validator_detail_v41.hpp"
+#line 9851 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr673;
 	if ( (*p) > 58 ) {
@@ -9862,7 +9866,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 9866 "inc/vcf/validator_detail_v41.hpp"
+#line 9870 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr675;
 		case 45: goto tr675;
@@ -9883,7 +9887,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 9887 "inc/vcf/validator_detail_v41.hpp"
+#line 9891 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr676;
 		case 73: goto tr678;
@@ -9901,7 +9905,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 9905 "inc/vcf/validator_detail_v41.hpp"
+#line 9909 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr680;
 	goto tr674;
@@ -9915,7 +9919,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 9919 "inc/vcf/validator_detail_v41.hpp"
+#line 9923 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9936,7 +9940,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 9940 "inc/vcf/validator_detail_v41.hpp"
+#line 9944 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr682;
 		case 45: goto tr682;
@@ -9954,7 +9958,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 9958 "inc/vcf/validator_detail_v41.hpp"
+#line 9962 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr683;
 	goto tr674;
@@ -9968,7 +9972,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 9972 "inc/vcf/validator_detail_v41.hpp"
+#line 9976 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9987,7 +9991,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 9991 "inc/vcf/validator_detail_v41.hpp"
+#line 9995 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10009,7 +10013,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10013 "inc/vcf/validator_detail_v41.hpp"
+#line 10017 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr684;
 	goto tr674;
@@ -10023,7 +10027,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10027 "inc/vcf/validator_detail_v41.hpp"
+#line 10031 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr685;
 	goto tr674;
@@ -10037,7 +10041,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10041 "inc/vcf/validator_detail_v41.hpp"
+#line 10045 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10054,7 +10058,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10058 "inc/vcf/validator_detail_v41.hpp"
+#line 10062 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr686;
 	goto tr674;
@@ -10068,7 +10072,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10072 "inc/vcf/validator_detail_v41.hpp"
+#line 10076 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr685;
 	goto tr674;
@@ -10086,7 +10090,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10090 "inc/vcf/validator_detail_v41.hpp"
+#line 10094 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10107,7 +10111,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 10111 "inc/vcf/validator_detail_v41.hpp"
+#line 10115 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10128,7 +10132,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10132 "inc/vcf/validator_detail_v41.hpp"
+#line 10136 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10149,7 +10153,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 10153 "inc/vcf/validator_detail_v41.hpp"
+#line 10157 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10170,7 +10174,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 10174 "inc/vcf/validator_detail_v41.hpp"
+#line 10178 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr691;
 	if ( (*p) > 58 ) {
@@ -10189,7 +10193,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 10193 "inc/vcf/validator_detail_v41.hpp"
+#line 10197 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr693;
@@ -10209,7 +10213,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 10213 "inc/vcf/validator_detail_v41.hpp"
+#line 10217 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10238,7 +10242,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 10242 "inc/vcf/validator_detail_v41.hpp"
+#line 10246 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10260,7 +10264,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 10264 "inc/vcf/validator_detail_v41.hpp"
+#line 10268 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10280,7 +10284,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10284 "inc/vcf/validator_detail_v41.hpp"
+#line 10288 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr699;
 	goto tr698;
@@ -10294,7 +10298,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10298 "inc/vcf/validator_detail_v41.hpp"
+#line 10302 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10311,7 +10315,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 10315 "inc/vcf/validator_detail_v41.hpp"
+#line 10319 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr700;
 	if ( (*p) > 58 ) {
@@ -10330,7 +10334,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 10334 "inc/vcf/validator_detail_v41.hpp"
+#line 10338 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr702;
 		case 45: goto tr702;
@@ -10348,7 +10352,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 10352 "inc/vcf/validator_detail_v41.hpp"
+#line 10356 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr703;
 	goto tr701;
@@ -10362,7 +10366,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 10366 "inc/vcf/validator_detail_v41.hpp"
+#line 10370 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10385,7 +10389,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 10389 "inc/vcf/validator_detail_v41.hpp"
+#line 10393 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10406,7 +10410,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 10410 "inc/vcf/validator_detail_v41.hpp"
+#line 10414 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10427,7 +10431,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 10431 "inc/vcf/validator_detail_v41.hpp"
+#line 10435 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr706;
 	if ( (*p) > 58 ) {
@@ -10446,7 +10450,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 10450 "inc/vcf/validator_detail_v41.hpp"
+#line 10454 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr708;
 		case 45: goto tr708;
@@ -10464,7 +10468,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 10468 "inc/vcf/validator_detail_v41.hpp"
+#line 10472 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr709;
 	goto tr707;
@@ -10478,7 +10482,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 10482 "inc/vcf/validator_detail_v41.hpp"
+#line 10486 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10501,7 +10505,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 10505 "inc/vcf/validator_detail_v41.hpp"
+#line 10509 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10523,7 +10527,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 10527 "inc/vcf/validator_detail_v41.hpp"
+#line 10531 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10543,7 +10547,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 10547 "inc/vcf/validator_detail_v41.hpp"
+#line 10551 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr715;
 	goto tr714;
@@ -10557,7 +10561,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 10561 "inc/vcf/validator_detail_v41.hpp"
+#line 10565 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10574,7 +10578,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 10578 "inc/vcf/validator_detail_v41.hpp"
+#line 10582 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10594,7 +10598,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 10598 "inc/vcf/validator_detail_v41.hpp"
+#line 10602 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr719;
 	goto tr718;
@@ -10608,7 +10612,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 10612 "inc/vcf/validator_detail_v41.hpp"
+#line 10616 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10629,7 +10633,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 10633 "inc/vcf/validator_detail_v41.hpp"
+#line 10637 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10650,7 +10654,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 10654 "inc/vcf/validator_detail_v41.hpp"
+#line 10658 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 48: goto tr721;
 		case 61: goto tr722;
@@ -10671,7 +10675,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 10675 "inc/vcf/validator_detail_v41.hpp"
+#line 10679 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr723;
 	if ( (*p) > 58 ) {
@@ -10690,7 +10694,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 10694 "inc/vcf/validator_detail_v41.hpp"
+#line 10698 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr725;
 		case 45: goto tr725;
@@ -10708,7 +10712,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 10712 "inc/vcf/validator_detail_v41.hpp"
+#line 10716 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr726;
 	goto tr724;
@@ -10722,7 +10726,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 10726 "inc/vcf/validator_detail_v41.hpp"
+#line 10730 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10741,7 +10745,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 10745 "inc/vcf/validator_detail_v41.hpp"
+#line 10749 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr728;
 		case 45: goto tr728;
@@ -10762,7 +10766,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 10766 "inc/vcf/validator_detail_v41.hpp"
+#line 10770 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr729;
 		case 73: goto tr731;
@@ -10780,7 +10784,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 10784 "inc/vcf/validator_detail_v41.hpp"
+#line 10788 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr733;
 	goto tr727;
@@ -10794,7 +10798,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 10798 "inc/vcf/validator_detail_v41.hpp"
+#line 10802 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10815,7 +10819,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 10819 "inc/vcf/validator_detail_v41.hpp"
+#line 10823 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr735;
 		case 45: goto tr735;
@@ -10833,7 +10837,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 10837 "inc/vcf/validator_detail_v41.hpp"
+#line 10841 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr736;
 	goto tr727;
@@ -10847,7 +10851,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 10851 "inc/vcf/validator_detail_v41.hpp"
+#line 10855 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10866,7 +10870,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 10870 "inc/vcf/validator_detail_v41.hpp"
+#line 10874 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10888,7 +10892,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 10892 "inc/vcf/validator_detail_v41.hpp"
+#line 10896 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr737;
 	goto tr727;
@@ -10902,7 +10906,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 10906 "inc/vcf/validator_detail_v41.hpp"
+#line 10910 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr738;
 	goto tr727;
@@ -10916,7 +10920,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 10920 "inc/vcf/validator_detail_v41.hpp"
+#line 10924 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10933,7 +10937,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 10937 "inc/vcf/validator_detail_v41.hpp"
+#line 10941 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr739;
 	goto tr727;
@@ -10947,7 +10951,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 10951 "inc/vcf/validator_detail_v41.hpp"
+#line 10955 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr738;
 	goto tr727;
@@ -10965,7 +10969,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 10969 "inc/vcf/validator_detail_v41.hpp"
+#line 10973 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10986,7 +10990,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 10990 "inc/vcf/validator_detail_v41.hpp"
+#line 10994 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr741;
 	if ( (*p) > 58 ) {
@@ -11005,7 +11009,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 11009 "inc/vcf/validator_detail_v41.hpp"
+#line 11013 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr743;
 		case 45: goto tr743;
@@ -11023,7 +11027,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 11027 "inc/vcf/validator_detail_v41.hpp"
+#line 11031 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr744;
 	goto tr742;
@@ -11037,7 +11041,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 11041 "inc/vcf/validator_detail_v41.hpp"
+#line 11045 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11060,7 +11064,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 11064 "inc/vcf/validator_detail_v41.hpp"
+#line 11068 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11082,7 +11086,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 11086 "inc/vcf/validator_detail_v41.hpp"
+#line 11090 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr747;
 	if ( (*p) > 58 ) {
@@ -11101,7 +11105,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 11105 "inc/vcf/validator_detail_v41.hpp"
+#line 11109 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr749;
 		case 45: goto tr749;
@@ -11122,7 +11126,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 11126 "inc/vcf/validator_detail_v41.hpp"
+#line 11130 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr750;
 		case 73: goto tr752;
@@ -11140,7 +11144,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 11144 "inc/vcf/validator_detail_v41.hpp"
+#line 11148 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr754;
 	goto tr748;
@@ -11154,7 +11158,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 11158 "inc/vcf/validator_detail_v41.hpp"
+#line 11162 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11175,7 +11179,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 11179 "inc/vcf/validator_detail_v41.hpp"
+#line 11183 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr756;
 		case 45: goto tr756;
@@ -11193,7 +11197,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 11197 "inc/vcf/validator_detail_v41.hpp"
+#line 11201 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr757;
 	goto tr748;
@@ -11207,7 +11211,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 11211 "inc/vcf/validator_detail_v41.hpp"
+#line 11215 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11226,7 +11230,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 11230 "inc/vcf/validator_detail_v41.hpp"
+#line 11234 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11248,7 +11252,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 11252 "inc/vcf/validator_detail_v41.hpp"
+#line 11256 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr758;
 	goto tr748;
@@ -11262,7 +11266,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 11266 "inc/vcf/validator_detail_v41.hpp"
+#line 11270 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr759;
 	goto tr748;
@@ -11276,7 +11280,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 11280 "inc/vcf/validator_detail_v41.hpp"
+#line 11284 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11293,7 +11297,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 11297 "inc/vcf/validator_detail_v41.hpp"
+#line 11301 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr760;
 	goto tr748;
@@ -11307,7 +11311,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 11311 "inc/vcf/validator_detail_v41.hpp"
+#line 11315 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr759;
 	goto tr748;
@@ -11321,7 +11325,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 11325 "inc/vcf/validator_detail_v41.hpp"
+#line 11329 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11342,7 +11346,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 11346 "inc/vcf/validator_detail_v41.hpp"
+#line 11350 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11363,7 +11367,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 11367 "inc/vcf/validator_detail_v41.hpp"
+#line 11371 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11384,7 +11388,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 11388 "inc/vcf/validator_detail_v41.hpp"
+#line 11392 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11405,7 +11409,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 11409 "inc/vcf/validator_detail_v41.hpp"
+#line 11413 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11426,7 +11430,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 11430 "inc/vcf/validator_detail_v41.hpp"
+#line 11434 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11446,7 +11450,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 11450 "inc/vcf/validator_detail_v41.hpp"
+#line 11454 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr769;
 	goto tr768;
@@ -11460,7 +11464,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 11464 "inc/vcf/validator_detail_v41.hpp"
+#line 11468 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11481,7 +11485,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 11485 "inc/vcf/validator_detail_v41.hpp"
+#line 11489 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11502,7 +11506,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 11506 "inc/vcf/validator_detail_v41.hpp"
+#line 11510 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11523,7 +11527,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 11527 "inc/vcf/validator_detail_v41.hpp"
+#line 11531 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11544,7 +11548,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 11548 "inc/vcf/validator_detail_v41.hpp"
+#line 11552 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11565,7 +11569,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 11569 "inc/vcf/validator_detail_v41.hpp"
+#line 11573 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11586,7 +11590,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 11590 "inc/vcf/validator_detail_v41.hpp"
+#line 11594 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11607,7 +11611,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 11611 "inc/vcf/validator_detail_v41.hpp"
+#line 11615 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11628,7 +11632,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 11632 "inc/vcf/validator_detail_v41.hpp"
+#line 11636 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11649,7 +11653,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 11653 "inc/vcf/validator_detail_v41.hpp"
+#line 11657 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11669,7 +11673,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 11673 "inc/vcf/validator_detail_v41.hpp"
+#line 11677 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr781;
 	goto tr780;
@@ -11683,7 +11687,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 11687 "inc/vcf/validator_detail_v41.hpp"
+#line 11691 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11704,7 +11708,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 11708 "inc/vcf/validator_detail_v41.hpp"
+#line 11712 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11742,7 +11746,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 11746 "inc/vcf/validator_detail_v41.hpp"
+#line 11750 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr585;
 	if ( (*p) < 65 ) {
@@ -11780,7 +11784,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 11784 "inc/vcf/validator_detail_v41.hpp"
+#line 11788 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr590;
 		case 58: goto st430;
@@ -11816,7 +11820,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 11820 "inc/vcf/validator_detail_v41.hpp"
+#line 11824 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr782;
 		case 45: goto tr782;
@@ -11834,7 +11838,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 11838 "inc/vcf/validator_detail_v41.hpp"
+#line 11842 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr783;
 	goto tr572;
@@ -11848,7 +11852,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 11852 "inc/vcf/validator_detail_v41.hpp"
+#line 11856 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr582;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11874,7 +11878,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 11878 "inc/vcf/validator_detail_v41.hpp"
+#line 11882 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr582;
 		case 46: goto tr578;
@@ -11904,7 +11908,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 11908 "inc/vcf/validator_detail_v41.hpp"
+#line 11912 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr784;
 	goto tr572;
@@ -11918,7 +11922,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 11922 "inc/vcf/validator_detail_v41.hpp"
+#line 11926 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr785;
 	goto tr572;
@@ -11932,7 +11936,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 11936 "inc/vcf/validator_detail_v41.hpp"
+#line 11940 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr582;
 	goto tr572;
@@ -11950,7 +11954,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 11954 "inc/vcf/validator_detail_v41.hpp"
+#line 11958 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr582;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11970,7 +11974,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 11974 "inc/vcf/validator_detail_v41.hpp"
+#line 11978 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr786;
 	goto tr572;
@@ -11984,7 +11988,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 11988 "inc/vcf/validator_detail_v41.hpp"
+#line 11992 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr785;
 	goto tr572;
@@ -11998,7 +12002,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 12002 "inc/vcf/validator_detail_v41.hpp"
+#line 12006 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr564;
 		case 46: goto tr787;
@@ -12037,7 +12041,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 12041 "inc/vcf/validator_detail_v41.hpp"
+#line 12045 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr788;
 		case 67: goto tr788;
@@ -12061,7 +12065,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 12065 "inc/vcf/validator_detail_v41.hpp"
+#line 12069 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr570;
 		case 44: goto tr571;
@@ -12097,7 +12101,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 12101 "inc/vcf/validator_detail_v41.hpp"
+#line 12105 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr790;
 		case 95: goto tr790;
@@ -12121,7 +12125,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 12125 "inc/vcf/validator_detail_v41.hpp"
+#line 12129 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 62: goto tr791;
 		case 95: goto tr789;
@@ -12155,7 +12159,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 12159 "inc/vcf/validator_detail_v41.hpp"
+#line 12163 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr570;
 		case 44: goto tr571;
@@ -12184,7 +12188,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 12188 "inc/vcf/validator_detail_v41.hpp"
+#line 12192 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr796;
 	if ( (*p) < 65 ) {
@@ -12206,7 +12210,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 12210 "inc/vcf/validator_detail_v41.hpp"
+#line 12214 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr799;
 		case 59: goto tr797;
@@ -12243,7 +12247,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 12247 "inc/vcf/validator_detail_v41.hpp"
+#line 12251 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr797;
 		case 61: goto tr797;
@@ -12279,7 +12283,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 12283 "inc/vcf/validator_detail_v41.hpp"
+#line 12287 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr799;
 		case 61: goto tr798;
@@ -12300,7 +12304,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 12304 "inc/vcf/validator_detail_v41.hpp"
+#line 12308 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr800;
 		case 45: goto tr800;
@@ -12318,7 +12322,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 12322 "inc/vcf/validator_detail_v41.hpp"
+#line 12326 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr801;
 	goto tr563;
@@ -12332,7 +12336,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 12336 "inc/vcf/validator_detail_v41.hpp"
+#line 12340 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr791;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12348,7 +12352,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 12352 "inc/vcf/validator_detail_v41.hpp"
+#line 12356 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr802;
@@ -12368,7 +12372,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 12372 "inc/vcf/validator_detail_v41.hpp"
+#line 12376 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr803;
 		case 62: goto tr805;
@@ -12404,7 +12408,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 12408 "inc/vcf/validator_detail_v41.hpp"
+#line 12412 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr803;
 		case 61: goto tr803;
@@ -12440,7 +12444,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 12444 "inc/vcf/validator_detail_v41.hpp"
+#line 12448 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr804;
 		case 62: goto tr805;
@@ -12461,7 +12465,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 12465 "inc/vcf/validator_detail_v41.hpp"
+#line 12469 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr799;
 	goto tr563;
@@ -12475,7 +12479,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 12479 "inc/vcf/validator_detail_v41.hpp"
+#line 12483 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr807;
 	if ( (*p) < 65 ) {
@@ -12497,7 +12501,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 12501 "inc/vcf/validator_detail_v41.hpp"
+#line 12505 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr810;
 		case 59: goto tr808;
@@ -12534,7 +12538,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 12538 "inc/vcf/validator_detail_v41.hpp"
+#line 12542 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr808;
 		case 61: goto tr808;
@@ -12570,7 +12574,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 12574 "inc/vcf/validator_detail_v41.hpp"
+#line 12578 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr810;
 		case 61: goto tr809;
@@ -12591,7 +12595,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 12595 "inc/vcf/validator_detail_v41.hpp"
+#line 12599 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr811;
 		case 45: goto tr811;
@@ -12609,7 +12613,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 12613 "inc/vcf/validator_detail_v41.hpp"
+#line 12617 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr812;
 	goto tr563;
@@ -12623,7 +12627,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 12627 "inc/vcf/validator_detail_v41.hpp"
+#line 12631 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr791;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12639,7 +12643,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 12643 "inc/vcf/validator_detail_v41.hpp"
+#line 12647 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr813;
@@ -12659,7 +12663,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 12663 "inc/vcf/validator_detail_v41.hpp"
+#line 12667 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr814;
 		case 62: goto tr816;
@@ -12695,7 +12699,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 12699 "inc/vcf/validator_detail_v41.hpp"
+#line 12703 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr814;
 		case 61: goto tr814;
@@ -12731,7 +12735,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 12735 "inc/vcf/validator_detail_v41.hpp"
+#line 12739 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr815;
 		case 62: goto tr816;
@@ -12752,7 +12756,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 12756 "inc/vcf/validator_detail_v41.hpp"
+#line 12760 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr810;
 	goto tr563;
@@ -12770,7 +12774,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 12774 "inc/vcf/validator_detail_v41.hpp"
+#line 12778 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr818;
 	if ( (*p) < 65 ) {
@@ -12792,7 +12796,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 12796 "inc/vcf/validator_detail_v41.hpp"
+#line 12800 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr821;
 		case 59: goto tr819;
@@ -12829,7 +12833,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 12833 "inc/vcf/validator_detail_v41.hpp"
+#line 12837 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr819;
 		case 61: goto tr819;
@@ -12865,7 +12869,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 12869 "inc/vcf/validator_detail_v41.hpp"
+#line 12873 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr821;
 		case 61: goto tr820;
@@ -12886,7 +12890,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 12890 "inc/vcf/validator_detail_v41.hpp"
+#line 12894 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr822;
 		case 45: goto tr822;
@@ -12904,7 +12908,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 12908 "inc/vcf/validator_detail_v41.hpp"
+#line 12912 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr823;
 	goto tr563;
@@ -12918,7 +12922,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 12922 "inc/vcf/validator_detail_v41.hpp"
+#line 12926 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr824;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12934,7 +12938,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 12938 "inc/vcf/validator_detail_v41.hpp"
+#line 12942 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr825;
@@ -12954,7 +12958,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 12958 "inc/vcf/validator_detail_v41.hpp"
+#line 12962 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr826;
 		case 62: goto tr828;
@@ -12990,7 +12994,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 12994 "inc/vcf/validator_detail_v41.hpp"
+#line 12998 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr826;
 		case 61: goto tr826;
@@ -13026,7 +13030,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 13030 "inc/vcf/validator_detail_v41.hpp"
+#line 13034 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr827;
 		case 62: goto tr828;
@@ -13047,7 +13051,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 13051 "inc/vcf/validator_detail_v41.hpp"
+#line 13055 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr821;
 	goto tr563;
@@ -13065,7 +13069,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 13069 "inc/vcf/validator_detail_v41.hpp"
+#line 13073 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr830;
 	if ( (*p) < 65 ) {
@@ -13087,7 +13091,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 13091 "inc/vcf/validator_detail_v41.hpp"
+#line 13095 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr833;
 		case 59: goto tr831;
@@ -13124,7 +13128,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 13128 "inc/vcf/validator_detail_v41.hpp"
+#line 13132 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr831;
 		case 61: goto tr831;
@@ -13160,7 +13164,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 13164 "inc/vcf/validator_detail_v41.hpp"
+#line 13168 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr833;
 		case 61: goto tr832;
@@ -13181,7 +13185,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 13185 "inc/vcf/validator_detail_v41.hpp"
+#line 13189 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr834;
 		case 45: goto tr834;
@@ -13199,7 +13203,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 13203 "inc/vcf/validator_detail_v41.hpp"
+#line 13207 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr563;
@@ -13213,7 +13217,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 13217 "inc/vcf/validator_detail_v41.hpp"
+#line 13221 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr824;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13229,7 +13233,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 13233 "inc/vcf/validator_detail_v41.hpp"
+#line 13237 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr836;
@@ -13249,7 +13253,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 13253 "inc/vcf/validator_detail_v41.hpp"
+#line 13257 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr837;
 		case 62: goto tr839;
@@ -13285,7 +13289,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 13289 "inc/vcf/validator_detail_v41.hpp"
+#line 13293 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr837;
 		case 61: goto tr837;
@@ -13321,7 +13325,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 13325 "inc/vcf/validator_detail_v41.hpp"
+#line 13329 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr838;
 		case 62: goto tr839;
@@ -13342,7 +13346,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 13346 "inc/vcf/validator_detail_v41.hpp"
+#line 13350 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr833;
 	goto tr563;
@@ -13360,7 +13364,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 13364 "inc/vcf/validator_detail_v41.hpp"
+#line 13368 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr570;
 		case 65: goto tr788;
@@ -13385,7 +13389,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 13389 "inc/vcf/validator_detail_v41.hpp"
+#line 13393 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr547;
 		case 61: goto tr547;
@@ -13421,7 +13425,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 13425 "inc/vcf/validator_detail_v41.hpp"
+#line 13429 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr546;
 		case 59: goto tr548;
@@ -13451,14 +13455,14 @@ tr841:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 757 "src/vcf/vcf_v41.ragel"
+#line 759 "src/vcf/vcf_v41.ragel"
 	{ {goto st28;} }
 	goto st660;
 st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 13462 "inc/vcf/validator_detail_v41.hpp"
+#line 13466 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 st657:
 	if ( ++p == pe )
@@ -13478,14 +13482,14 @@ tr843:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 758 "src/vcf/vcf_v41.ragel"
+#line 760 "src/vcf/vcf_v41.ragel"
 	{ {goto st659;} }
 	goto st661;
 st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 13489 "inc/vcf/validator_detail_v41.hpp"
+#line 13493 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -14168,7 +14172,7 @@ case 661:
 	case 13: 
 #line 60 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14221,7 +14225,7 @@ case 661:
 	case 72: 
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14230,8 +14234,8 @@ case 661:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 	break;
@@ -14246,13 +14250,13 @@ case 661:
 	case 414: 
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
@@ -14268,13 +14272,13 @@ case 661:
 	case 21: 
 #line 219 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.1'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         p--; {goto st656;}
     }
 #line 60 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14301,12 +14305,12 @@ case 661:
 	case 98: 
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14318,14 +14322,14 @@ case 661:
 	case 307: 
 	case 308: 
 	case 309: 
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 238 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14358,14 +14362,14 @@ case 661:
 	case 347: 
 	case 348: 
 	case 349: 
-#line 243 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14392,14 +14396,14 @@ case 661:
 	case 127: 
 	case 128: 
 	case 132: 
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14438,14 +14442,14 @@ case 661:
 	case 175: 
 	case 176: 
 	case 180: 
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14483,14 +14487,14 @@ case 661:
 	case 223: 
 	case 224: 
 	case 228: 
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14504,14 +14508,14 @@ case 661:
 	case 240: 
 	case 241: 
 	case 248: 
-#line 287 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14526,14 +14530,14 @@ case 661:
 	case 358: 
 	case 359: 
 	case 360: 
-#line 293 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14548,14 +14552,14 @@ case 661:
 	case 257: 
 	case 258: 
 	case 298: 
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14596,28 +14600,29 @@ case 661:
 	case 403: 
 	case 404: 
 	case 405: 
-#line 331 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
@@ -14631,54 +14636,54 @@ case 661:
 	case 443: 
 	case 654: 
 	case 655: 
-#line 347 "src/vcf/vcf_v41.ragel"
+#line 349 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 416: 
 	case 417: 
 	case 418: 
-#line 353 "src/vcf/vcf_v41.ragel"
+#line 355 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 419: 
 	case 420: 
-#line 359 "src/vcf/vcf_v41.ragel"
+#line 361 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 421: 
 	case 422: 
-#line 365 "src/vcf/vcf_v41.ragel"
+#line 367 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -14739,14 +14744,14 @@ case 661:
 	case 651: 
 	case 652: 
 	case 653: 
-#line 371 "src/vcf/vcf_v41.ragel"
+#line 373 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -14764,14 +14769,14 @@ case 661:
 	case 596: 
 	case 597: 
 	case 598: 
-#line 377 "src/vcf/vcf_v41.ragel"
+#line 379 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -14780,42 +14785,42 @@ case 661:
 	case 431: 
 	case 587: 
 	case 588: 
-#line 383 "src/vcf/vcf_v41.ragel"
+#line 385 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 435: 
 	case 436: 
-#line 495 "src/vcf/vcf_v41.ragel"
+#line 497 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 446: 
 	case 447: 
-#line 501 "src/vcf/vcf_v41.ragel"
+#line 503 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -14823,31 +14828,32 @@ case 661:
 	case 28: 
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
-#line 331 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
@@ -14858,108 +14864,109 @@ case 661:
 	case 102: 
 #line 231 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st656;}
     }
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 103: 
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 155: 
 	case 156: 
 	case 184: 
-#line 260 "src/vcf/vcf_v41.ragel"
+#line 261 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 203: 
 	case 204: 
 	case 232: 
-#line 276 "src/vcf/vcf_v41.ragel"
+#line 277 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 162: 
 	case 163: 
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 282 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 210: 
 	case 211: 
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 282 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14972,19 +14979,19 @@ case 661:
 	case 268: 
 	case 269: 
 	case 270: 
-#line 304 "src/vcf/vcf_v41.ragel"
+#line 305 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -14997,19 +15004,19 @@ case 661:
 	case 278: 
 	case 279: 
 	case 280: 
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 310 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15017,76 +15024,76 @@ case 661:
 	case 328: 
 	case 329: 
 	case 330: 
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 243 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 113: 
 	case 114: 
 	case 115: 
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 145: 
 	case 146: 
 	case 147: 
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 193: 
 	case 194: 
 	case 195: 
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15096,37 +15103,37 @@ case 661:
 	case 245: 
 	case 246: 
 	case 247: 
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 287 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 259: 
 	case 260: 
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15136,19 +15143,19 @@ case 661:
 	case 99: 
 	case 100: 
 	case 101: 
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15158,19 +15165,19 @@ case 661:
 	case 133: 
 	case 134: 
 	case 135: 
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15180,19 +15187,19 @@ case 661:
 	case 181: 
 	case 182: 
 	case 183: 
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15202,19 +15209,19 @@ case 661:
 	case 229: 
 	case 230: 
 	case 231: 
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15237,19 +15244,19 @@ case 661:
 	case 299: 
 	case 300: 
 	case 301: 
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15260,19 +15267,19 @@ case 661:
 	case 314: 
 	case 315: 
 	case 316: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 326 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st656;}
     }
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 238 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15284,19 +15291,19 @@ case 661:
 	case 366: 
 	case 367: 
 	case 368: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 326 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st656;}
     }
-#line 293 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
@@ -15347,75 +15354,75 @@ case 661:
 	case 581: 
 	case 582: 
 	case 586: 
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 453: 
 	case 454: 
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 401 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 460: 
 	case 461: 
 	case 462: 
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 406 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 464: 
 	case 465: 
 	case 466: 
-#line 409 "src/vcf/vcf_v41.ragel"
+#line 411 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -15432,38 +15439,38 @@ case 661:
 	case 478: 
 	case 479: 
 	case 480: 
-#line 414 "src/vcf/vcf_v41.ragel"
+#line 416 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 482: 
 	case 483: 
 	case 484: 
-#line 419 "src/vcf/vcf_v41.ragel"
+#line 421 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -15480,129 +15487,129 @@ case 661:
 	case 497: 
 	case 498: 
 	case 499: 
-#line 424 "src/vcf/vcf_v41.ragel"
+#line 426 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 505: 
 	case 506: 
-#line 429 "src/vcf/vcf_v41.ragel"
+#line 431 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 509: 
 	case 510: 
-#line 434 "src/vcf/vcf_v41.ragel"
+#line 436 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 512: 
 	case 513: 
 	case 514: 
-#line 439 "src/vcf/vcf_v41.ragel"
+#line 441 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 518: 
 	case 519: 
 	case 520: 
-#line 444 "src/vcf/vcf_v41.ragel"
+#line 446 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 523: 
 	case 524: 
-#line 449 "src/vcf/vcf_v41.ragel"
+#line 451 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 526: 
 	case 527: 
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 456 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -15619,57 +15626,57 @@ case 661:
 	case 544: 
 	case 545: 
 	case 546: 
-#line 459 "src/vcf/vcf_v41.ragel"
+#line 461 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 531: 
 	case 532: 
 	case 533: 
-#line 464 "src/vcf/vcf_v41.ragel"
+#line 466 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 549: 
 	case 550: 
 	case 551: 
-#line 469 "src/vcf/vcf_v41.ragel"
+#line 471 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -15686,73 +15693,73 @@ case 661:
 	case 564: 
 	case 565: 
 	case 566: 
-#line 474 "src/vcf/vcf_v41.ragel"
+#line 476 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 573: 
 	case 574: 
-#line 479 "src/vcf/vcf_v41.ragel"
+#line 481 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 584: 
 	case 585: 
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 486 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 456: 
 	case 457: 
-#line 489 "src/vcf/vcf_v41.ragel"
+#line 491 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
@@ -15760,322 +15767,323 @@ case 661:
 	case 438: 
 	case 444: 
 	case 445: 
-#line 508 "src/vcf/vcf_v41.ragel"
+#line 510 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st657;}
     }
-#line 501 "src/vcf/vcf_v41.ragel"
+#line 503 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 22: 
 #line 60 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
-#line 331 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 #line 78 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st657;}
     }
 	break;
 	case 271: 
-#line 304 "src/vcf/vcf_v41.ragel"
+#line 305 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 310 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 281: 
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 310 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 320 "src/vcf/vcf_v41.ragel"
+#line 321 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 261: 
-#line 315 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st656;}
     }
-#line 304 "src/vcf/vcf_v41.ragel"
+#line 305 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
 	case 508: 
-#line 434 "src/vcf/vcf_v41.ragel"
+#line 436 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 522: 
-#line 449 "src/vcf/vcf_v41.ragel"
+#line 451 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 525: 
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 456 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 572: 
-#line 479 "src/vcf/vcf_v41.ragel"
+#line 481 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 583: 
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 486 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 455: 
-#line 489 "src/vcf/vcf_v41.ragel"
+#line 491 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st657;}
     }
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 396 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st657;}
     }
-#line 389 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st657;}
     }
 #line 91 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st657;}
     }
 	break;
 	case 24: 
 #line 226 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st656;}
     }
-#line 249 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st656;}
     }
-#line 255 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st656;}
     }
-#line 271 "src/vcf/vcf_v41.ragel"
+#line 272 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st656;}
     }
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 238 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st656;}
     }
-#line 243 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st656;}
     }
-#line 299 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st656;}
     }
-#line 287 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st656;}
     }
-#line 293 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st656;}
     }
 #line 65 "src/vcf/vcf_v41.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st656;}
     }
 	break;
-#line 16072 "inc/vcf/validator_detail_v41.hpp"
+#line 16080 "inc/vcf/validator_detail_v41.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 789 "src/vcf/vcf_v41.ragel"
+#line 791 "src/vcf/vcf_v41.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 755 "src/vcf/vcf_v41.ragel"
+#line 759 "src/vcf/vcf_v41.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v41_en_meta_section_skip = 656;
 static const int vcf_v41_en_body_section_skip = 657;
 
 
-#line 761 "src/vcf/vcf_v41.ragel"
+#line 765 "src/vcf/vcf_v41.ragel"
 
 }
 
@@ -60,7 +60,7 @@ namespace ebi
 	cs = vcf_v41_start;
 	}
 
-#line 777 "src/vcf/vcf_v41.ragel"
+#line 781 "src/vcf/vcf_v41.ragel"
 
     }
 
@@ -86,7 +86,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 215 "src/vcf/vcf_v41.ragel"
+#line 219 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_fileformat_section_error(*this,
             "The fileformat declaration is not 'fileformat=VCFv4.1'");
@@ -109,15 +109,15 @@ tr23:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st656;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 331 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -129,8 +129,8 @@ tr23:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -142,15 +142,15 @@ tr25:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st656;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 331 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -162,55 +162,55 @@ tr25:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
     }
 	goto st0;
 tr28:
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
     }
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
     }
-#line 233 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st656;}
     }
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 243 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
     }
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 287 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st656;}
     }
-#line 289 "src/vcf/vcf_v41.ragel"
+#line 293 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st656;}
@@ -229,7 +229,7 @@ tr38:
     }
 	goto st0;
 tr121:
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
@@ -241,12 +241,12 @@ tr121:
     }
 	goto st0;
 tr129:
-#line 227 "src/vcf/vcf_v41.ragel"
+#line 231 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
         p--; {goto st656;}
     }
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
@@ -258,12 +258,12 @@ tr129:
     }
 	goto st0;
 tr147:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
@@ -275,12 +275,12 @@ tr147:
     }
 	goto st0;
 tr158:
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -292,7 +292,7 @@ tr158:
     }
 	goto st0;
 tr161:
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
@@ -304,12 +304,12 @@ tr161:
     }
 	goto st0;
 tr171:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
@@ -321,12 +321,12 @@ tr171:
     }
 	goto st0;
 tr190:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
@@ -338,7 +338,7 @@ tr190:
     }
 	goto st0;
 tr200:
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -350,12 +350,12 @@ tr200:
     }
 	goto st0;
 tr210:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -367,12 +367,12 @@ tr210:
     }
 	goto st0;
 tr223:
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -384,12 +384,12 @@ tr223:
     }
 	goto st0;
 tr232:
-#line 277 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -401,12 +401,12 @@ tr232:
     }
 	goto st0;
 tr249:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -418,7 +418,7 @@ tr249:
     }
 	goto st0;
 tr260:
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -430,12 +430,12 @@ tr260:
     }
 	goto st0;
 tr269:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -447,12 +447,12 @@ tr269:
     }
 	goto st0;
 tr282:
-#line 272 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -464,12 +464,12 @@ tr282:
     }
 	goto st0;
 tr291:
-#line 277 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -481,12 +481,12 @@ tr291:
     }
 	goto st0;
 tr308:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -498,7 +498,7 @@ tr308:
     }
 	goto st0;
 tr319:
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 287 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st656;}
@@ -510,12 +510,12 @@ tr319:
     }
 	goto st0;
 tr329:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 287 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st656;}
@@ -527,7 +527,7 @@ tr329:
     }
 	goto st0;
 tr341:
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -539,12 +539,12 @@ tr341:
     }
 	goto st0;
 tr352:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -556,17 +556,17 @@ tr352:
     }
 	goto st0;
 tr357:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -578,12 +578,12 @@ tr357:
     }
 	goto st0;
 tr359:
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -595,17 +595,17 @@ tr359:
     }
 	goto st0;
 tr369:
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 305 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -617,12 +617,12 @@ tr369:
     }
 	goto st0;
 tr372:
-#line 305 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -634,17 +634,17 @@ tr372:
     }
 	goto st0;
 tr382:
-#line 305 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -656,12 +656,12 @@ tr382:
     }
 	goto st0;
 tr385:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -673,7 +673,7 @@ tr385:
     }
 	goto st0;
 tr408:
-#line 233 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st656;}
@@ -685,12 +685,12 @@ tr408:
     }
 	goto st0;
 tr417:
-#line 321 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st656;}
     }
-#line 233 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st656;}
@@ -702,7 +702,7 @@ tr417:
     }
 	goto st0;
 tr424:
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 243 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st656;}
@@ -714,12 +714,12 @@ tr424:
     }
 	goto st0;
 tr435:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 243 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st656;}
@@ -731,7 +731,7 @@ tr435:
     }
 	goto st0;
 tr474:
-#line 289 "src/vcf/vcf_v41.ragel"
+#line 293 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st656;}
@@ -743,12 +743,12 @@ tr474:
     }
 	goto st0;
 tr486:
-#line 321 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st656;}
     }
-#line 289 "src/vcf/vcf_v41.ragel"
+#line 293 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st656;}
@@ -760,15 +760,15 @@ tr486:
     }
 	goto st0;
 tr494:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 331 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -780,8 +780,8 @@ tr494:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -795,15 +795,15 @@ tr533:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
     }
 	goto st0;
 tr545:
-#line 343 "src/vcf/vcf_v41.ragel"
+#line 347 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st657;}
@@ -815,7 +815,7 @@ tr545:
     }
 	goto st0;
 tr549:
-#line 349 "src/vcf/vcf_v41.ragel"
+#line 353 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
         p--; {goto st657;}
@@ -827,7 +827,7 @@ tr549:
     }
 	goto st0;
 tr554:
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 359 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
         p--; {goto st657;}
@@ -839,7 +839,7 @@ tr554:
     }
 	goto st0;
 tr559:
-#line 361 "src/vcf/vcf_v41.ragel"
+#line 365 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
         p--; {goto st657;}
@@ -851,7 +851,7 @@ tr559:
     }
 	goto st0;
 tr563:
-#line 367 "src/vcf/vcf_v41.ragel"
+#line 371 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
         p--; {goto st657;}
@@ -863,7 +863,7 @@ tr563:
     }
 	goto st0;
 tr572:
-#line 373 "src/vcf/vcf_v41.ragel"
+#line 377 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
         p--; {goto st657;}
@@ -875,7 +875,7 @@ tr572:
     }
 	goto st0;
 tr584:
-#line 379 "src/vcf/vcf_v41.ragel"
+#line 383 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
         p--; {goto st657;}
@@ -887,12 +887,12 @@ tr584:
     }
 	goto st0;
 tr592:
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -904,7 +904,7 @@ tr592:
     }
 	goto st0;
 tr613:
-#line 491 "src/vcf/vcf_v41.ragel"
+#line 495 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
         p--; {goto st657;}
@@ -916,14 +916,14 @@ tr613:
     }
 	goto st0;
 tr618:
-#line 504 "src/vcf/vcf_v41.ragel"
+#line 508 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_body_section_error(*this, message_stream.str());
         p--; {goto st657;}
     }
-#line 497 "src/vcf/vcf_v41.ragel"
+#line 501 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -937,7 +937,7 @@ tr618:
     }
 	goto st0;
 tr630:
-#line 497 "src/vcf/vcf_v41.ragel"
+#line 501 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -951,12 +951,12 @@ tr630:
     }
 	goto st0;
 tr636:
-#line 395 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -968,17 +968,17 @@ tr636:
     }
 	goto st0;
 tr638:
-#line 485 "src/vcf/vcf_v41.ragel"
+#line 489 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -990,12 +990,12 @@ tr638:
     }
 	goto st0;
 tr640:
-#line 485 "src/vcf/vcf_v41.ragel"
+#line 489 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1007,12 +1007,12 @@ tr640:
     }
 	goto st0;
 tr647:
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1024,12 +1024,12 @@ tr647:
     }
 	goto st0;
 tr651:
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 409 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1041,12 +1041,12 @@ tr651:
     }
 	goto st0;
 tr655:
-#line 410 "src/vcf/vcf_v41.ragel"
+#line 414 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1058,12 +1058,12 @@ tr655:
     }
 	goto st0;
 tr669:
-#line 415 "src/vcf/vcf_v41.ragel"
+#line 419 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1075,12 +1075,12 @@ tr669:
     }
 	goto st0;
 tr674:
-#line 420 "src/vcf/vcf_v41.ragel"
+#line 424 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1092,12 +1092,12 @@ tr674:
     }
 	goto st0;
 tr692:
-#line 425 "src/vcf/vcf_v41.ragel"
+#line 429 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1109,17 +1109,17 @@ tr692:
     }
 	goto st0;
 tr696:
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 434 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1131,12 +1131,12 @@ tr696:
     }
 	goto st0;
 tr698:
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 434 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1148,12 +1148,12 @@ tr698:
     }
 	goto st0;
 tr701:
-#line 435 "src/vcf/vcf_v41.ragel"
+#line 439 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1165,12 +1165,12 @@ tr701:
     }
 	goto st0;
 tr707:
-#line 440 "src/vcf/vcf_v41.ragel"
+#line 444 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1182,17 +1182,17 @@ tr707:
     }
 	goto st0;
 tr712:
-#line 445 "src/vcf/vcf_v41.ragel"
+#line 449 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1204,12 +1204,12 @@ tr712:
     }
 	goto st0;
 tr714:
-#line 445 "src/vcf/vcf_v41.ragel"
+#line 449 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1221,17 +1221,17 @@ tr714:
     }
 	goto st0;
 tr716:
-#line 450 "src/vcf/vcf_v41.ragel"
+#line 454 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1243,12 +1243,12 @@ tr716:
     }
 	goto st0;
 tr718:
-#line 450 "src/vcf/vcf_v41.ragel"
+#line 454 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1260,12 +1260,12 @@ tr718:
     }
 	goto st0;
 tr724:
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 464 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1277,12 +1277,12 @@ tr724:
     }
 	goto st0;
 tr727:
-#line 455 "src/vcf/vcf_v41.ragel"
+#line 459 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1294,12 +1294,12 @@ tr727:
     }
 	goto st0;
 tr742:
-#line 465 "src/vcf/vcf_v41.ragel"
+#line 469 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1311,12 +1311,12 @@ tr742:
     }
 	goto st0;
 tr748:
-#line 470 "src/vcf/vcf_v41.ragel"
+#line 474 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1328,17 +1328,17 @@ tr748:
     }
 	goto st0;
 tr766:
-#line 475 "src/vcf/vcf_v41.ragel"
+#line 479 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1350,12 +1350,12 @@ tr766:
     }
 	goto st0;
 tr768:
-#line 475 "src/vcf/vcf_v41.ragel"
+#line 479 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1367,17 +1367,17 @@ tr768:
     }
 	goto st0;
 tr778:
-#line 480 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1389,12 +1389,12 @@ tr778:
     }
 	goto st0;
 tr780:
-#line 480 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -1413,13 +1413,13 @@ tr844:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
     }
-#line 343 "src/vcf/vcf_v41.ragel"
+#line 347 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st657;}
@@ -1632,8 +1632,8 @@ tr22:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (ParsingError error) {
-          ErrorPolicy::handle_meta_section_error(*this, error.what());
+        } catch (FileformatError error) {
+          ErrorPolicy::handle_meta_section_error(*this, error.get_raw_message());
           p--; {goto st656;}
         }  
     }
@@ -1764,8 +1764,8 @@ tr44:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -1784,8 +1784,8 @@ tr52:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -8061,8 +8061,8 @@ tr845:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 #line 31 "src/vcf/vcf_v41.ragel"
@@ -8826,14 +8826,18 @@ tr610:
 #line 198 "src/vcf/vcf_v41.ragel"
 	{
         try {
-          // Handle all columns and build record
-          ParsePolicy::handle_body_line(*this);
-          // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-          OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_body_section_error(*this, ex.what());
-        } catch (ParsingWarning ex) {
-          ErrorPolicy::handle_body_section_warning(*this, ex.what());
+            // Handle all columns and build record
+            ParsePolicy::handle_body_line(*this);
+            try {
+                // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
+                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+            } catch (MetaSectionError &ex) {
+                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
+            } catch (BodySectionError &ex) {
+                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            }
+        } catch (BodySectionError ex) {
+            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -8851,7 +8855,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 8855 "inc/vcf/validator_detail_v41.hpp"
+#line 8859 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st439;
 	if ( (*p) < 65 ) {
@@ -8868,8 +8872,8 @@ tr846:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 	goto st439;
@@ -8877,7 +8881,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 8881 "inc/vcf/validator_detail_v41.hpp"
+#line 8885 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr623;
@@ -8901,7 +8905,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 8905 "inc/vcf/validator_detail_v41.hpp"
+#line 8909 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr624;
 		case 62: goto tr626;
@@ -8937,7 +8941,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 8941 "inc/vcf/validator_detail_v41.hpp"
+#line 8945 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr624;
 		case 61: goto tr624;
@@ -8973,7 +8977,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 8977 "inc/vcf/validator_detail_v41.hpp"
+#line 8981 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr625;
 		case 62: goto tr626;
@@ -8994,7 +8998,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 8998 "inc/vcf/validator_detail_v41.hpp"
+#line 9002 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr627;
 	goto tr545;
@@ -9008,7 +9012,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 9012 "inc/vcf/validator_detail_v41.hpp"
+#line 9016 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr628;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9034,7 +9038,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 9038 "inc/vcf/validator_detail_v41.hpp"
+#line 9042 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr615;
 		case 10: goto tr610;
@@ -9055,7 +9059,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 9059 "inc/vcf/validator_detail_v41.hpp"
+#line 9063 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr631;
@@ -9072,7 +9076,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 9076 "inc/vcf/validator_detail_v41.hpp"
+#line 9080 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr615;
 		case 10: goto tr610;
@@ -9091,7 +9095,7 @@ st448:
 	if ( ++p == pe )
 		goto _test_eof448;
 case 448:
-#line 9095 "inc/vcf/validator_detail_v41.hpp"
+#line 9099 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 49: goto tr596;
 		case 58: goto tr593;
@@ -9142,7 +9146,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 9146 "inc/vcf/validator_detail_v41.hpp"
+#line 9150 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9163,7 +9167,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 9167 "inc/vcf/validator_detail_v41.hpp"
+#line 9171 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9184,7 +9188,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 9188 "inc/vcf/validator_detail_v41.hpp"
+#line 9192 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9205,7 +9209,7 @@ st452:
 	if ( ++p == pe )
 		goto _test_eof452;
 case 452:
-#line 9209 "inc/vcf/validator_detail_v41.hpp"
+#line 9213 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9226,7 +9230,7 @@ st453:
 	if ( ++p == pe )
 		goto _test_eof453;
 case 453:
-#line 9230 "inc/vcf/validator_detail_v41.hpp"
+#line 9234 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr637;
@@ -9243,7 +9247,7 @@ st454:
 	if ( ++p == pe )
 		goto _test_eof454;
 case 454:
-#line 9247 "inc/vcf/validator_detail_v41.hpp"
+#line 9251 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9262,7 +9266,7 @@ st455:
 	if ( ++p == pe )
 		goto _test_eof455;
 case 455:
-#line 9266 "inc/vcf/validator_detail_v41.hpp"
+#line 9270 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9282,7 +9286,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 9286 "inc/vcf/validator_detail_v41.hpp"
+#line 9290 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr641;
 	goto tr640;
@@ -9296,7 +9300,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 9300 "inc/vcf/validator_detail_v41.hpp"
+#line 9304 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9317,7 +9321,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 9321 "inc/vcf/validator_detail_v41.hpp"
+#line 9325 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9341,7 +9345,7 @@ st459:
 	if ( ++p == pe )
 		goto _test_eof459;
 case 459:
-#line 9345 "inc/vcf/validator_detail_v41.hpp"
+#line 9349 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr646;
 	if ( (*p) > 58 ) {
@@ -9360,7 +9364,7 @@ st460:
 	if ( ++p == pe )
 		goto _test_eof460;
 case 460:
-#line 9364 "inc/vcf/validator_detail_v41.hpp"
+#line 9368 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr649;
 		case 67: goto tr649;
@@ -9386,7 +9390,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 9390 "inc/vcf/validator_detail_v41.hpp"
+#line 9394 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9403,7 +9407,7 @@ st462:
 	if ( ++p == pe )
 		goto _test_eof462;
 case 462:
-#line 9407 "inc/vcf/validator_detail_v41.hpp"
+#line 9411 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9430,7 +9434,7 @@ st463:
 	if ( ++p == pe )
 		goto _test_eof463;
 case 463:
-#line 9434 "inc/vcf/validator_detail_v41.hpp"
+#line 9438 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr650;
 	if ( (*p) > 58 ) {
@@ -9449,7 +9453,7 @@ st464:
 	if ( ++p == pe )
 		goto _test_eof464;
 case 464:
-#line 9453 "inc/vcf/validator_detail_v41.hpp"
+#line 9457 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr652;
 		case 45: goto tr652;
@@ -9467,7 +9471,7 @@ st465:
 	if ( ++p == pe )
 		goto _test_eof465;
 case 465:
-#line 9471 "inc/vcf/validator_detail_v41.hpp"
+#line 9475 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr653;
 	goto tr651;
@@ -9481,7 +9485,7 @@ st466:
 	if ( ++p == pe )
 		goto _test_eof466;
 case 466:
-#line 9485 "inc/vcf/validator_detail_v41.hpp"
+#line 9489 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9501,7 +9505,7 @@ st467:
 	if ( ++p == pe )
 		goto _test_eof467;
 case 467:
-#line 9505 "inc/vcf/validator_detail_v41.hpp"
+#line 9509 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr654;
 	if ( (*p) > 58 ) {
@@ -9520,7 +9524,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 9524 "inc/vcf/validator_detail_v41.hpp"
+#line 9528 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr656;
 		case 45: goto tr656;
@@ -9541,7 +9545,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 9545 "inc/vcf/validator_detail_v41.hpp"
+#line 9549 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr657;
 		case 73: goto tr659;
@@ -9559,7 +9563,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 9563 "inc/vcf/validator_detail_v41.hpp"
+#line 9567 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr661;
 	goto tr655;
@@ -9573,7 +9577,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 9577 "inc/vcf/validator_detail_v41.hpp"
+#line 9581 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9595,7 +9599,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 9599 "inc/vcf/validator_detail_v41.hpp"
+#line 9603 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr663;
 		case 45: goto tr663;
@@ -9613,7 +9617,7 @@ st473:
 	if ( ++p == pe )
 		goto _test_eof473;
 case 473:
-#line 9617 "inc/vcf/validator_detail_v41.hpp"
+#line 9621 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr664;
 	goto tr655;
@@ -9627,7 +9631,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 9631 "inc/vcf/validator_detail_v41.hpp"
+#line 9635 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9647,7 +9651,7 @@ st475:
 	if ( ++p == pe )
 		goto _test_eof475;
 case 475:
-#line 9651 "inc/vcf/validator_detail_v41.hpp"
+#line 9655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9670,7 +9674,7 @@ st476:
 	if ( ++p == pe )
 		goto _test_eof476;
 case 476:
-#line 9674 "inc/vcf/validator_detail_v41.hpp"
+#line 9678 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr665;
 	goto tr655;
@@ -9684,7 +9688,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 9688 "inc/vcf/validator_detail_v41.hpp"
+#line 9692 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr666;
 	goto tr655;
@@ -9698,7 +9702,7 @@ st478:
 	if ( ++p == pe )
 		goto _test_eof478;
 case 478:
-#line 9702 "inc/vcf/validator_detail_v41.hpp"
+#line 9706 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9716,7 +9720,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 9720 "inc/vcf/validator_detail_v41.hpp"
+#line 9724 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr667;
 	goto tr655;
@@ -9730,7 +9734,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 9734 "inc/vcf/validator_detail_v41.hpp"
+#line 9738 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr666;
 	goto tr655;
@@ -9744,7 +9748,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 9748 "inc/vcf/validator_detail_v41.hpp"
+#line 9752 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr668;
 	if ( (*p) > 58 ) {
@@ -9763,7 +9767,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 9767 "inc/vcf/validator_detail_v41.hpp"
+#line 9771 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr670;
 		case 45: goto tr670;
@@ -9781,7 +9785,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 9785 "inc/vcf/validator_detail_v41.hpp"
+#line 9789 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr671;
 	goto tr669;
@@ -9795,7 +9799,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 9799 "inc/vcf/validator_detail_v41.hpp"
+#line 9803 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9818,7 +9822,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 9822 "inc/vcf/validator_detail_v41.hpp"
+#line 9826 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9839,7 +9843,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 9843 "inc/vcf/validator_detail_v41.hpp"
+#line 9847 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr673;
 	if ( (*p) > 58 ) {
@@ -9858,7 +9862,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 9862 "inc/vcf/validator_detail_v41.hpp"
+#line 9866 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr675;
 		case 45: goto tr675;
@@ -9879,7 +9883,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 9883 "inc/vcf/validator_detail_v41.hpp"
+#line 9887 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr676;
 		case 73: goto tr678;
@@ -9897,7 +9901,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 9901 "inc/vcf/validator_detail_v41.hpp"
+#line 9905 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr680;
 	goto tr674;
@@ -9911,7 +9915,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 9915 "inc/vcf/validator_detail_v41.hpp"
+#line 9919 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9932,7 +9936,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 9936 "inc/vcf/validator_detail_v41.hpp"
+#line 9940 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr682;
 		case 45: goto tr682;
@@ -9950,7 +9954,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 9954 "inc/vcf/validator_detail_v41.hpp"
+#line 9958 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr683;
 	goto tr674;
@@ -9964,7 +9968,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 9968 "inc/vcf/validator_detail_v41.hpp"
+#line 9972 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -9983,7 +9987,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 9987 "inc/vcf/validator_detail_v41.hpp"
+#line 9991 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10005,7 +10009,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10009 "inc/vcf/validator_detail_v41.hpp"
+#line 10013 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr684;
 	goto tr674;
@@ -10019,7 +10023,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10023 "inc/vcf/validator_detail_v41.hpp"
+#line 10027 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr685;
 	goto tr674;
@@ -10033,7 +10037,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10037 "inc/vcf/validator_detail_v41.hpp"
+#line 10041 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10050,7 +10054,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10054 "inc/vcf/validator_detail_v41.hpp"
+#line 10058 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr686;
 	goto tr674;
@@ -10064,7 +10068,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10068 "inc/vcf/validator_detail_v41.hpp"
+#line 10072 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr685;
 	goto tr674;
@@ -10082,7 +10086,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10086 "inc/vcf/validator_detail_v41.hpp"
+#line 10090 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10103,7 +10107,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 10107 "inc/vcf/validator_detail_v41.hpp"
+#line 10111 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10124,7 +10128,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10128 "inc/vcf/validator_detail_v41.hpp"
+#line 10132 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10145,7 +10149,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 10149 "inc/vcf/validator_detail_v41.hpp"
+#line 10153 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10166,7 +10170,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 10170 "inc/vcf/validator_detail_v41.hpp"
+#line 10174 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr691;
 	if ( (*p) > 58 ) {
@@ -10185,7 +10189,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 10189 "inc/vcf/validator_detail_v41.hpp"
+#line 10193 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr693;
@@ -10205,7 +10209,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 10209 "inc/vcf/validator_detail_v41.hpp"
+#line 10213 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10234,7 +10238,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 10238 "inc/vcf/validator_detail_v41.hpp"
+#line 10242 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10256,7 +10260,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 10260 "inc/vcf/validator_detail_v41.hpp"
+#line 10264 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10276,7 +10280,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10280 "inc/vcf/validator_detail_v41.hpp"
+#line 10284 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr699;
 	goto tr698;
@@ -10290,7 +10294,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10294 "inc/vcf/validator_detail_v41.hpp"
+#line 10298 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10307,7 +10311,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 10311 "inc/vcf/validator_detail_v41.hpp"
+#line 10315 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr700;
 	if ( (*p) > 58 ) {
@@ -10326,7 +10330,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 10330 "inc/vcf/validator_detail_v41.hpp"
+#line 10334 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr702;
 		case 45: goto tr702;
@@ -10344,7 +10348,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 10348 "inc/vcf/validator_detail_v41.hpp"
+#line 10352 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr703;
 	goto tr701;
@@ -10358,7 +10362,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 10362 "inc/vcf/validator_detail_v41.hpp"
+#line 10366 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10381,7 +10385,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 10385 "inc/vcf/validator_detail_v41.hpp"
+#line 10389 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10402,7 +10406,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 10406 "inc/vcf/validator_detail_v41.hpp"
+#line 10410 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10423,7 +10427,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 10427 "inc/vcf/validator_detail_v41.hpp"
+#line 10431 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr706;
 	if ( (*p) > 58 ) {
@@ -10442,7 +10446,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 10446 "inc/vcf/validator_detail_v41.hpp"
+#line 10450 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr708;
 		case 45: goto tr708;
@@ -10460,7 +10464,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 10464 "inc/vcf/validator_detail_v41.hpp"
+#line 10468 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr709;
 	goto tr707;
@@ -10474,7 +10478,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 10478 "inc/vcf/validator_detail_v41.hpp"
+#line 10482 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10497,7 +10501,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 10501 "inc/vcf/validator_detail_v41.hpp"
+#line 10505 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10519,7 +10523,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 10523 "inc/vcf/validator_detail_v41.hpp"
+#line 10527 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10539,7 +10543,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 10543 "inc/vcf/validator_detail_v41.hpp"
+#line 10547 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr715;
 	goto tr714;
@@ -10553,7 +10557,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 10557 "inc/vcf/validator_detail_v41.hpp"
+#line 10561 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10570,7 +10574,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 10574 "inc/vcf/validator_detail_v41.hpp"
+#line 10578 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10590,7 +10594,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 10594 "inc/vcf/validator_detail_v41.hpp"
+#line 10598 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr719;
 	goto tr718;
@@ -10604,7 +10608,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 10608 "inc/vcf/validator_detail_v41.hpp"
+#line 10612 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10625,7 +10629,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 10629 "inc/vcf/validator_detail_v41.hpp"
+#line 10633 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10646,7 +10650,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 10650 "inc/vcf/validator_detail_v41.hpp"
+#line 10654 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 48: goto tr721;
 		case 61: goto tr722;
@@ -10667,7 +10671,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 10671 "inc/vcf/validator_detail_v41.hpp"
+#line 10675 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr723;
 	if ( (*p) > 58 ) {
@@ -10686,7 +10690,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 10690 "inc/vcf/validator_detail_v41.hpp"
+#line 10694 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr725;
 		case 45: goto tr725;
@@ -10704,7 +10708,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 10708 "inc/vcf/validator_detail_v41.hpp"
+#line 10712 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr726;
 	goto tr724;
@@ -10718,7 +10722,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 10722 "inc/vcf/validator_detail_v41.hpp"
+#line 10726 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10737,7 +10741,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 10741 "inc/vcf/validator_detail_v41.hpp"
+#line 10745 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr728;
 		case 45: goto tr728;
@@ -10758,7 +10762,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 10762 "inc/vcf/validator_detail_v41.hpp"
+#line 10766 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr729;
 		case 73: goto tr731;
@@ -10776,7 +10780,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 10780 "inc/vcf/validator_detail_v41.hpp"
+#line 10784 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr733;
 	goto tr727;
@@ -10790,7 +10794,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 10794 "inc/vcf/validator_detail_v41.hpp"
+#line 10798 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10811,7 +10815,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 10815 "inc/vcf/validator_detail_v41.hpp"
+#line 10819 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr735;
 		case 45: goto tr735;
@@ -10829,7 +10833,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 10833 "inc/vcf/validator_detail_v41.hpp"
+#line 10837 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr736;
 	goto tr727;
@@ -10843,7 +10847,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 10847 "inc/vcf/validator_detail_v41.hpp"
+#line 10851 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10862,7 +10866,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 10866 "inc/vcf/validator_detail_v41.hpp"
+#line 10870 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10884,7 +10888,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 10888 "inc/vcf/validator_detail_v41.hpp"
+#line 10892 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr737;
 	goto tr727;
@@ -10898,7 +10902,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 10902 "inc/vcf/validator_detail_v41.hpp"
+#line 10906 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr738;
 	goto tr727;
@@ -10912,7 +10916,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 10916 "inc/vcf/validator_detail_v41.hpp"
+#line 10920 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10929,7 +10933,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 10933 "inc/vcf/validator_detail_v41.hpp"
+#line 10937 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr739;
 	goto tr727;
@@ -10943,7 +10947,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 10947 "inc/vcf/validator_detail_v41.hpp"
+#line 10951 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr738;
 	goto tr727;
@@ -10961,7 +10965,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 10965 "inc/vcf/validator_detail_v41.hpp"
+#line 10969 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -10982,7 +10986,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 10986 "inc/vcf/validator_detail_v41.hpp"
+#line 10990 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr741;
 	if ( (*p) > 58 ) {
@@ -11001,7 +11005,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 11005 "inc/vcf/validator_detail_v41.hpp"
+#line 11009 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr743;
 		case 45: goto tr743;
@@ -11019,7 +11023,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 11023 "inc/vcf/validator_detail_v41.hpp"
+#line 11027 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr744;
 	goto tr742;
@@ -11033,7 +11037,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 11037 "inc/vcf/validator_detail_v41.hpp"
+#line 11041 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11056,7 +11060,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 11060 "inc/vcf/validator_detail_v41.hpp"
+#line 11064 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11078,7 +11082,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 11082 "inc/vcf/validator_detail_v41.hpp"
+#line 11086 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr747;
 	if ( (*p) > 58 ) {
@@ -11097,7 +11101,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 11101 "inc/vcf/validator_detail_v41.hpp"
+#line 11105 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr749;
 		case 45: goto tr749;
@@ -11118,7 +11122,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 11122 "inc/vcf/validator_detail_v41.hpp"
+#line 11126 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr750;
 		case 73: goto tr752;
@@ -11136,7 +11140,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 11140 "inc/vcf/validator_detail_v41.hpp"
+#line 11144 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr754;
 	goto tr748;
@@ -11150,7 +11154,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 11154 "inc/vcf/validator_detail_v41.hpp"
+#line 11158 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11171,7 +11175,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 11175 "inc/vcf/validator_detail_v41.hpp"
+#line 11179 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr756;
 		case 45: goto tr756;
@@ -11189,7 +11193,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 11193 "inc/vcf/validator_detail_v41.hpp"
+#line 11197 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr757;
 	goto tr748;
@@ -11203,7 +11207,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 11207 "inc/vcf/validator_detail_v41.hpp"
+#line 11211 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11222,7 +11226,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 11226 "inc/vcf/validator_detail_v41.hpp"
+#line 11230 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11244,7 +11248,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 11248 "inc/vcf/validator_detail_v41.hpp"
+#line 11252 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr758;
 	goto tr748;
@@ -11258,7 +11262,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 11262 "inc/vcf/validator_detail_v41.hpp"
+#line 11266 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr759;
 	goto tr748;
@@ -11272,7 +11276,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 11276 "inc/vcf/validator_detail_v41.hpp"
+#line 11280 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11289,7 +11293,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 11293 "inc/vcf/validator_detail_v41.hpp"
+#line 11297 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr760;
 	goto tr748;
@@ -11303,7 +11307,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 11307 "inc/vcf/validator_detail_v41.hpp"
+#line 11311 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr759;
 	goto tr748;
@@ -11317,7 +11321,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 11321 "inc/vcf/validator_detail_v41.hpp"
+#line 11325 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11338,7 +11342,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 11342 "inc/vcf/validator_detail_v41.hpp"
+#line 11346 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11359,7 +11363,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 11363 "inc/vcf/validator_detail_v41.hpp"
+#line 11367 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11380,7 +11384,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 11384 "inc/vcf/validator_detail_v41.hpp"
+#line 11388 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11401,7 +11405,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 11405 "inc/vcf/validator_detail_v41.hpp"
+#line 11409 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11422,7 +11426,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 11426 "inc/vcf/validator_detail_v41.hpp"
+#line 11430 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11442,7 +11446,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 11446 "inc/vcf/validator_detail_v41.hpp"
+#line 11450 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr769;
 	goto tr768;
@@ -11456,7 +11460,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 11460 "inc/vcf/validator_detail_v41.hpp"
+#line 11464 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11477,7 +11481,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 11481 "inc/vcf/validator_detail_v41.hpp"
+#line 11485 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11498,7 +11502,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 11502 "inc/vcf/validator_detail_v41.hpp"
+#line 11506 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11519,7 +11523,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 11523 "inc/vcf/validator_detail_v41.hpp"
+#line 11527 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11540,7 +11544,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 11544 "inc/vcf/validator_detail_v41.hpp"
+#line 11548 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11561,7 +11565,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 11565 "inc/vcf/validator_detail_v41.hpp"
+#line 11569 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11582,7 +11586,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 11586 "inc/vcf/validator_detail_v41.hpp"
+#line 11590 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11603,7 +11607,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 11607 "inc/vcf/validator_detail_v41.hpp"
+#line 11611 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11624,7 +11628,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 11628 "inc/vcf/validator_detail_v41.hpp"
+#line 11632 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11645,7 +11649,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 11649 "inc/vcf/validator_detail_v41.hpp"
+#line 11653 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11665,7 +11669,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 11669 "inc/vcf/validator_detail_v41.hpp"
+#line 11673 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr781;
 	goto tr780;
@@ -11679,7 +11683,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 11683 "inc/vcf/validator_detail_v41.hpp"
+#line 11687 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11700,7 +11704,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 11704 "inc/vcf/validator_detail_v41.hpp"
+#line 11708 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr609;
 		case 10: goto tr610;
@@ -11738,7 +11742,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 11742 "inc/vcf/validator_detail_v41.hpp"
+#line 11746 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr585;
 	if ( (*p) < 65 ) {
@@ -11776,7 +11780,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 11780 "inc/vcf/validator_detail_v41.hpp"
+#line 11784 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr590;
 		case 58: goto st430;
@@ -11812,7 +11816,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 11816 "inc/vcf/validator_detail_v41.hpp"
+#line 11820 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr782;
 		case 45: goto tr782;
@@ -11830,7 +11834,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 11834 "inc/vcf/validator_detail_v41.hpp"
+#line 11838 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr783;
 	goto tr572;
@@ -11844,7 +11848,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 11848 "inc/vcf/validator_detail_v41.hpp"
+#line 11852 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr582;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11870,7 +11874,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 11874 "inc/vcf/validator_detail_v41.hpp"
+#line 11878 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr582;
 		case 46: goto tr578;
@@ -11900,7 +11904,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 11904 "inc/vcf/validator_detail_v41.hpp"
+#line 11908 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr784;
 	goto tr572;
@@ -11914,7 +11918,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 11918 "inc/vcf/validator_detail_v41.hpp"
+#line 11922 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr785;
 	goto tr572;
@@ -11928,7 +11932,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 11932 "inc/vcf/validator_detail_v41.hpp"
+#line 11936 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr582;
 	goto tr572;
@@ -11946,7 +11950,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 11950 "inc/vcf/validator_detail_v41.hpp"
+#line 11954 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr582;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11966,7 +11970,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 11970 "inc/vcf/validator_detail_v41.hpp"
+#line 11974 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr786;
 	goto tr572;
@@ -11980,7 +11984,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 11984 "inc/vcf/validator_detail_v41.hpp"
+#line 11988 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr785;
 	goto tr572;
@@ -11994,7 +11998,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 11998 "inc/vcf/validator_detail_v41.hpp"
+#line 12002 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr564;
 		case 46: goto tr787;
@@ -12033,7 +12037,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 12037 "inc/vcf/validator_detail_v41.hpp"
+#line 12041 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr788;
 		case 67: goto tr788;
@@ -12057,7 +12061,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 12061 "inc/vcf/validator_detail_v41.hpp"
+#line 12065 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr570;
 		case 44: goto tr571;
@@ -12093,7 +12097,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 12097 "inc/vcf/validator_detail_v41.hpp"
+#line 12101 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr790;
 		case 95: goto tr790;
@@ -12117,7 +12121,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 12121 "inc/vcf/validator_detail_v41.hpp"
+#line 12125 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 62: goto tr791;
 		case 95: goto tr789;
@@ -12151,7 +12155,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 12155 "inc/vcf/validator_detail_v41.hpp"
+#line 12159 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr570;
 		case 44: goto tr571;
@@ -12180,7 +12184,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 12184 "inc/vcf/validator_detail_v41.hpp"
+#line 12188 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr796;
 	if ( (*p) < 65 ) {
@@ -12202,7 +12206,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 12206 "inc/vcf/validator_detail_v41.hpp"
+#line 12210 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr799;
 		case 59: goto tr797;
@@ -12239,7 +12243,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 12243 "inc/vcf/validator_detail_v41.hpp"
+#line 12247 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr797;
 		case 61: goto tr797;
@@ -12275,7 +12279,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 12279 "inc/vcf/validator_detail_v41.hpp"
+#line 12283 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr799;
 		case 61: goto tr798;
@@ -12296,7 +12300,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 12300 "inc/vcf/validator_detail_v41.hpp"
+#line 12304 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr800;
 		case 45: goto tr800;
@@ -12314,7 +12318,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 12318 "inc/vcf/validator_detail_v41.hpp"
+#line 12322 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr801;
 	goto tr563;
@@ -12328,7 +12332,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 12332 "inc/vcf/validator_detail_v41.hpp"
+#line 12336 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr791;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12344,7 +12348,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 12348 "inc/vcf/validator_detail_v41.hpp"
+#line 12352 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr802;
@@ -12364,7 +12368,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 12368 "inc/vcf/validator_detail_v41.hpp"
+#line 12372 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr803;
 		case 62: goto tr805;
@@ -12400,7 +12404,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 12404 "inc/vcf/validator_detail_v41.hpp"
+#line 12408 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr803;
 		case 61: goto tr803;
@@ -12436,7 +12440,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 12440 "inc/vcf/validator_detail_v41.hpp"
+#line 12444 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr804;
 		case 62: goto tr805;
@@ -12457,7 +12461,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 12461 "inc/vcf/validator_detail_v41.hpp"
+#line 12465 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr799;
 	goto tr563;
@@ -12471,7 +12475,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 12475 "inc/vcf/validator_detail_v41.hpp"
+#line 12479 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr807;
 	if ( (*p) < 65 ) {
@@ -12493,7 +12497,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 12497 "inc/vcf/validator_detail_v41.hpp"
+#line 12501 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr810;
 		case 59: goto tr808;
@@ -12530,7 +12534,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 12534 "inc/vcf/validator_detail_v41.hpp"
+#line 12538 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr808;
 		case 61: goto tr808;
@@ -12566,7 +12570,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 12570 "inc/vcf/validator_detail_v41.hpp"
+#line 12574 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr810;
 		case 61: goto tr809;
@@ -12587,7 +12591,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 12591 "inc/vcf/validator_detail_v41.hpp"
+#line 12595 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr811;
 		case 45: goto tr811;
@@ -12605,7 +12609,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 12609 "inc/vcf/validator_detail_v41.hpp"
+#line 12613 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr812;
 	goto tr563;
@@ -12619,7 +12623,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 12623 "inc/vcf/validator_detail_v41.hpp"
+#line 12627 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr791;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12635,7 +12639,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 12639 "inc/vcf/validator_detail_v41.hpp"
+#line 12643 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr813;
@@ -12655,7 +12659,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 12659 "inc/vcf/validator_detail_v41.hpp"
+#line 12663 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr814;
 		case 62: goto tr816;
@@ -12691,7 +12695,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 12695 "inc/vcf/validator_detail_v41.hpp"
+#line 12699 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr814;
 		case 61: goto tr814;
@@ -12727,7 +12731,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 12731 "inc/vcf/validator_detail_v41.hpp"
+#line 12735 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr815;
 		case 62: goto tr816;
@@ -12748,7 +12752,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 12752 "inc/vcf/validator_detail_v41.hpp"
+#line 12756 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr810;
 	goto tr563;
@@ -12766,7 +12770,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 12770 "inc/vcf/validator_detail_v41.hpp"
+#line 12774 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr818;
 	if ( (*p) < 65 ) {
@@ -12788,7 +12792,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 12792 "inc/vcf/validator_detail_v41.hpp"
+#line 12796 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr821;
 		case 59: goto tr819;
@@ -12825,7 +12829,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 12829 "inc/vcf/validator_detail_v41.hpp"
+#line 12833 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr819;
 		case 61: goto tr819;
@@ -12861,7 +12865,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 12865 "inc/vcf/validator_detail_v41.hpp"
+#line 12869 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr821;
 		case 61: goto tr820;
@@ -12882,7 +12886,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 12886 "inc/vcf/validator_detail_v41.hpp"
+#line 12890 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr822;
 		case 45: goto tr822;
@@ -12900,7 +12904,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 12904 "inc/vcf/validator_detail_v41.hpp"
+#line 12908 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr823;
 	goto tr563;
@@ -12914,7 +12918,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 12918 "inc/vcf/validator_detail_v41.hpp"
+#line 12922 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr824;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12930,7 +12934,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 12934 "inc/vcf/validator_detail_v41.hpp"
+#line 12938 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr825;
@@ -12950,7 +12954,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 12954 "inc/vcf/validator_detail_v41.hpp"
+#line 12958 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr826;
 		case 62: goto tr828;
@@ -12986,7 +12990,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 12990 "inc/vcf/validator_detail_v41.hpp"
+#line 12994 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr826;
 		case 61: goto tr826;
@@ -13022,7 +13026,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 13026 "inc/vcf/validator_detail_v41.hpp"
+#line 13030 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr827;
 		case 62: goto tr828;
@@ -13043,7 +13047,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 13047 "inc/vcf/validator_detail_v41.hpp"
+#line 13051 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr821;
 	goto tr563;
@@ -13061,7 +13065,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 13065 "inc/vcf/validator_detail_v41.hpp"
+#line 13069 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr830;
 	if ( (*p) < 65 ) {
@@ -13083,7 +13087,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 13087 "inc/vcf/validator_detail_v41.hpp"
+#line 13091 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr833;
 		case 59: goto tr831;
@@ -13120,7 +13124,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 13124 "inc/vcf/validator_detail_v41.hpp"
+#line 13128 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr831;
 		case 61: goto tr831;
@@ -13156,7 +13160,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 13160 "inc/vcf/validator_detail_v41.hpp"
+#line 13164 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr833;
 		case 61: goto tr832;
@@ -13177,7 +13181,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 13181 "inc/vcf/validator_detail_v41.hpp"
+#line 13185 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr834;
 		case 45: goto tr834;
@@ -13195,7 +13199,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 13199 "inc/vcf/validator_detail_v41.hpp"
+#line 13203 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr563;
@@ -13209,7 +13213,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 13213 "inc/vcf/validator_detail_v41.hpp"
+#line 13217 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr824;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13225,7 +13229,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 13229 "inc/vcf/validator_detail_v41.hpp"
+#line 13233 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr836;
@@ -13245,7 +13249,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 13249 "inc/vcf/validator_detail_v41.hpp"
+#line 13253 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr837;
 		case 62: goto tr839;
@@ -13281,7 +13285,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 13285 "inc/vcf/validator_detail_v41.hpp"
+#line 13289 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr837;
 		case 61: goto tr837;
@@ -13317,7 +13321,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 13321 "inc/vcf/validator_detail_v41.hpp"
+#line 13325 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr838;
 		case 62: goto tr839;
@@ -13338,7 +13342,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 13342 "inc/vcf/validator_detail_v41.hpp"
+#line 13346 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr833;
 	goto tr563;
@@ -13356,7 +13360,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 13360 "inc/vcf/validator_detail_v41.hpp"
+#line 13364 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr570;
 		case 65: goto tr788;
@@ -13381,7 +13385,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 13385 "inc/vcf/validator_detail_v41.hpp"
+#line 13389 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr547;
 		case 61: goto tr547;
@@ -13417,7 +13421,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 13421 "inc/vcf/validator_detail_v41.hpp"
+#line 13425 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr546;
 		case 59: goto tr548;
@@ -13447,14 +13451,14 @@ tr841:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 753 "src/vcf/vcf_v41.ragel"
+#line 757 "src/vcf/vcf_v41.ragel"
 	{ {goto st28;} }
 	goto st660;
 st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 13458 "inc/vcf/validator_detail_v41.hpp"
+#line 13462 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 st657:
 	if ( ++p == pe )
@@ -13474,14 +13478,14 @@ tr843:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 754 "src/vcf/vcf_v41.ragel"
+#line 758 "src/vcf/vcf_v41.ragel"
 	{ {goto st659;} }
 	goto st661;
 st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 13485 "inc/vcf/validator_detail_v41.hpp"
+#line 13489 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -14226,8 +14230,8 @@ case 661:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 	break;
@@ -14247,8 +14251,8 @@ case 661:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -14262,7 +14266,7 @@ case 661:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 215 "src/vcf/vcf_v41.ragel"
+#line 219 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_fileformat_section_error(*this,
             "The fileformat declaration is not 'fileformat=VCFv4.1'");
@@ -14295,7 +14299,7 @@ case 661:
 	case 93: 
 	case 94: 
 	case 98: 
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
@@ -14314,7 +14318,7 @@ case 661:
 	case 307: 
 	case 308: 
 	case 309: 
-#line 233 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st656;}
@@ -14354,7 +14358,7 @@ case 661:
 	case 347: 
 	case 348: 
 	case 349: 
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 243 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st656;}
@@ -14388,7 +14392,7 @@ case 661:
 	case 127: 
 	case 128: 
 	case 132: 
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
@@ -14434,7 +14438,7 @@ case 661:
 	case 175: 
 	case 176: 
 	case 180: 
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -14479,7 +14483,7 @@ case 661:
 	case 223: 
 	case 224: 
 	case 228: 
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -14500,7 +14504,7 @@ case 661:
 	case 240: 
 	case 241: 
 	case 248: 
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 287 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st656;}
@@ -14522,7 +14526,7 @@ case 661:
 	case 358: 
 	case 359: 
 	case 360: 
-#line 289 "src/vcf/vcf_v41.ragel"
+#line 293 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st656;}
@@ -14544,7 +14548,7 @@ case 661:
 	case 257: 
 	case 258: 
 	case 298: 
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -14592,15 +14596,15 @@ case 661:
 	case 403: 
 	case 404: 
 	case 405: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 331 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -14612,8 +14616,8 @@ case 661:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -14627,7 +14631,7 @@ case 661:
 	case 443: 
 	case 654: 
 	case 655: 
-#line 343 "src/vcf/vcf_v41.ragel"
+#line 347 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st657;}
@@ -14641,7 +14645,7 @@ case 661:
 	case 416: 
 	case 417: 
 	case 418: 
-#line 349 "src/vcf/vcf_v41.ragel"
+#line 353 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
         p--; {goto st657;}
@@ -14654,7 +14658,7 @@ case 661:
 	break;
 	case 419: 
 	case 420: 
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 359 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
         p--; {goto st657;}
@@ -14667,7 +14671,7 @@ case 661:
 	break;
 	case 421: 
 	case 422: 
-#line 361 "src/vcf/vcf_v41.ragel"
+#line 365 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
         p--; {goto st657;}
@@ -14735,7 +14739,7 @@ case 661:
 	case 651: 
 	case 652: 
 	case 653: 
-#line 367 "src/vcf/vcf_v41.ragel"
+#line 371 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
         p--; {goto st657;}
@@ -14760,7 +14764,7 @@ case 661:
 	case 596: 
 	case 597: 
 	case 598: 
-#line 373 "src/vcf/vcf_v41.ragel"
+#line 377 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
         p--; {goto st657;}
@@ -14776,7 +14780,7 @@ case 661:
 	case 431: 
 	case 587: 
 	case 588: 
-#line 379 "src/vcf/vcf_v41.ragel"
+#line 383 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
         p--; {goto st657;}
@@ -14789,7 +14793,7 @@ case 661:
 	break;
 	case 435: 
 	case 436: 
-#line 491 "src/vcf/vcf_v41.ragel"
+#line 495 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
         p--; {goto st657;}
@@ -14802,7 +14806,7 @@ case 661:
 	break;
 	case 446: 
 	case 447: 
-#line 497 "src/vcf/vcf_v41.ragel"
+#line 501 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -14822,15 +14826,15 @@ case 661:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st656;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 331 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -14842,8 +14846,8 @@ case 661:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -14852,12 +14856,12 @@ case 661:
 	case 80: 
 	case 81: 
 	case 102: 
-#line 227 "src/vcf/vcf_v41.ragel"
+#line 231 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
         p--; {goto st656;}
     }
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
@@ -14869,12 +14873,12 @@ case 661:
     }
 	break;
 	case 103: 
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -14888,12 +14892,12 @@ case 661:
 	case 155: 
 	case 156: 
 	case 184: 
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -14907,12 +14911,12 @@ case 661:
 	case 203: 
 	case 204: 
 	case 232: 
-#line 272 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -14925,12 +14929,12 @@ case 661:
 	break;
 	case 162: 
 	case 163: 
-#line 277 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -14943,12 +14947,12 @@ case 661:
 	break;
 	case 210: 
 	case 211: 
-#line 277 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -14968,12 +14972,12 @@ case 661:
 	case 268: 
 	case 269: 
 	case 270: 
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -14993,12 +14997,12 @@ case 661:
 	case 278: 
 	case 279: 
 	case 280: 
-#line 305 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -15013,12 +15017,12 @@ case 661:
 	case 328: 
 	case 329: 
 	case 330: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 243 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st656;}
@@ -15032,12 +15036,12 @@ case 661:
 	case 113: 
 	case 114: 
 	case 115: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
@@ -15051,12 +15055,12 @@ case 661:
 	case 145: 
 	case 146: 
 	case 147: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -15070,12 +15074,12 @@ case 661:
 	case 193: 
 	case 194: 
 	case 195: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -15092,12 +15096,12 @@ case 661:
 	case 245: 
 	case 246: 
 	case 247: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 287 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st656;}
@@ -15110,12 +15114,12 @@ case 661:
 	break;
 	case 259: 
 	case 260: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -15132,12 +15136,12 @@ case 661:
 	case 99: 
 	case 100: 
 	case 101: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
@@ -15154,12 +15158,12 @@ case 661:
 	case 133: 
 	case 134: 
 	case 135: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
@@ -15176,12 +15180,12 @@ case 661:
 	case 181: 
 	case 182: 
 	case 183: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
@@ -15198,12 +15202,12 @@ case 661:
 	case 229: 
 	case 230: 
 	case 231: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
@@ -15233,12 +15237,12 @@ case 661:
 	case 299: 
 	case 300: 
 	case 301: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -15256,12 +15260,12 @@ case 661:
 	case 314: 
 	case 315: 
 	case 316: 
-#line 321 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st656;}
     }
-#line 233 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st656;}
@@ -15280,12 +15284,12 @@ case 661:
 	case 366: 
 	case 367: 
 	case 368: 
-#line 321 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st656;}
     }
-#line 289 "src/vcf/vcf_v41.ragel"
+#line 293 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st656;}
@@ -15343,12 +15347,12 @@ case 661:
 	case 581: 
 	case 582: 
 	case 586: 
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15361,12 +15365,12 @@ case 661:
 	break;
 	case 453: 
 	case 454: 
-#line 395 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15380,12 +15384,12 @@ case 661:
 	case 460: 
 	case 461: 
 	case 462: 
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15399,12 +15403,12 @@ case 661:
 	case 464: 
 	case 465: 
 	case 466: 
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 409 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15428,12 +15432,12 @@ case 661:
 	case 478: 
 	case 479: 
 	case 480: 
-#line 410 "src/vcf/vcf_v41.ragel"
+#line 414 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15447,12 +15451,12 @@ case 661:
 	case 482: 
 	case 483: 
 	case 484: 
-#line 415 "src/vcf/vcf_v41.ragel"
+#line 419 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15476,12 +15480,12 @@ case 661:
 	case 497: 
 	case 498: 
 	case 499: 
-#line 420 "src/vcf/vcf_v41.ragel"
+#line 424 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15494,12 +15498,12 @@ case 661:
 	break;
 	case 505: 
 	case 506: 
-#line 425 "src/vcf/vcf_v41.ragel"
+#line 429 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15512,12 +15516,12 @@ case 661:
 	break;
 	case 509: 
 	case 510: 
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 434 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15531,12 +15535,12 @@ case 661:
 	case 512: 
 	case 513: 
 	case 514: 
-#line 435 "src/vcf/vcf_v41.ragel"
+#line 439 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15550,12 +15554,12 @@ case 661:
 	case 518: 
 	case 519: 
 	case 520: 
-#line 440 "src/vcf/vcf_v41.ragel"
+#line 444 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15568,12 +15572,12 @@ case 661:
 	break;
 	case 523: 
 	case 524: 
-#line 445 "src/vcf/vcf_v41.ragel"
+#line 449 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15586,12 +15590,12 @@ case 661:
 	break;
 	case 526: 
 	case 527: 
-#line 450 "src/vcf/vcf_v41.ragel"
+#line 454 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15615,12 +15619,12 @@ case 661:
 	case 544: 
 	case 545: 
 	case 546: 
-#line 455 "src/vcf/vcf_v41.ragel"
+#line 459 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15634,12 +15638,12 @@ case 661:
 	case 531: 
 	case 532: 
 	case 533: 
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 464 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15653,12 +15657,12 @@ case 661:
 	case 549: 
 	case 550: 
 	case 551: 
-#line 465 "src/vcf/vcf_v41.ragel"
+#line 469 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15682,12 +15686,12 @@ case 661:
 	case 564: 
 	case 565: 
 	case 566: 
-#line 470 "src/vcf/vcf_v41.ragel"
+#line 474 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15700,12 +15704,12 @@ case 661:
 	break;
 	case 573: 
 	case 574: 
-#line 475 "src/vcf/vcf_v41.ragel"
+#line 479 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15718,12 +15722,12 @@ case 661:
 	break;
 	case 584: 
 	case 585: 
-#line 480 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15736,12 +15740,12 @@ case 661:
 	break;
 	case 456: 
 	case 457: 
-#line 485 "src/vcf/vcf_v41.ragel"
+#line 489 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15756,14 +15760,14 @@ case 661:
 	case 438: 
 	case 444: 
 	case 445: 
-#line 504 "src/vcf/vcf_v41.ragel"
+#line 508 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_body_section_error(*this, message_stream.str());
         p--; {goto st657;}
     }
-#line 497 "src/vcf/vcf_v41.ragel"
+#line 501 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -15787,15 +15791,15 @@ case 661:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st656;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 331 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
@@ -15807,25 +15811,25 @@ case 661:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st657;}
     }
 	break;
 	case 271: 
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 305 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -15837,17 +15841,17 @@ case 661:
     }
 	break;
 	case 281: 
-#line 305 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -15859,17 +15863,17 @@ case 661:
     }
 	break;
 	case 261: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 315 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st656;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
@@ -15881,17 +15885,17 @@ case 661:
     }
 	break;
 	case 508: 
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 434 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15903,17 +15907,17 @@ case 661:
     }
 	break;
 	case 522: 
-#line 445 "src/vcf/vcf_v41.ragel"
+#line 449 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15925,17 +15929,17 @@ case 661:
     }
 	break;
 	case 525: 
-#line 450 "src/vcf/vcf_v41.ragel"
+#line 454 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15947,17 +15951,17 @@ case 661:
     }
 	break;
 	case 572: 
-#line 475 "src/vcf/vcf_v41.ragel"
+#line 479 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15969,17 +15973,17 @@ case 661:
     }
 	break;
 	case 583: 
-#line 480 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -15991,17 +15995,17 @@ case 661:
     }
 	break;
 	case 455: 
-#line 485 "src/vcf/vcf_v41.ragel"
+#line 489 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st657;}
     }
-#line 390 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st657;}
     }
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st657;}
@@ -16013,47 +16017,47 @@ case 661:
     }
 	break;
 	case 24: 
-#line 222 "src/vcf/vcf_v41.ragel"
+#line 226 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st656;}
     }
-#line 245 "src/vcf/vcf_v41.ragel"
+#line 249 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st656;}
     }
-#line 251 "src/vcf/vcf_v41.ragel"
+#line 255 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st656;}
     }
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 271 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st656;}
     }
-#line 233 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st656;}
     }
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 243 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st656;}
     }
-#line 295 "src/vcf/vcf_v41.ragel"
+#line 299 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st656;}
     }
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 287 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st656;}
     }
-#line 289 "src/vcf/vcf_v41.ragel"
+#line 293 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st656;}
@@ -16064,14 +16068,14 @@ case 661:
         p--; {goto st656;}
     }
 	break;
-#line 16068 "inc/vcf/validator_detail_v41.hpp"
+#line 16072 "inc/vcf/validator_detail_v41.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 785 "src/vcf/vcf_v41.ragel"
+#line 789 "src/vcf/vcf_v41.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 746 "src/vcf/vcf_v42.ragel"
+#line 748 "src/vcf/vcf_v42.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v42_en_meta_section_skip = 728;
 static const int vcf_v42_en_body_section_skip = 729;
 
 
-#line 752 "src/vcf/vcf_v42.ragel"
+#line 754 "src/vcf/vcf_v42.ragel"
 
 }
 
@@ -60,7 +60,7 @@ namespace ebi
 	cs = vcf_v42_start;
 	}
 
-#line 768 "src/vcf/vcf_v42.ragel"
+#line 770 "src/vcf/vcf_v42.ragel"
 
     }
 
@@ -81,56 +81,57 @@ case 1:
 tr0:
 #line 60 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr14:
 #line 214 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.2'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         p--; {goto st728;}
     }
 #line 60 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr23:
 #line 60 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
-#line 326 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
@@ -139,31 +140,32 @@ tr23:
 tr25:
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
-#line 326 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
@@ -172,809 +174,811 @@ tr25:
 tr28:
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 233 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st728;}
     }
-#line 238 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
-#line 282 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st728;}
     }
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 289 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr38:
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr121:
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr129:
 #line 226 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr147:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr156:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr170:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr182:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr189:
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr192:
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr202:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr221:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr243:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr255:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr261:
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr271:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr284:
-#line 255 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr293:
-#line 276 "src/vcf/vcf_v42.ragel"
+#line 277 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr310:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr332:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr344:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr351:
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr360:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr373:
-#line 271 "src/vcf/vcf_v42.ragel"
+#line 272 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr382:
-#line 276 "src/vcf/vcf_v42.ragel"
+#line 277 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr399:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr421:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr433:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr440:
-#line 282 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr450:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 282 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr462:
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr473:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr478:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 299 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr480:
-#line 299 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr490:
-#line 299 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 304 "src/vcf/vcf_v42.ragel"
+#line 305 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr493:
-#line 304 "src/vcf/vcf_v42.ragel"
+#line 305 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr503:
-#line 304 "src/vcf/vcf_v42.ragel"
+#line 305 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr506:
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr529:
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 233 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr538:
-#line 320 "src/vcf/vcf_v42.ragel"
+#line 321 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st728;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 233 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr545:
-#line 238 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr556:
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 238 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr595:
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 289 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr607:
-#line 320 "src/vcf/vcf_v42.ragel"
+#line 321 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st728;}
     }
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 289 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	goto st0;
 tr615:
-#line 326 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
@@ -983,647 +987,647 @@ tr615:
 tr654:
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 	goto st0;
 tr666:
-#line 342 "src/vcf/vcf_v42.ragel"
+#line 344 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr670:
-#line 348 "src/vcf/vcf_v42.ragel"
+#line 350 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr675:
-#line 354 "src/vcf/vcf_v42.ragel"
+#line 356 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr680:
-#line 360 "src/vcf/vcf_v42.ragel"
+#line 362 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr684:
-#line 366 "src/vcf/vcf_v42.ragel"
+#line 368 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr693:
-#line 372 "src/vcf/vcf_v42.ragel"
+#line 374 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr705:
-#line 378 "src/vcf/vcf_v42.ragel"
+#line 380 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr713:
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr734:
-#line 490 "src/vcf/vcf_v42.ragel"
+#line 492 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr739:
-#line 503 "src/vcf/vcf_v42.ragel"
+#line 505 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st729;}
     }
-#line 496 "src/vcf/vcf_v42.ragel"
+#line 498 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr751:
-#line 496 "src/vcf/vcf_v42.ragel"
+#line 498 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr757:
-#line 394 "src/vcf/vcf_v42.ragel"
+#line 396 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr759:
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 486 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr761:
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 486 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr768:
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 401 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr772:
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 406 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr776:
-#line 409 "src/vcf/vcf_v42.ragel"
+#line 411 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr790:
-#line 414 "src/vcf/vcf_v42.ragel"
+#line 416 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr795:
-#line 419 "src/vcf/vcf_v42.ragel"
+#line 421 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr813:
-#line 424 "src/vcf/vcf_v42.ragel"
+#line 426 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr817:
-#line 429 "src/vcf/vcf_v42.ragel"
+#line 431 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr819:
-#line 429 "src/vcf/vcf_v42.ragel"
+#line 431 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr822:
-#line 434 "src/vcf/vcf_v42.ragel"
+#line 436 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr828:
-#line 439 "src/vcf/vcf_v42.ragel"
+#line 441 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr833:
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 446 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr835:
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 446 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr837:
-#line 449 "src/vcf/vcf_v42.ragel"
+#line 451 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr839:
-#line 449 "src/vcf/vcf_v42.ragel"
+#line 451 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr845:
-#line 459 "src/vcf/vcf_v42.ragel"
+#line 461 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr848:
-#line 454 "src/vcf/vcf_v42.ragel"
+#line 456 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr863:
-#line 464 "src/vcf/vcf_v42.ragel"
+#line 466 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr869:
-#line 469 "src/vcf/vcf_v42.ragel"
+#line 471 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr887:
-#line 474 "src/vcf/vcf_v42.ragel"
+#line 476 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr889:
-#line 474 "src/vcf/vcf_v42.ragel"
+#line 476 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr899:
-#line 479 "src/vcf/vcf_v42.ragel"
+#line 481 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr901:
-#line 479 "src/vcf/vcf_v42.ragel"
+#line 481 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
 tr965:
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
-#line 342 "src/vcf/vcf_v42.ragel"
+#line 344 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	goto st0;
-#line 1627 "inc/vcf/validator_detail_v42.hpp"
+#line 1631 "inc/vcf/validator_detail_v42.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1732,7 +1736,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1736 "inc/vcf/validator_detail_v42.hpp"
+#line 1740 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1746,7 +1750,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1750 "inc/vcf/validator_detail_v42.hpp"
+#line 1754 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1760,7 +1764,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1764 "inc/vcf/validator_detail_v42.hpp"
+#line 1768 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1774,7 +1778,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1778 "inc/vcf/validator_detail_v42.hpp"
+#line 1782 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1788,7 +1792,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1792 "inc/vcf/validator_detail_v42.hpp"
+#line 1796 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1802,7 +1806,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1806 "inc/vcf/validator_detail_v42.hpp"
+#line 1810 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 50 )
 		goto tr21;
 	goto tr14;
@@ -1816,7 +1820,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1820 "inc/vcf/validator_detail_v42.hpp"
+#line 1824 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto tr22;
 	goto tr14;
@@ -1840,7 +1844,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1844 "inc/vcf/validator_detail_v42.hpp"
+#line 1848 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr23;
@@ -1893,7 +1897,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1897 "inc/vcf/validator_detail_v42.hpp"
+#line 1901 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr40;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1909,7 +1913,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1913 "inc/vcf/validator_detail_v42.hpp"
+#line 1917 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto st29;
 		case 60: goto st34;
@@ -1937,7 +1941,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 1941 "inc/vcf/validator_detail_v42.hpp"
+#line 1945 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto tr44;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1952,8 +1956,8 @@ tr44:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -1972,8 +1976,8 @@ tr52:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -1991,7 +1995,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 1995 "inc/vcf/validator_detail_v42.hpp"
+#line 1999 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr25;
@@ -2026,7 +2030,7 @@ st30:
 	if ( ++p == pe )
 		goto _test_eof30;
 case 30:
-#line 2030 "inc/vcf/validator_detail_v42.hpp"
+#line 2034 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr50;
 		case 92: goto tr51;
@@ -2054,7 +2058,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2058 "inc/vcf/validator_detail_v42.hpp"
+#line 2062 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto tr52;
 	goto tr38;
@@ -2078,7 +2082,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2082 "inc/vcf/validator_detail_v42.hpp"
+#line 2086 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr51;
@@ -2100,7 +2104,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2104 "inc/vcf/validator_detail_v42.hpp"
+#line 2108 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr50;
@@ -2160,7 +2164,7 @@ st36:
 	if ( ++p == pe )
 		goto _test_eof36;
 case 36:
-#line 2164 "inc/vcf/validator_detail_v42.hpp"
+#line 2168 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr61;
 		case 92: goto tr62;
@@ -2188,7 +2192,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2192 "inc/vcf/validator_detail_v42.hpp"
+#line 2196 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st31;
 	goto tr38;
@@ -2212,7 +2216,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2216 "inc/vcf/validator_detail_v42.hpp"
+#line 2220 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr64;
 		case 92: goto tr62;
@@ -2234,7 +2238,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2238 "inc/vcf/validator_detail_v42.hpp"
+#line 2242 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr61;
 		case 62: goto tr65;
@@ -2253,7 +2257,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2257 "inc/vcf/validator_detail_v42.hpp"
+#line 2261 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr61;
@@ -2272,7 +2276,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2276 "inc/vcf/validator_detail_v42.hpp"
+#line 2280 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st41;
 	if ( (*p) < 48 ) {
@@ -2307,7 +2311,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2311 "inc/vcf/validator_detail_v42.hpp"
+#line 2315 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr68;
 		case 95: goto tr67;
@@ -2334,7 +2338,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2338 "inc/vcf/validator_detail_v42.hpp"
+#line 2342 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st62;
 	if ( (*p) < 45 ) {
@@ -2366,7 +2370,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2370 "inc/vcf/validator_detail_v42.hpp"
+#line 2374 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr72;
 		case 62: goto tr50;
@@ -2387,7 +2391,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2391 "inc/vcf/validator_detail_v42.hpp"
+#line 2395 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr73;
 	if ( (*p) < 48 ) {
@@ -2412,7 +2416,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2416 "inc/vcf/validator_detail_v42.hpp"
+#line 2420 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st46;
 	if ( (*p) < 48 ) {
@@ -2447,7 +2451,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2451 "inc/vcf/validator_detail_v42.hpp"
+#line 2455 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr77;
 		case 95: goto tr76;
@@ -2474,7 +2478,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2478 "inc/vcf/validator_detail_v42.hpp"
+#line 2482 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st49;
 	if ( (*p) < 45 ) {
@@ -2517,7 +2521,7 @@ st50:
 	if ( ++p == pe )
 		goto _test_eof50;
 case 50:
-#line 2521 "inc/vcf/validator_detail_v42.hpp"
+#line 2525 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 92: goto tr84;
@@ -2545,7 +2549,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2549 "inc/vcf/validator_detail_v42.hpp"
+#line 2553 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st45;
 		case 62: goto st31;
@@ -2571,7 +2575,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2575 "inc/vcf/validator_detail_v42.hpp"
+#line 2579 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr86;
 		case 92: goto tr84;
@@ -2593,7 +2597,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2597 "inc/vcf/validator_detail_v42.hpp"
+#line 2601 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr87;
@@ -2633,7 +2637,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2637 "inc/vcf/validator_detail_v42.hpp"
+#line 2641 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr82;
@@ -2684,7 +2688,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2688 "inc/vcf/validator_detail_v42.hpp"
+#line 2692 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr82;
@@ -2735,7 +2739,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2739 "inc/vcf/validator_detail_v42.hpp"
+#line 2743 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr82;
@@ -2778,7 +2782,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2782 "inc/vcf/validator_detail_v42.hpp"
+#line 2786 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr95;
 		case 44: goto tr82;
@@ -2808,7 +2812,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2812 "inc/vcf/validator_detail_v42.hpp"
+#line 2816 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr98;
@@ -2848,7 +2852,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2852 "inc/vcf/validator_detail_v42.hpp"
+#line 2856 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr83;
@@ -2877,7 +2881,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2881 "inc/vcf/validator_detail_v42.hpp"
+#line 2885 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr86;
 		case 44: goto tr98;
@@ -2897,7 +2901,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 2901 "inc/vcf/validator_detail_v42.hpp"
+#line 2905 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr80;
 		case 44: goto tr101;
@@ -2938,7 +2942,7 @@ st63:
 	if ( ++p == pe )
 		goto _test_eof63;
 case 63:
-#line 2942 "inc/vcf/validator_detail_v42.hpp"
+#line 2946 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 92: goto tr106;
@@ -2966,7 +2970,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 2970 "inc/vcf/validator_detail_v42.hpp"
+#line 2974 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr107;
 		case 92: goto tr106;
@@ -2988,7 +2992,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 2992 "inc/vcf/validator_detail_v42.hpp"
+#line 2996 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr108;
@@ -3018,7 +3022,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3022 "inc/vcf/validator_detail_v42.hpp"
+#line 3026 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr105;
@@ -3069,7 +3073,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3073 "inc/vcf/validator_detail_v42.hpp"
+#line 3077 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr105;
@@ -3120,7 +3124,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3124 "inc/vcf/validator_detail_v42.hpp"
+#line 3128 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 47: goto tr105;
@@ -3163,7 +3167,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3167 "inc/vcf/validator_detail_v42.hpp"
+#line 3171 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr95;
 		case 44: goto tr105;
@@ -3193,7 +3197,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3197 "inc/vcf/validator_detail_v42.hpp"
+#line 3201 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr83;
 		case 44: goto tr118;
@@ -3223,7 +3227,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3227 "inc/vcf/validator_detail_v42.hpp"
+#line 3231 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr83;
@@ -3252,7 +3256,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3256 "inc/vcf/validator_detail_v42.hpp"
+#line 3260 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr107;
 		case 44: goto tr118;
@@ -3276,7 +3280,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3280 "inc/vcf/validator_detail_v42.hpp"
+#line 3284 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 76: goto tr122;
@@ -3294,7 +3298,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3298 "inc/vcf/validator_detail_v42.hpp"
+#line 3302 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 84: goto st75;
@@ -3321,7 +3325,7 @@ st76:
 	if ( ++p == pe )
 		goto _test_eof76;
 case 76:
-#line 3325 "inc/vcf/validator_detail_v42.hpp"
+#line 3329 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st77;
 	goto tr121;
@@ -3387,7 +3391,7 @@ st81:
 	if ( ++p == pe )
 		goto _test_eof81;
 case 81:
-#line 3391 "inc/vcf/validator_detail_v42.hpp"
+#line 3395 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr132;
 		case 95: goto tr133;
@@ -3411,7 +3415,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3415 "inc/vcf/validator_detail_v42.hpp"
+#line 3419 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st83;
 	goto tr121;
@@ -3509,7 +3513,7 @@ st95:
 	if ( ++p == pe )
 		goto _test_eof95;
 case 95:
-#line 3513 "inc/vcf/validator_detail_v42.hpp"
+#line 3517 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr149;
 		case 92: goto tr150;
@@ -3537,7 +3541,7 @@ st96:
 	if ( ++p == pe )
 		goto _test_eof96;
 case 96:
-#line 3541 "inc/vcf/validator_detail_v42.hpp"
+#line 3545 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 92: goto tr153;
@@ -3565,7 +3569,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3569 "inc/vcf/validator_detail_v42.hpp"
+#line 3573 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st98;
 		case 62: goto st112;
@@ -3599,7 +3603,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3603 "inc/vcf/validator_detail_v42.hpp"
+#line 3607 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st99;
 	if ( (*p) < 48 ) {
@@ -3634,7 +3638,7 @@ st100:
 	if ( ++p == pe )
 		goto _test_eof100;
 case 100:
-#line 3638 "inc/vcf/validator_detail_v42.hpp"
+#line 3642 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr161;
 		case 95: goto tr160;
@@ -3661,7 +3665,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3665 "inc/vcf/validator_detail_v42.hpp"
+#line 3669 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st102;
 	goto tr121;
@@ -3696,7 +3700,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3700 "inc/vcf/validator_detail_v42.hpp"
+#line 3704 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 92: goto tr166;
@@ -3724,7 +3728,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3728 "inc/vcf/validator_detail_v42.hpp"
+#line 3732 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr167;
 		case 92: goto tr166;
@@ -3746,7 +3750,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3750 "inc/vcf/validator_detail_v42.hpp"
+#line 3754 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 44: goto tr168;
@@ -3776,7 +3780,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3780 "inc/vcf/validator_detail_v42.hpp"
+#line 3784 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 47: goto tr165;
@@ -3827,7 +3831,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3831 "inc/vcf/validator_detail_v42.hpp"
+#line 3835 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 47: goto tr165;
@@ -3878,7 +3882,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3882 "inc/vcf/validator_detail_v42.hpp"
+#line 3886 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 47: goto tr165;
@@ -3921,7 +3925,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 3925 "inc/vcf/validator_detail_v42.hpp"
+#line 3929 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr176;
 		case 92: goto tr166;
@@ -3939,7 +3943,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 3943 "inc/vcf/validator_detail_v42.hpp"
+#line 3947 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr149;
 		case 44: goto tr177;
@@ -3969,7 +3973,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 3973 "inc/vcf/validator_detail_v42.hpp"
+#line 3977 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr152;
@@ -4005,7 +4009,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4009 "inc/vcf/validator_detail_v42.hpp"
+#line 4013 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr179;
 		case 92: goto tr153;
@@ -4027,7 +4031,7 @@ st114:
 	if ( ++p == pe )
 		goto _test_eof114;
 case 114:
-#line 4031 "inc/vcf/validator_detail_v42.hpp"
+#line 4035 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 44: goto tr180;
@@ -4047,7 +4051,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4051 "inc/vcf/validator_detail_v42.hpp"
+#line 4055 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 47: goto tr151;
@@ -4098,7 +4102,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4102 "inc/vcf/validator_detail_v42.hpp"
+#line 4106 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 47: goto tr151;
@@ -4149,7 +4153,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4153 "inc/vcf/validator_detail_v42.hpp"
+#line 4157 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr152;
 		case 47: goto tr151;
@@ -4192,7 +4196,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4196 "inc/vcf/validator_detail_v42.hpp"
+#line 4200 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr176;
 		case 92: goto tr153;
@@ -4210,7 +4214,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4214 "inc/vcf/validator_detail_v42.hpp"
+#line 4218 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr152;
@@ -4233,7 +4237,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4237 "inc/vcf/validator_detail_v42.hpp"
+#line 4241 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto st120;
 		case 95: goto st120;
@@ -4261,7 +4265,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4265 "inc/vcf/validator_detail_v42.hpp"
+#line 4269 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 73: goto tr190;
@@ -4280,7 +4284,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4284 "inc/vcf/validator_detail_v42.hpp"
+#line 4288 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 76: goto tr193;
@@ -4298,7 +4302,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4302 "inc/vcf/validator_detail_v42.hpp"
+#line 4306 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 84: goto tr194;
@@ -4316,7 +4320,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4320 "inc/vcf/validator_detail_v42.hpp"
+#line 4324 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto tr195;
@@ -4334,7 +4338,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4338 "inc/vcf/validator_detail_v42.hpp"
+#line 4342 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 82: goto st126;
@@ -4361,7 +4365,7 @@ st127:
 	if ( ++p == pe )
 		goto _test_eof127;
 case 127:
-#line 4365 "inc/vcf/validator_detail_v42.hpp"
+#line 4369 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st128;
 	goto tr192;
@@ -4418,7 +4422,7 @@ st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 4422 "inc/vcf/validator_detail_v42.hpp"
+#line 4426 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st132;
 	if ( (*p) < 48 ) {
@@ -4457,7 +4461,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4461 "inc/vcf/validator_detail_v42.hpp"
+#line 4465 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr207;
 		case 95: goto tr206;
@@ -4484,7 +4488,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4488 "inc/vcf/validator_detail_v42.hpp"
+#line 4492 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st135;
 	goto tr192;
@@ -4582,7 +4586,7 @@ st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 4586 "inc/vcf/validator_detail_v42.hpp"
+#line 4590 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr223;
 		case 92: goto tr224;
@@ -4610,7 +4614,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4614 "inc/vcf/validator_detail_v42.hpp"
+#line 4618 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 92: goto tr227;
@@ -4638,7 +4642,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4642 "inc/vcf/validator_detail_v42.hpp"
+#line 4646 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st150;
 		case 62: goto st164;
@@ -4672,7 +4676,7 @@ st151:
 	if ( ++p == pe )
 		goto _test_eof151;
 case 151:
-#line 4676 "inc/vcf/validator_detail_v42.hpp"
+#line 4680 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st151;
 	if ( (*p) < 48 ) {
@@ -4707,7 +4711,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4711 "inc/vcf/validator_detail_v42.hpp"
+#line 4715 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr234;
 		case 95: goto tr233;
@@ -4734,7 +4738,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4738 "inc/vcf/validator_detail_v42.hpp"
+#line 4742 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st154;
 	goto tr192;
@@ -4769,7 +4773,7 @@ st155:
 	if ( ++p == pe )
 		goto _test_eof155;
 case 155:
-#line 4773 "inc/vcf/validator_detail_v42.hpp"
+#line 4777 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 92: goto tr239;
@@ -4797,7 +4801,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 4801 "inc/vcf/validator_detail_v42.hpp"
+#line 4805 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr240;
 		case 92: goto tr239;
@@ -4819,7 +4823,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4823 "inc/vcf/validator_detail_v42.hpp"
+#line 4827 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 44: goto tr241;
@@ -4849,7 +4853,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 4853 "inc/vcf/validator_detail_v42.hpp"
+#line 4857 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 47: goto tr238;
@@ -4900,7 +4904,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 4904 "inc/vcf/validator_detail_v42.hpp"
+#line 4908 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 47: goto tr238;
@@ -4951,7 +4955,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 4955 "inc/vcf/validator_detail_v42.hpp"
+#line 4959 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 47: goto tr238;
@@ -4994,7 +4998,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 4998 "inc/vcf/validator_detail_v42.hpp"
+#line 5002 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr249;
 		case 92: goto tr239;
@@ -5012,7 +5016,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5016 "inc/vcf/validator_detail_v42.hpp"
+#line 5020 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr223;
 		case 44: goto tr250;
@@ -5042,7 +5046,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5046 "inc/vcf/validator_detail_v42.hpp"
+#line 5050 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr226;
@@ -5078,7 +5082,7 @@ st165:
 	if ( ++p == pe )
 		goto _test_eof165;
 case 165:
-#line 5082 "inc/vcf/validator_detail_v42.hpp"
+#line 5086 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr252;
 		case 92: goto tr227;
@@ -5100,7 +5104,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5104 "inc/vcf/validator_detail_v42.hpp"
+#line 5108 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 44: goto tr253;
@@ -5120,7 +5124,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5124 "inc/vcf/validator_detail_v42.hpp"
+#line 5128 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 47: goto tr225;
@@ -5171,7 +5175,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5175 "inc/vcf/validator_detail_v42.hpp"
+#line 5179 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 47: goto tr225;
@@ -5222,7 +5226,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5226 "inc/vcf/validator_detail_v42.hpp"
+#line 5230 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr226;
 		case 47: goto tr225;
@@ -5265,7 +5269,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5269 "inc/vcf/validator_detail_v42.hpp"
+#line 5273 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr249;
 		case 92: goto tr227;
@@ -5283,7 +5287,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5287 "inc/vcf/validator_detail_v42.hpp"
+#line 5291 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr226;
@@ -5302,7 +5306,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5306 "inc/vcf/validator_detail_v42.hpp"
+#line 5310 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 82: goto tr262;
@@ -5320,7 +5324,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5324 "inc/vcf/validator_detail_v42.hpp"
+#line 5328 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 77: goto tr263;
@@ -5338,7 +5342,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5342 "inc/vcf/validator_detail_v42.hpp"
+#line 5346 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 65: goto tr264;
@@ -5356,7 +5360,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5360 "inc/vcf/validator_detail_v42.hpp"
+#line 5364 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 84: goto st176;
@@ -5383,7 +5387,7 @@ st177:
 	if ( ++p == pe )
 		goto _test_eof177;
 case 177:
-#line 5387 "inc/vcf/validator_detail_v42.hpp"
+#line 5391 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st178;
 	goto tr261;
@@ -5440,7 +5444,7 @@ st182:
 	if ( ++p == pe )
 		goto _test_eof182;
 case 182:
-#line 5444 "inc/vcf/validator_detail_v42.hpp"
+#line 5448 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st182;
 	if ( (*p) < 48 ) {
@@ -5479,7 +5483,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5483 "inc/vcf/validator_detail_v42.hpp"
+#line 5487 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr276;
 		case 95: goto tr275;
@@ -5506,7 +5510,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5510 "inc/vcf/validator_detail_v42.hpp"
+#line 5514 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st185;
 	goto tr261;
@@ -5583,7 +5587,7 @@ st192:
 	if ( ++p == pe )
 		goto _test_eof192;
 case 192:
-#line 5587 "inc/vcf/validator_detail_v42.hpp"
+#line 5591 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr287;
 	goto tr284;
@@ -5597,7 +5601,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5601 "inc/vcf/validator_detail_v42.hpp"
+#line 5605 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st194;
 	goto tr261;
@@ -5663,7 +5667,7 @@ st199:
 	if ( ++p == pe )
 		goto _test_eof199;
 case 199:
-#line 5667 "inc/vcf/validator_detail_v42.hpp"
+#line 5671 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr295;
 	if ( (*p) > 90 ) {
@@ -5682,7 +5686,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5686 "inc/vcf/validator_detail_v42.hpp"
+#line 5690 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st201;
 	goto tr261;
@@ -5780,7 +5784,7 @@ st213:
 	if ( ++p == pe )
 		goto _test_eof213;
 case 213:
-#line 5784 "inc/vcf/validator_detail_v42.hpp"
+#line 5788 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr312;
 		case 92: goto tr313;
@@ -5808,7 +5812,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 5812 "inc/vcf/validator_detail_v42.hpp"
+#line 5816 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 92: goto tr316;
@@ -5836,7 +5840,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 5840 "inc/vcf/validator_detail_v42.hpp"
+#line 5844 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st216;
 		case 62: goto st230;
@@ -5870,7 +5874,7 @@ st217:
 	if ( ++p == pe )
 		goto _test_eof217;
 case 217:
-#line 5874 "inc/vcf/validator_detail_v42.hpp"
+#line 5878 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st217;
 	if ( (*p) < 48 ) {
@@ -5905,7 +5909,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 5909 "inc/vcf/validator_detail_v42.hpp"
+#line 5913 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr323;
 		case 95: goto tr322;
@@ -5932,7 +5936,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 5936 "inc/vcf/validator_detail_v42.hpp"
+#line 5940 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st220;
 	goto tr261;
@@ -5967,7 +5971,7 @@ st221:
 	if ( ++p == pe )
 		goto _test_eof221;
 case 221:
-#line 5971 "inc/vcf/validator_detail_v42.hpp"
+#line 5975 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 92: goto tr328;
@@ -5995,7 +5999,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 5999 "inc/vcf/validator_detail_v42.hpp"
+#line 6003 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr329;
 		case 92: goto tr328;
@@ -6017,7 +6021,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6021 "inc/vcf/validator_detail_v42.hpp"
+#line 6025 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 44: goto tr330;
@@ -6047,7 +6051,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6051 "inc/vcf/validator_detail_v42.hpp"
+#line 6055 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 47: goto tr327;
@@ -6098,7 +6102,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6102 "inc/vcf/validator_detail_v42.hpp"
+#line 6106 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 47: goto tr327;
@@ -6149,7 +6153,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6153 "inc/vcf/validator_detail_v42.hpp"
+#line 6157 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 47: goto tr327;
@@ -6192,7 +6196,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6196 "inc/vcf/validator_detail_v42.hpp"
+#line 6200 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr338;
 		case 92: goto tr328;
@@ -6210,7 +6214,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6214 "inc/vcf/validator_detail_v42.hpp"
+#line 6218 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr312;
 		case 44: goto tr339;
@@ -6240,7 +6244,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6244 "inc/vcf/validator_detail_v42.hpp"
+#line 6248 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr315;
@@ -6276,7 +6280,7 @@ st231:
 	if ( ++p == pe )
 		goto _test_eof231;
 case 231:
-#line 6280 "inc/vcf/validator_detail_v42.hpp"
+#line 6284 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr341;
 		case 92: goto tr316;
@@ -6298,7 +6302,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6302 "inc/vcf/validator_detail_v42.hpp"
+#line 6306 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 44: goto tr342;
@@ -6318,7 +6322,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6322 "inc/vcf/validator_detail_v42.hpp"
+#line 6326 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 47: goto tr314;
@@ -6369,7 +6373,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6373 "inc/vcf/validator_detail_v42.hpp"
+#line 6377 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 47: goto tr314;
@@ -6420,7 +6424,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6424 "inc/vcf/validator_detail_v42.hpp"
+#line 6428 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr315;
 		case 47: goto tr314;
@@ -6463,7 +6467,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6467 "inc/vcf/validator_detail_v42.hpp"
+#line 6471 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr338;
 		case 92: goto tr316;
@@ -6481,7 +6485,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6485 "inc/vcf/validator_detail_v42.hpp"
+#line 6489 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr315;
@@ -6514,7 +6518,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6518 "inc/vcf/validator_detail_v42.hpp"
+#line 6522 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr287;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6534,7 +6538,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6538 "inc/vcf/validator_detail_v42.hpp"
+#line 6542 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 78: goto tr352;
@@ -6552,7 +6556,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6556 "inc/vcf/validator_detail_v42.hpp"
+#line 6560 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 70: goto tr353;
@@ -6570,7 +6574,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6574 "inc/vcf/validator_detail_v42.hpp"
+#line 6578 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 79: goto st242;
@@ -6597,7 +6601,7 @@ st243:
 	if ( ++p == pe )
 		goto _test_eof243;
 case 243:
-#line 6601 "inc/vcf/validator_detail_v42.hpp"
+#line 6605 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st244;
 	goto tr351;
@@ -6654,7 +6658,7 @@ st248:
 	if ( ++p == pe )
 		goto _test_eof248;
 case 248:
-#line 6658 "inc/vcf/validator_detail_v42.hpp"
+#line 6662 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st248;
 	if ( (*p) < 48 ) {
@@ -6693,7 +6697,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6697 "inc/vcf/validator_detail_v42.hpp"
+#line 6701 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr365;
 		case 95: goto tr364;
@@ -6720,7 +6724,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6724 "inc/vcf/validator_detail_v42.hpp"
+#line 6728 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st251;
 	goto tr351;
@@ -6797,7 +6801,7 @@ st258:
 	if ( ++p == pe )
 		goto _test_eof258;
 case 258:
-#line 6801 "inc/vcf/validator_detail_v42.hpp"
+#line 6805 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr376;
 	goto tr373;
@@ -6811,7 +6815,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 6815 "inc/vcf/validator_detail_v42.hpp"
+#line 6819 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st260;
 	goto tr351;
@@ -6877,7 +6881,7 @@ st265:
 	if ( ++p == pe )
 		goto _test_eof265;
 case 265:
-#line 6881 "inc/vcf/validator_detail_v42.hpp"
+#line 6885 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr384;
 	if ( (*p) > 90 ) {
@@ -6896,7 +6900,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 6900 "inc/vcf/validator_detail_v42.hpp"
+#line 6904 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st267;
 	goto tr351;
@@ -6994,7 +6998,7 @@ st279:
 	if ( ++p == pe )
 		goto _test_eof279;
 case 279:
-#line 6998 "inc/vcf/validator_detail_v42.hpp"
+#line 7002 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr401;
 		case 92: goto tr402;
@@ -7022,7 +7026,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7026 "inc/vcf/validator_detail_v42.hpp"
+#line 7030 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 92: goto tr405;
@@ -7050,7 +7054,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7054 "inc/vcf/validator_detail_v42.hpp"
+#line 7058 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st282;
 		case 62: goto st296;
@@ -7084,7 +7088,7 @@ st283:
 	if ( ++p == pe )
 		goto _test_eof283;
 case 283:
-#line 7088 "inc/vcf/validator_detail_v42.hpp"
+#line 7092 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st283;
 	if ( (*p) < 48 ) {
@@ -7119,7 +7123,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7123 "inc/vcf/validator_detail_v42.hpp"
+#line 7127 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr412;
 		case 95: goto tr411;
@@ -7146,7 +7150,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7150 "inc/vcf/validator_detail_v42.hpp"
+#line 7154 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st286;
 	goto tr351;
@@ -7181,7 +7185,7 @@ st287:
 	if ( ++p == pe )
 		goto _test_eof287;
 case 287:
-#line 7185 "inc/vcf/validator_detail_v42.hpp"
+#line 7189 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 92: goto tr417;
@@ -7209,7 +7213,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7213 "inc/vcf/validator_detail_v42.hpp"
+#line 7217 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr418;
 		case 92: goto tr417;
@@ -7231,7 +7235,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7235 "inc/vcf/validator_detail_v42.hpp"
+#line 7239 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 44: goto tr419;
@@ -7261,7 +7265,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7265 "inc/vcf/validator_detail_v42.hpp"
+#line 7269 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 47: goto tr416;
@@ -7312,7 +7316,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7316 "inc/vcf/validator_detail_v42.hpp"
+#line 7320 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 47: goto tr416;
@@ -7363,7 +7367,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7367 "inc/vcf/validator_detail_v42.hpp"
+#line 7371 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 47: goto tr416;
@@ -7406,7 +7410,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7410 "inc/vcf/validator_detail_v42.hpp"
+#line 7414 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr427;
 		case 92: goto tr417;
@@ -7424,7 +7428,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7428 "inc/vcf/validator_detail_v42.hpp"
+#line 7432 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr401;
 		case 44: goto tr428;
@@ -7454,7 +7458,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7458 "inc/vcf/validator_detail_v42.hpp"
+#line 7462 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr404;
@@ -7490,7 +7494,7 @@ st297:
 	if ( ++p == pe )
 		goto _test_eof297;
 case 297:
-#line 7494 "inc/vcf/validator_detail_v42.hpp"
+#line 7498 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr430;
 		case 92: goto tr405;
@@ -7512,7 +7516,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7516 "inc/vcf/validator_detail_v42.hpp"
+#line 7520 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 44: goto tr431;
@@ -7532,7 +7536,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7536 "inc/vcf/validator_detail_v42.hpp"
+#line 7540 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 47: goto tr403;
@@ -7583,7 +7587,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7587 "inc/vcf/validator_detail_v42.hpp"
+#line 7591 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 47: goto tr403;
@@ -7634,7 +7638,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7638 "inc/vcf/validator_detail_v42.hpp"
+#line 7642 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 47: goto tr403;
@@ -7677,7 +7681,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7681 "inc/vcf/validator_detail_v42.hpp"
+#line 7685 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr427;
 		case 92: goto tr405;
@@ -7695,7 +7699,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7699 "inc/vcf/validator_detail_v42.hpp"
+#line 7703 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr404;
@@ -7728,7 +7732,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7732 "inc/vcf/validator_detail_v42.hpp"
+#line 7736 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr376;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -7748,7 +7752,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 7752 "inc/vcf/validator_detail_v42.hpp"
+#line 7756 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto tr441;
@@ -7766,7 +7770,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 7770 "inc/vcf/validator_detail_v42.hpp"
+#line 7774 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 68: goto tr442;
@@ -7784,7 +7788,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 7788 "inc/vcf/validator_detail_v42.hpp"
+#line 7792 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 73: goto tr443;
@@ -7802,7 +7806,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 7806 "inc/vcf/validator_detail_v42.hpp"
+#line 7810 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 71: goto tr444;
@@ -7820,7 +7824,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 7824 "inc/vcf/validator_detail_v42.hpp"
+#line 7828 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 82: goto tr445;
@@ -7838,7 +7842,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 7842 "inc/vcf/validator_detail_v42.hpp"
+#line 7846 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto tr446;
@@ -7856,7 +7860,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 7860 "inc/vcf/validator_detail_v42.hpp"
+#line 7864 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto st312;
@@ -7883,7 +7887,7 @@ st313:
 	if ( ++p == pe )
 		goto _test_eof313;
 case 313:
-#line 7887 "inc/vcf/validator_detail_v42.hpp"
+#line 7891 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st314;
 	goto tr440;
@@ -7897,7 +7901,7 @@ st314:
 	if ( ++p == pe )
 		goto _test_eof314;
 case 314:
-#line 7901 "inc/vcf/validator_detail_v42.hpp"
+#line 7905 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr451;
 	if ( (*p) < 48 ) {
@@ -7922,7 +7926,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 7926 "inc/vcf/validator_detail_v42.hpp"
+#line 7930 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st315;
 	if ( (*p) < 48 ) {
@@ -7957,7 +7961,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 7961 "inc/vcf/validator_detail_v42.hpp"
+#line 7965 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr455;
 		case 95: goto tr454;
@@ -7984,7 +7988,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 7988 "inc/vcf/validator_detail_v42.hpp"
+#line 7992 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr456;
 	if ( (*p) < 48 ) {
@@ -8009,7 +8013,7 @@ st318:
 	if ( ++p == pe )
 		goto _test_eof318;
 case 318:
-#line 8013 "inc/vcf/validator_detail_v42.hpp"
+#line 8017 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st318;
 	if ( (*p) < 48 ) {
@@ -8044,7 +8048,7 @@ st319:
 	if ( ++p == pe )
 		goto _test_eof319;
 case 319:
-#line 8048 "inc/vcf/validator_detail_v42.hpp"
+#line 8052 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr460;
 		case 62: goto tr461;
@@ -8072,7 +8076,7 @@ st320:
 	if ( ++p == pe )
 		goto _test_eof320;
 case 320:
-#line 8076 "inc/vcf/validator_detail_v42.hpp"
+#line 8080 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto tr52;
 	goto tr440;
@@ -8090,7 +8094,7 @@ st321:
 	if ( ++p == pe )
 		goto _test_eof321;
 case 321:
-#line 8094 "inc/vcf/validator_detail_v42.hpp"
+#line 8098 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 65: goto tr463;
@@ -8108,7 +8112,7 @@ st322:
 	if ( ++p == pe )
 		goto _test_eof322;
 case 322:
-#line 8112 "inc/vcf/validator_detail_v42.hpp"
+#line 8116 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 77: goto tr464;
@@ -8126,7 +8130,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 8130 "inc/vcf/validator_detail_v42.hpp"
+#line 8134 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 80: goto tr465;
@@ -8144,7 +8148,7 @@ st324:
 	if ( ++p == pe )
 		goto _test_eof324;
 case 324:
-#line 8148 "inc/vcf/validator_detail_v42.hpp"
+#line 8152 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 76: goto tr466;
@@ -8162,7 +8166,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8166 "inc/vcf/validator_detail_v42.hpp"
+#line 8170 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 69: goto st326;
@@ -8189,7 +8193,7 @@ st327:
 	if ( ++p == pe )
 		goto _test_eof327;
 case 327:
-#line 8193 "inc/vcf/validator_detail_v42.hpp"
+#line 8197 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st328;
 	goto tr462;
@@ -8246,7 +8250,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 8250 "inc/vcf/validator_detail_v42.hpp"
+#line 8254 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st332;
 	if ( (*p) < 48 ) {
@@ -8285,7 +8289,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 8289 "inc/vcf/validator_detail_v42.hpp"
+#line 8293 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr479;
 		case 95: goto tr477;
@@ -8312,7 +8316,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 8316 "inc/vcf/validator_detail_v42.hpp"
+#line 8320 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 71 )
 		goto st335;
 	goto tr480;
@@ -8405,7 +8409,7 @@ st343:
 	if ( ++p == pe )
 		goto _test_eof343;
 case 343:
-#line 8409 "inc/vcf/validator_detail_v42.hpp"
+#line 8413 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr492;
 	if ( (*p) < 35 ) {
@@ -8427,7 +8431,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 8431 "inc/vcf/validator_detail_v42.hpp"
+#line 8435 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 77 )
 		goto st345;
 	goto tr493;
@@ -8520,7 +8524,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 8524 "inc/vcf/validator_detail_v42.hpp"
+#line 8528 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr505;
 	if ( (*p) < 35 ) {
@@ -8542,7 +8546,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8546 "inc/vcf/validator_detail_v42.hpp"
+#line 8550 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st355;
 	goto tr506;
@@ -8640,7 +8644,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 8644 "inc/vcf/validator_detail_v42.hpp"
+#line 8648 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr521;
 		case 92: goto tr522;
@@ -8668,7 +8672,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 8672 "inc/vcf/validator_detail_v42.hpp"
+#line 8676 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr524;
 		case 92: goto tr525;
@@ -8696,7 +8700,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 8700 "inc/vcf/validator_detail_v42.hpp"
+#line 8704 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st370;
 	goto tr506;
@@ -8727,7 +8731,7 @@ st371:
 	if ( ++p == pe )
 		goto _test_eof371;
 case 371:
-#line 8731 "inc/vcf/validator_detail_v42.hpp"
+#line 8735 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr527;
 		case 92: goto tr525;
@@ -8749,7 +8753,7 @@ st372:
 	if ( ++p == pe )
 		goto _test_eof372;
 case 372:
-#line 8753 "inc/vcf/validator_detail_v42.hpp"
+#line 8757 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr524;
 		case 62: goto tr528;
@@ -8768,7 +8772,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 8772 "inc/vcf/validator_detail_v42.hpp"
+#line 8776 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr524;
@@ -8791,7 +8795,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 8795 "inc/vcf/validator_detail_v42.hpp"
+#line 8799 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 115: goto tr530;
@@ -8809,7 +8813,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8813 "inc/vcf/validator_detail_v42.hpp"
+#line 8817 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 115: goto tr531;
@@ -8827,7 +8831,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 8831 "inc/vcf/validator_detail_v42.hpp"
+#line 8835 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr532;
@@ -8845,7 +8849,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 8849 "inc/vcf/validator_detail_v42.hpp"
+#line 8853 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 109: goto tr533;
@@ -8863,7 +8867,7 @@ st378:
 	if ( ++p == pe )
 		goto _test_eof378;
 case 378:
-#line 8867 "inc/vcf/validator_detail_v42.hpp"
+#line 8871 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 98: goto tr534;
@@ -8881,7 +8885,7 @@ st379:
 	if ( ++p == pe )
 		goto _test_eof379;
 case 379:
-#line 8885 "inc/vcf/validator_detail_v42.hpp"
+#line 8889 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 108: goto tr535;
@@ -8899,7 +8903,7 @@ st380:
 	if ( ++p == pe )
 		goto _test_eof380;
 case 380:
-#line 8903 "inc/vcf/validator_detail_v42.hpp"
+#line 8907 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 121: goto st381;
@@ -8926,7 +8930,7 @@ st382:
 	if ( ++p == pe )
 		goto _test_eof382;
 case 382:
-#line 8930 "inc/vcf/validator_detail_v42.hpp"
+#line 8934 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr539;
@@ -8943,7 +8947,7 @@ st383:
 	if ( ++p == pe )
 		goto _test_eof383;
 case 383:
-#line 8947 "inc/vcf/validator_detail_v42.hpp"
+#line 8951 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr538;
 		case 35: goto tr538;
@@ -8998,7 +9002,7 @@ st388:
 	if ( ++p == pe )
 		goto _test_eof388;
 case 388:
-#line 9002 "inc/vcf/validator_detail_v42.hpp"
+#line 9006 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto tr44;
 	goto tr544;
@@ -9016,7 +9020,7 @@ st389:
 	if ( ++p == pe )
 		goto _test_eof389;
 case 389:
-#line 9020 "inc/vcf/validator_detail_v42.hpp"
+#line 9024 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 111: goto tr546;
@@ -9034,7 +9038,7 @@ st390:
 	if ( ++p == pe )
 		goto _test_eof390;
 case 390:
-#line 9038 "inc/vcf/validator_detail_v42.hpp"
+#line 9042 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 110: goto tr547;
@@ -9052,7 +9056,7 @@ st391:
 	if ( ++p == pe )
 		goto _test_eof391;
 case 391:
-#line 9056 "inc/vcf/validator_detail_v42.hpp"
+#line 9060 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 116: goto tr548;
@@ -9070,7 +9074,7 @@ st392:
 	if ( ++p == pe )
 		goto _test_eof392;
 case 392:
-#line 9074 "inc/vcf/validator_detail_v42.hpp"
+#line 9078 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 105: goto tr549;
@@ -9088,7 +9092,7 @@ st393:
 	if ( ++p == pe )
 		goto _test_eof393;
 case 393:
-#line 9092 "inc/vcf/validator_detail_v42.hpp"
+#line 9096 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 103: goto st394;
@@ -9115,7 +9119,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9119 "inc/vcf/validator_detail_v42.hpp"
+#line 9123 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st396;
 	goto tr545;
@@ -9171,7 +9175,7 @@ st400:
 	if ( ++p == pe )
 		goto _test_eof400;
 case 400:
-#line 9175 "inc/vcf/validator_detail_v42.hpp"
+#line 9179 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr559;
 		case 59: goto tr558;
@@ -9208,7 +9212,7 @@ st401:
 	if ( ++p == pe )
 		goto _test_eof401;
 case 401:
-#line 9212 "inc/vcf/validator_detail_v42.hpp"
+#line 9216 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr558;
 		case 61: goto tr558;
@@ -9247,7 +9251,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 9251 "inc/vcf/validator_detail_v42.hpp"
+#line 9255 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr559;
 		case 59: goto tr560;
@@ -9269,7 +9273,7 @@ st403:
 	if ( ++p == pe )
 		goto _test_eof403;
 case 403:
-#line 9273 "inc/vcf/validator_detail_v42.hpp"
+#line 9277 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr562;
 	if ( (*p) < 48 ) {
@@ -9294,7 +9298,7 @@ st404:
 	if ( ++p == pe )
 		goto _test_eof404;
 case 404:
-#line 9298 "inc/vcf/validator_detail_v42.hpp"
+#line 9302 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st404;
 	if ( (*p) < 48 ) {
@@ -9329,7 +9333,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 9333 "inc/vcf/validator_detail_v42.hpp"
+#line 9337 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr566;
 		case 95: goto tr565;
@@ -9356,7 +9360,7 @@ st406:
 	if ( ++p == pe )
 		goto _test_eof406;
 case 406:
-#line 9360 "inc/vcf/validator_detail_v42.hpp"
+#line 9364 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st409;
 	if ( (*p) < 45 ) {
@@ -9388,7 +9392,7 @@ st407:
 	if ( ++p == pe )
 		goto _test_eof407;
 case 407:
-#line 9392 "inc/vcf/validator_detail_v42.hpp"
+#line 9396 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr559;
 		case 62: goto tr561;
@@ -9409,7 +9413,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9413 "inc/vcf/validator_detail_v42.hpp"
+#line 9417 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto tr52;
 	goto tr545;
@@ -9444,7 +9448,7 @@ st410:
 	if ( ++p == pe )
 		goto _test_eof410;
 case 410:
-#line 9448 "inc/vcf/validator_detail_v42.hpp"
+#line 9452 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr574;
 		case 92: goto tr575;
@@ -9472,7 +9476,7 @@ st411:
 	if ( ++p == pe )
 		goto _test_eof411;
 case 411:
-#line 9476 "inc/vcf/validator_detail_v42.hpp"
+#line 9480 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st403;
 		case 62: goto st408;
@@ -9498,7 +9502,7 @@ st412:
 	if ( ++p == pe )
 		goto _test_eof412;
 case 412:
-#line 9502 "inc/vcf/validator_detail_v42.hpp"
+#line 9506 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr578;
 		case 92: goto tr575;
@@ -9520,7 +9524,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9524 "inc/vcf/validator_detail_v42.hpp"
+#line 9528 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr574;
 		case 44: goto tr579;
@@ -9560,7 +9564,7 @@ st414:
 	if ( ++p == pe )
 		goto _test_eof414;
 case 414:
-#line 9564 "inc/vcf/validator_detail_v42.hpp"
+#line 9568 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr574;
 		case 47: goto tr573;
@@ -9611,7 +9615,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9615 "inc/vcf/validator_detail_v42.hpp"
+#line 9619 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr574;
 		case 47: goto tr573;
@@ -9662,7 +9666,7 @@ st416:
 	if ( ++p == pe )
 		goto _test_eof416;
 case 416:
-#line 9666 "inc/vcf/validator_detail_v42.hpp"
+#line 9670 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr574;
 		case 47: goto tr573;
@@ -9705,7 +9709,7 @@ st417:
 	if ( ++p == pe )
 		goto _test_eof417;
 case 417:
-#line 9709 "inc/vcf/validator_detail_v42.hpp"
+#line 9713 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr587;
 		case 44: goto tr573;
@@ -9735,7 +9739,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 9739 "inc/vcf/validator_detail_v42.hpp"
+#line 9743 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr574;
 		case 44: goto tr590;
@@ -9775,7 +9779,7 @@ st419:
 	if ( ++p == pe )
 		goto _test_eof419;
 case 419:
-#line 9779 "inc/vcf/validator_detail_v42.hpp"
+#line 9783 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 34: goto tr574;
@@ -9804,7 +9808,7 @@ st420:
 	if ( ++p == pe )
 		goto _test_eof420;
 case 420:
-#line 9808 "inc/vcf/validator_detail_v42.hpp"
+#line 9812 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr578;
 		case 44: goto tr590;
@@ -9824,7 +9828,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9828 "inc/vcf/validator_detail_v42.hpp"
+#line 9832 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr571;
 		case 44: goto tr593;
@@ -9848,7 +9852,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9852 "inc/vcf/validator_detail_v42.hpp"
+#line 9856 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr596;
@@ -9866,7 +9870,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9870 "inc/vcf/validator_detail_v42.hpp"
+#line 9874 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 100: goto tr597;
@@ -9884,7 +9888,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9888 "inc/vcf/validator_detail_v42.hpp"
+#line 9892 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 105: goto tr598;
@@ -9902,7 +9906,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9906 "inc/vcf/validator_detail_v42.hpp"
+#line 9910 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 103: goto tr599;
@@ -9920,7 +9924,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9924 "inc/vcf/validator_detail_v42.hpp"
+#line 9928 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 114: goto tr600;
@@ -9938,7 +9942,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9942 "inc/vcf/validator_detail_v42.hpp"
+#line 9946 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr601;
@@ -9956,7 +9960,7 @@ st428:
 	if ( ++p == pe )
 		goto _test_eof428;
 case 428:
-#line 9960 "inc/vcf/validator_detail_v42.hpp"
+#line 9964 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 101: goto tr602;
@@ -9974,7 +9978,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 9978 "inc/vcf/validator_detail_v42.hpp"
+#line 9982 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 68: goto tr603;
@@ -9992,7 +9996,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 9996 "inc/vcf/validator_detail_v42.hpp"
+#line 10000 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr40;
 		case 66: goto st431;
@@ -10019,7 +10023,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 10023 "inc/vcf/validator_detail_v42.hpp"
+#line 10027 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st433;
 	goto tr595;
@@ -10043,7 +10047,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10047 "inc/vcf/validator_detail_v42.hpp"
+#line 10051 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr607;
 		case 35: goto tr607;
@@ -10098,7 +10102,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10102 "inc/vcf/validator_detail_v42.hpp"
+#line 10106 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr607;
 		case 62: goto tr614;
@@ -10118,7 +10122,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10122 "inc/vcf/validator_detail_v42.hpp"
+#line 10126 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr52;
 		case 62: goto tr614;
@@ -10444,7 +10448,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10448 "inc/vcf/validator_detail_v42.hpp"
+#line 10452 "inc/vcf/validator_detail_v42.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr662;
 	goto tr654;
@@ -10468,7 +10472,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 10472 "inc/vcf/validator_detail_v42.hpp"
+#line 10476 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr663;
 		case 10: goto tr664;
@@ -10516,7 +10520,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 10520 "inc/vcf/validator_detail_v42.hpp"
+#line 10524 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr967;
 	if ( (*p) < 65 ) {
@@ -10543,8 +10547,8 @@ tr966:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 #line 31 "src/vcf/vcf_v42.ragel"
@@ -10560,7 +10564,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 10564 "inc/vcf/validator_detail_v42.hpp"
+#line 10568 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr667;
 		case 59: goto tr668;
@@ -10615,7 +10619,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 10619 "inc/vcf/validator_detail_v42.hpp"
+#line 10623 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr671;
 		case 45: goto tr671;
@@ -10633,7 +10637,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 10637 "inc/vcf/validator_detail_v42.hpp"
+#line 10641 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr673;
 	goto tr670;
@@ -10657,7 +10661,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10661 "inc/vcf/validator_detail_v42.hpp"
+#line 10665 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr674;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10687,7 +10691,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 10691 "inc/vcf/validator_detail_v42.hpp"
+#line 10695 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr676;
@@ -10714,7 +10718,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 10718 "inc/vcf/validator_detail_v42.hpp"
+#line 10722 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr677;
 		case 59: goto tr679;
@@ -10740,7 +10744,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 10744 "inc/vcf/validator_detail_v42.hpp"
+#line 10748 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr681;
 		case 67: goto tr681;
@@ -10774,7 +10778,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 10778 "inc/vcf/validator_detail_v42.hpp"
+#line 10782 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr682;
 		case 65: goto tr683;
@@ -10807,7 +10811,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10811 "inc/vcf/validator_detail_v42.hpp"
+#line 10815 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr685;
 		case 46: goto tr686;
@@ -10846,7 +10850,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10850 "inc/vcf/validator_detail_v42.hpp"
+#line 10854 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr691;
 		case 44: goto tr692;
@@ -10870,7 +10874,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10874 "inc/vcf/validator_detail_v42.hpp"
+#line 10878 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr694;
 		case 45: goto tr694;
@@ -10895,7 +10899,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10899 "inc/vcf/validator_detail_v42.hpp"
+#line 10903 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr699;
 		case 73: goto tr701;
@@ -10913,7 +10917,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10917 "inc/vcf/validator_detail_v42.hpp"
+#line 10921 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr702;
 	goto tr693;
@@ -10927,7 +10931,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10931 "inc/vcf/validator_detail_v42.hpp"
+#line 10935 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr703;
 		case 69: goto tr704;
@@ -10954,7 +10958,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 10958 "inc/vcf/validator_detail_v42.hpp"
+#line 10962 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr707;
 		case 58: goto tr706;
@@ -10990,7 +10994,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10994 "inc/vcf/validator_detail_v42.hpp"
+#line 10998 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto st502;
 	if ( (*p) < 65 ) {
@@ -11034,7 +11038,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11038 "inc/vcf/validator_detail_v42.hpp"
+#line 11042 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr711;
 		case 59: goto tr712;
@@ -11060,7 +11064,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11064 "inc/vcf/validator_detail_v42.hpp"
+#line 11068 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr715;
 		case 49: goto tr717;
@@ -11118,7 +11122,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11122 "inc/vcf/validator_detail_v42.hpp"
+#line 11126 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr728;
 		case 60: goto tr728;
@@ -11164,7 +11168,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11168 "inc/vcf/validator_detail_v42.hpp"
+#line 11172 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11198,7 +11202,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11202 "inc/vcf/validator_detail_v42.hpp"
+#line 11206 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr735;
 	if ( (*p) > 90 ) {
@@ -11227,7 +11231,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 11231 "inc/vcf/validator_detail_v42.hpp"
+#line 11235 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr736;
 		case 46: goto tr737;
@@ -11261,7 +11265,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11265 "inc/vcf/validator_detail_v42.hpp"
+#line 11269 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr740;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11287,7 +11291,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 11291 "inc/vcf/validator_detail_v42.hpp"
+#line 11295 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr736;
 		case 10: goto tr731;
@@ -11313,13 +11317,13 @@ tr731:
             try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-            } catch (MetaSectionError &ex) {
-                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
-            } catch (BodySectionError &ex) {
-                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            } catch (MetaSectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
+            } catch (BodySectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError ex) {
-            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
+        } catch (BodySectionError &error) {
+            ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -11337,7 +11341,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 11341 "inc/vcf/validator_detail_v42.hpp"
+#line 11345 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st511;
 	if ( (*p) < 65 ) {
@@ -11354,8 +11358,8 @@ tr967:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 	goto st511;
@@ -11363,7 +11367,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11367 "inc/vcf/validator_detail_v42.hpp"
+#line 11371 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr744;
@@ -11387,7 +11391,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11391 "inc/vcf/validator_detail_v42.hpp"
+#line 11395 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr745;
 		case 62: goto tr747;
@@ -11423,7 +11427,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11427 "inc/vcf/validator_detail_v42.hpp"
+#line 11431 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr745;
 		case 61: goto tr745;
@@ -11459,7 +11463,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11463 "inc/vcf/validator_detail_v42.hpp"
+#line 11467 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr746;
 		case 62: goto tr747;
@@ -11480,7 +11484,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11484 "inc/vcf/validator_detail_v42.hpp"
+#line 11488 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr748;
 	goto tr666;
@@ -11494,7 +11498,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11498 "inc/vcf/validator_detail_v42.hpp"
+#line 11502 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr749;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11520,7 +11524,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11524 "inc/vcf/validator_detail_v42.hpp"
+#line 11528 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr736;
 		case 10: goto tr731;
@@ -11541,7 +11545,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11545 "inc/vcf/validator_detail_v42.hpp"
+#line 11549 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr752;
@@ -11558,7 +11562,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11562 "inc/vcf/validator_detail_v42.hpp"
+#line 11566 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr736;
 		case 10: goto tr731;
@@ -11577,7 +11581,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11581 "inc/vcf/validator_detail_v42.hpp"
+#line 11585 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 49: goto tr717;
 		case 58: goto tr714;
@@ -11628,7 +11632,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11632 "inc/vcf/validator_detail_v42.hpp"
+#line 11636 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11649,7 +11653,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11653 "inc/vcf/validator_detail_v42.hpp"
+#line 11657 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11670,7 +11674,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11674 "inc/vcf/validator_detail_v42.hpp"
+#line 11678 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11691,7 +11695,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11695 "inc/vcf/validator_detail_v42.hpp"
+#line 11699 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11712,7 +11716,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11716 "inc/vcf/validator_detail_v42.hpp"
+#line 11720 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr758;
@@ -11729,7 +11733,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11733 "inc/vcf/validator_detail_v42.hpp"
+#line 11737 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11748,7 +11752,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11752 "inc/vcf/validator_detail_v42.hpp"
+#line 11756 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11768,7 +11772,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11772 "inc/vcf/validator_detail_v42.hpp"
+#line 11776 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr762;
 	goto tr761;
@@ -11782,7 +11786,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 11786 "inc/vcf/validator_detail_v42.hpp"
+#line 11790 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11803,7 +11807,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 11807 "inc/vcf/validator_detail_v42.hpp"
+#line 11811 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11827,7 +11831,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 11831 "inc/vcf/validator_detail_v42.hpp"
+#line 11835 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr767;
 	if ( (*p) > 58 ) {
@@ -11846,7 +11850,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 11850 "inc/vcf/validator_detail_v42.hpp"
+#line 11854 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr770;
 		case 67: goto tr770;
@@ -11872,7 +11876,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 11876 "inc/vcf/validator_detail_v42.hpp"
+#line 11880 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11889,7 +11893,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 11893 "inc/vcf/validator_detail_v42.hpp"
+#line 11897 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11916,7 +11920,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 11920 "inc/vcf/validator_detail_v42.hpp"
+#line 11924 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr771;
 	if ( (*p) > 58 ) {
@@ -11935,7 +11939,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 11939 "inc/vcf/validator_detail_v42.hpp"
+#line 11943 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr773;
 		case 45: goto tr773;
@@ -11953,7 +11957,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 11957 "inc/vcf/validator_detail_v42.hpp"
+#line 11961 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr774;
 	goto tr772;
@@ -11967,7 +11971,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 11971 "inc/vcf/validator_detail_v42.hpp"
+#line 11975 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11987,7 +11991,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 11991 "inc/vcf/validator_detail_v42.hpp"
+#line 11995 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr775;
 	if ( (*p) > 58 ) {
@@ -12006,7 +12010,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12010 "inc/vcf/validator_detail_v42.hpp"
+#line 12014 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr777;
 		case 45: goto tr777;
@@ -12027,7 +12031,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12031 "inc/vcf/validator_detail_v42.hpp"
+#line 12035 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr778;
 		case 73: goto tr780;
@@ -12045,7 +12049,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12049 "inc/vcf/validator_detail_v42.hpp"
+#line 12053 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr782;
 	goto tr776;
@@ -12059,7 +12063,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12063 "inc/vcf/validator_detail_v42.hpp"
+#line 12067 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12081,7 +12085,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12085 "inc/vcf/validator_detail_v42.hpp"
+#line 12089 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr784;
 		case 45: goto tr784;
@@ -12099,7 +12103,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12103 "inc/vcf/validator_detail_v42.hpp"
+#line 12107 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr785;
 	goto tr776;
@@ -12113,7 +12117,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12117 "inc/vcf/validator_detail_v42.hpp"
+#line 12121 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12133,7 +12137,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12137 "inc/vcf/validator_detail_v42.hpp"
+#line 12141 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12156,7 +12160,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12160 "inc/vcf/validator_detail_v42.hpp"
+#line 12164 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr786;
 	goto tr776;
@@ -12170,7 +12174,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12174 "inc/vcf/validator_detail_v42.hpp"
+#line 12178 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr787;
 	goto tr776;
@@ -12184,7 +12188,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12188 "inc/vcf/validator_detail_v42.hpp"
+#line 12192 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12202,7 +12206,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12206 "inc/vcf/validator_detail_v42.hpp"
+#line 12210 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr788;
 	goto tr776;
@@ -12216,7 +12220,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12220 "inc/vcf/validator_detail_v42.hpp"
+#line 12224 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr787;
 	goto tr776;
@@ -12230,7 +12234,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12234 "inc/vcf/validator_detail_v42.hpp"
+#line 12238 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr789;
 	if ( (*p) > 58 ) {
@@ -12249,7 +12253,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12253 "inc/vcf/validator_detail_v42.hpp"
+#line 12257 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr791;
 		case 45: goto tr791;
@@ -12267,7 +12271,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12271 "inc/vcf/validator_detail_v42.hpp"
+#line 12275 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr792;
 	goto tr790;
@@ -12281,7 +12285,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12285 "inc/vcf/validator_detail_v42.hpp"
+#line 12289 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12304,7 +12308,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12308 "inc/vcf/validator_detail_v42.hpp"
+#line 12312 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12325,7 +12329,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12329 "inc/vcf/validator_detail_v42.hpp"
+#line 12333 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr794;
 	if ( (*p) > 58 ) {
@@ -12344,7 +12348,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12348 "inc/vcf/validator_detail_v42.hpp"
+#line 12352 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr796;
 		case 45: goto tr796;
@@ -12365,7 +12369,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12369 "inc/vcf/validator_detail_v42.hpp"
+#line 12373 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr797;
 		case 73: goto tr799;
@@ -12383,7 +12387,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 12387 "inc/vcf/validator_detail_v42.hpp"
+#line 12391 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr801;
 	goto tr795;
@@ -12397,7 +12401,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 12401 "inc/vcf/validator_detail_v42.hpp"
+#line 12405 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12418,7 +12422,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12422 "inc/vcf/validator_detail_v42.hpp"
+#line 12426 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr803;
 		case 45: goto tr803;
@@ -12436,7 +12440,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 12440 "inc/vcf/validator_detail_v42.hpp"
+#line 12444 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr804;
 	goto tr795;
@@ -12450,7 +12454,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 12454 "inc/vcf/validator_detail_v42.hpp"
+#line 12458 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12469,7 +12473,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 12473 "inc/vcf/validator_detail_v42.hpp"
+#line 12477 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12491,7 +12495,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 12495 "inc/vcf/validator_detail_v42.hpp"
+#line 12499 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr805;
 	goto tr795;
@@ -12505,7 +12509,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12509 "inc/vcf/validator_detail_v42.hpp"
+#line 12513 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr806;
 	goto tr795;
@@ -12519,7 +12523,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 12523 "inc/vcf/validator_detail_v42.hpp"
+#line 12527 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12536,7 +12540,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 12540 "inc/vcf/validator_detail_v42.hpp"
+#line 12544 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr807;
 	goto tr795;
@@ -12550,7 +12554,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 12554 "inc/vcf/validator_detail_v42.hpp"
+#line 12558 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr806;
 	goto tr795;
@@ -12568,7 +12572,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 12572 "inc/vcf/validator_detail_v42.hpp"
+#line 12576 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12589,7 +12593,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 12593 "inc/vcf/validator_detail_v42.hpp"
+#line 12597 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12610,7 +12614,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 12614 "inc/vcf/validator_detail_v42.hpp"
+#line 12618 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12631,7 +12635,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12635 "inc/vcf/validator_detail_v42.hpp"
+#line 12639 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12652,7 +12656,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12656 "inc/vcf/validator_detail_v42.hpp"
+#line 12660 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr812;
 	if ( (*p) > 58 ) {
@@ -12671,7 +12675,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12675 "inc/vcf/validator_detail_v42.hpp"
+#line 12679 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr814;
@@ -12691,7 +12695,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12695 "inc/vcf/validator_detail_v42.hpp"
+#line 12699 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12720,7 +12724,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12724 "inc/vcf/validator_detail_v42.hpp"
+#line 12728 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12742,7 +12746,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12746 "inc/vcf/validator_detail_v42.hpp"
+#line 12750 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12762,7 +12766,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12766 "inc/vcf/validator_detail_v42.hpp"
+#line 12770 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr820;
 	goto tr819;
@@ -12776,7 +12780,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12780 "inc/vcf/validator_detail_v42.hpp"
+#line 12784 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12793,7 +12797,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12797 "inc/vcf/validator_detail_v42.hpp"
+#line 12801 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr821;
 	if ( (*p) > 58 ) {
@@ -12812,7 +12816,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 12816 "inc/vcf/validator_detail_v42.hpp"
+#line 12820 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr823;
 		case 45: goto tr823;
@@ -12830,7 +12834,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 12834 "inc/vcf/validator_detail_v42.hpp"
+#line 12838 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr824;
 	goto tr822;
@@ -12844,7 +12848,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 12848 "inc/vcf/validator_detail_v42.hpp"
+#line 12852 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12867,7 +12871,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 12871 "inc/vcf/validator_detail_v42.hpp"
+#line 12875 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12888,7 +12892,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 12892 "inc/vcf/validator_detail_v42.hpp"
+#line 12896 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12909,7 +12913,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 12913 "inc/vcf/validator_detail_v42.hpp"
+#line 12917 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr827;
 	if ( (*p) > 58 ) {
@@ -12928,7 +12932,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 12932 "inc/vcf/validator_detail_v42.hpp"
+#line 12936 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr829;
 		case 45: goto tr829;
@@ -12946,7 +12950,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12950 "inc/vcf/validator_detail_v42.hpp"
+#line 12954 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr830;
 	goto tr828;
@@ -12960,7 +12964,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12964 "inc/vcf/validator_detail_v42.hpp"
+#line 12968 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12983,7 +12987,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12987 "inc/vcf/validator_detail_v42.hpp"
+#line 12991 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13005,7 +13009,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13009 "inc/vcf/validator_detail_v42.hpp"
+#line 13013 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13025,7 +13029,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13029 "inc/vcf/validator_detail_v42.hpp"
+#line 13033 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr836;
 	goto tr835;
@@ -13039,7 +13043,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13043 "inc/vcf/validator_detail_v42.hpp"
+#line 13047 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13056,7 +13060,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13060 "inc/vcf/validator_detail_v42.hpp"
+#line 13064 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13076,7 +13080,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13080 "inc/vcf/validator_detail_v42.hpp"
+#line 13084 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr840;
 	goto tr839;
@@ -13090,7 +13094,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13094 "inc/vcf/validator_detail_v42.hpp"
+#line 13098 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13111,7 +13115,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13115 "inc/vcf/validator_detail_v42.hpp"
+#line 13119 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13132,7 +13136,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13136 "inc/vcf/validator_detail_v42.hpp"
+#line 13140 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 48: goto tr842;
 		case 61: goto tr843;
@@ -13153,7 +13157,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13157 "inc/vcf/validator_detail_v42.hpp"
+#line 13161 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr844;
 	if ( (*p) > 58 ) {
@@ -13172,7 +13176,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13176 "inc/vcf/validator_detail_v42.hpp"
+#line 13180 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr846;
 		case 45: goto tr846;
@@ -13190,7 +13194,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13194 "inc/vcf/validator_detail_v42.hpp"
+#line 13198 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr847;
 	goto tr845;
@@ -13204,7 +13208,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13208 "inc/vcf/validator_detail_v42.hpp"
+#line 13212 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13223,7 +13227,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13227 "inc/vcf/validator_detail_v42.hpp"
+#line 13231 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr849;
 		case 45: goto tr849;
@@ -13244,7 +13248,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13248 "inc/vcf/validator_detail_v42.hpp"
+#line 13252 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr850;
 		case 73: goto tr852;
@@ -13262,7 +13266,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13266 "inc/vcf/validator_detail_v42.hpp"
+#line 13270 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr854;
 	goto tr848;
@@ -13276,7 +13280,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13280 "inc/vcf/validator_detail_v42.hpp"
+#line 13284 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13297,7 +13301,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13301 "inc/vcf/validator_detail_v42.hpp"
+#line 13305 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr856;
 		case 45: goto tr856;
@@ -13315,7 +13319,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13319 "inc/vcf/validator_detail_v42.hpp"
+#line 13323 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr857;
 	goto tr848;
@@ -13329,7 +13333,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13333 "inc/vcf/validator_detail_v42.hpp"
+#line 13337 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13348,7 +13352,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13352 "inc/vcf/validator_detail_v42.hpp"
+#line 13356 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13370,7 +13374,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13374 "inc/vcf/validator_detail_v42.hpp"
+#line 13378 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr858;
 	goto tr848;
@@ -13384,7 +13388,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13388 "inc/vcf/validator_detail_v42.hpp"
+#line 13392 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr859;
 	goto tr848;
@@ -13398,7 +13402,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13402 "inc/vcf/validator_detail_v42.hpp"
+#line 13406 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13415,7 +13419,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13419 "inc/vcf/validator_detail_v42.hpp"
+#line 13423 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr860;
 	goto tr848;
@@ -13429,7 +13433,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13433 "inc/vcf/validator_detail_v42.hpp"
+#line 13437 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr859;
 	goto tr848;
@@ -13447,7 +13451,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13451 "inc/vcf/validator_detail_v42.hpp"
+#line 13455 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13468,7 +13472,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13472 "inc/vcf/validator_detail_v42.hpp"
+#line 13476 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr862;
 	if ( (*p) > 58 ) {
@@ -13487,7 +13491,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13491 "inc/vcf/validator_detail_v42.hpp"
+#line 13495 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr864;
 		case 45: goto tr864;
@@ -13505,7 +13509,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13509 "inc/vcf/validator_detail_v42.hpp"
+#line 13513 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr865;
 	goto tr863;
@@ -13519,7 +13523,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13523 "inc/vcf/validator_detail_v42.hpp"
+#line 13527 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13542,7 +13546,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13546 "inc/vcf/validator_detail_v42.hpp"
+#line 13550 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13564,7 +13568,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13568 "inc/vcf/validator_detail_v42.hpp"
+#line 13572 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr868;
 	if ( (*p) > 58 ) {
@@ -13583,7 +13587,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13587 "inc/vcf/validator_detail_v42.hpp"
+#line 13591 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr870;
 		case 45: goto tr870;
@@ -13604,7 +13608,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13608 "inc/vcf/validator_detail_v42.hpp"
+#line 13612 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr871;
 		case 73: goto tr873;
@@ -13622,7 +13626,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 13626 "inc/vcf/validator_detail_v42.hpp"
+#line 13630 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr875;
 	goto tr869;
@@ -13636,7 +13640,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 13640 "inc/vcf/validator_detail_v42.hpp"
+#line 13644 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13657,7 +13661,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 13661 "inc/vcf/validator_detail_v42.hpp"
+#line 13665 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr877;
 		case 45: goto tr877;
@@ -13675,7 +13679,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 13679 "inc/vcf/validator_detail_v42.hpp"
+#line 13683 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr878;
 	goto tr869;
@@ -13689,7 +13693,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 13693 "inc/vcf/validator_detail_v42.hpp"
+#line 13697 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13708,7 +13712,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 13712 "inc/vcf/validator_detail_v42.hpp"
+#line 13716 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13730,7 +13734,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 13734 "inc/vcf/validator_detail_v42.hpp"
+#line 13738 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr879;
 	goto tr869;
@@ -13744,7 +13748,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 13748 "inc/vcf/validator_detail_v42.hpp"
+#line 13752 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr880;
 	goto tr869;
@@ -13758,7 +13762,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13762 "inc/vcf/validator_detail_v42.hpp"
+#line 13766 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13775,7 +13779,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 13779 "inc/vcf/validator_detail_v42.hpp"
+#line 13783 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr881;
 	goto tr869;
@@ -13789,7 +13793,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 13793 "inc/vcf/validator_detail_v42.hpp"
+#line 13797 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr880;
 	goto tr869;
@@ -13803,7 +13807,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 13807 "inc/vcf/validator_detail_v42.hpp"
+#line 13811 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13824,7 +13828,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 13828 "inc/vcf/validator_detail_v42.hpp"
+#line 13832 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13845,7 +13849,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 13849 "inc/vcf/validator_detail_v42.hpp"
+#line 13853 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13866,7 +13870,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 13870 "inc/vcf/validator_detail_v42.hpp"
+#line 13874 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13887,7 +13891,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 13891 "inc/vcf/validator_detail_v42.hpp"
+#line 13895 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13908,7 +13912,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 13912 "inc/vcf/validator_detail_v42.hpp"
+#line 13916 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13928,7 +13932,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 13932 "inc/vcf/validator_detail_v42.hpp"
+#line 13936 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr890;
 	goto tr889;
@@ -13942,7 +13946,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 13946 "inc/vcf/validator_detail_v42.hpp"
+#line 13950 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13963,7 +13967,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 13967 "inc/vcf/validator_detail_v42.hpp"
+#line 13971 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13984,7 +13988,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 13988 "inc/vcf/validator_detail_v42.hpp"
+#line 13992 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14005,7 +14009,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14009 "inc/vcf/validator_detail_v42.hpp"
+#line 14013 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14026,7 +14030,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14030 "inc/vcf/validator_detail_v42.hpp"
+#line 14034 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14047,7 +14051,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14051 "inc/vcf/validator_detail_v42.hpp"
+#line 14055 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14068,7 +14072,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14072 "inc/vcf/validator_detail_v42.hpp"
+#line 14076 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14089,7 +14093,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14093 "inc/vcf/validator_detail_v42.hpp"
+#line 14097 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14110,7 +14114,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14114 "inc/vcf/validator_detail_v42.hpp"
+#line 14118 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14131,7 +14135,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14135 "inc/vcf/validator_detail_v42.hpp"
+#line 14139 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14151,7 +14155,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14155 "inc/vcf/validator_detail_v42.hpp"
+#line 14159 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr902;
 	goto tr901;
@@ -14165,7 +14169,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14169 "inc/vcf/validator_detail_v42.hpp"
+#line 14173 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14186,7 +14190,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14190 "inc/vcf/validator_detail_v42.hpp"
+#line 14194 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14224,7 +14228,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14228 "inc/vcf/validator_detail_v42.hpp"
+#line 14232 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr706;
 	if ( (*p) < 65 ) {
@@ -14262,7 +14266,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14266 "inc/vcf/validator_detail_v42.hpp"
+#line 14270 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr711;
 		case 58: goto st502;
@@ -14298,7 +14302,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14302 "inc/vcf/validator_detail_v42.hpp"
+#line 14306 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr903;
 		case 45: goto tr903;
@@ -14316,7 +14320,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14320 "inc/vcf/validator_detail_v42.hpp"
+#line 14324 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr904;
 	goto tr693;
@@ -14330,7 +14334,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14334 "inc/vcf/validator_detail_v42.hpp"
+#line 14338 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr703;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14356,7 +14360,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14360 "inc/vcf/validator_detail_v42.hpp"
+#line 14364 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr703;
 		case 46: goto tr699;
@@ -14386,7 +14390,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14390 "inc/vcf/validator_detail_v42.hpp"
+#line 14394 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr905;
 	goto tr693;
@@ -14400,7 +14404,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14404 "inc/vcf/validator_detail_v42.hpp"
+#line 14408 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr906;
 	goto tr693;
@@ -14414,7 +14418,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14418 "inc/vcf/validator_detail_v42.hpp"
+#line 14422 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr703;
 	goto tr693;
@@ -14432,7 +14436,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14436 "inc/vcf/validator_detail_v42.hpp"
+#line 14440 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr703;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14452,7 +14456,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14456 "inc/vcf/validator_detail_v42.hpp"
+#line 14460 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr907;
 	goto tr693;
@@ -14466,7 +14470,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14470 "inc/vcf/validator_detail_v42.hpp"
+#line 14474 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr906;
 	goto tr693;
@@ -14480,7 +14484,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14484 "inc/vcf/validator_detail_v42.hpp"
+#line 14488 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr685;
 		case 46: goto tr908;
@@ -14519,7 +14523,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14523 "inc/vcf/validator_detail_v42.hpp"
+#line 14527 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr909;
 		case 67: goto tr909;
@@ -14543,7 +14547,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14547 "inc/vcf/validator_detail_v42.hpp"
+#line 14551 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr691;
 		case 44: goto tr692;
@@ -14579,7 +14583,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14583 "inc/vcf/validator_detail_v42.hpp"
+#line 14587 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr911;
 		case 95: goto tr911;
@@ -14603,7 +14607,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14607 "inc/vcf/validator_detail_v42.hpp"
+#line 14611 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 62: goto tr912;
 		case 95: goto tr910;
@@ -14637,7 +14641,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14641 "inc/vcf/validator_detail_v42.hpp"
+#line 14645 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr691;
 		case 44: goto tr692;
@@ -14666,7 +14670,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 14670 "inc/vcf/validator_detail_v42.hpp"
+#line 14674 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr917;
 	if ( (*p) < 65 ) {
@@ -14688,7 +14692,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 14692 "inc/vcf/validator_detail_v42.hpp"
+#line 14696 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr920;
 		case 59: goto tr918;
@@ -14725,7 +14729,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 14729 "inc/vcf/validator_detail_v42.hpp"
+#line 14733 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr918;
 		case 61: goto tr918;
@@ -14761,7 +14765,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 14765 "inc/vcf/validator_detail_v42.hpp"
+#line 14769 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr920;
 		case 61: goto tr919;
@@ -14782,7 +14786,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 14786 "inc/vcf/validator_detail_v42.hpp"
+#line 14790 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr921;
 		case 45: goto tr921;
@@ -14800,7 +14804,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 14804 "inc/vcf/validator_detail_v42.hpp"
+#line 14808 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr922;
 	goto tr684;
@@ -14814,7 +14818,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 14818 "inc/vcf/validator_detail_v42.hpp"
+#line 14822 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr912;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14830,7 +14834,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 14834 "inc/vcf/validator_detail_v42.hpp"
+#line 14838 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr923;
@@ -14850,7 +14854,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 14854 "inc/vcf/validator_detail_v42.hpp"
+#line 14858 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr924;
 		case 62: goto tr926;
@@ -14886,7 +14890,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 14890 "inc/vcf/validator_detail_v42.hpp"
+#line 14894 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr924;
 		case 61: goto tr924;
@@ -14922,7 +14926,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 14926 "inc/vcf/validator_detail_v42.hpp"
+#line 14930 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr925;
 		case 62: goto tr926;
@@ -14943,7 +14947,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 14947 "inc/vcf/validator_detail_v42.hpp"
+#line 14951 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr920;
 	goto tr684;
@@ -14957,7 +14961,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 14961 "inc/vcf/validator_detail_v42.hpp"
+#line 14965 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr928;
 	if ( (*p) < 65 ) {
@@ -14979,7 +14983,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 14983 "inc/vcf/validator_detail_v42.hpp"
+#line 14987 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr931;
 		case 59: goto tr929;
@@ -15016,7 +15020,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15020 "inc/vcf/validator_detail_v42.hpp"
+#line 15024 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr929;
 		case 61: goto tr929;
@@ -15052,7 +15056,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15056 "inc/vcf/validator_detail_v42.hpp"
+#line 15060 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr931;
 		case 61: goto tr930;
@@ -15073,7 +15077,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15077 "inc/vcf/validator_detail_v42.hpp"
+#line 15081 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr932;
 		case 45: goto tr932;
@@ -15091,7 +15095,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15095 "inc/vcf/validator_detail_v42.hpp"
+#line 15099 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr684;
@@ -15105,7 +15109,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15109 "inc/vcf/validator_detail_v42.hpp"
+#line 15113 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr912;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15121,7 +15125,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15125 "inc/vcf/validator_detail_v42.hpp"
+#line 15129 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr934;
@@ -15141,7 +15145,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15145 "inc/vcf/validator_detail_v42.hpp"
+#line 15149 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr935;
 		case 62: goto tr937;
@@ -15177,7 +15181,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15181 "inc/vcf/validator_detail_v42.hpp"
+#line 15185 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr935;
 		case 61: goto tr935;
@@ -15213,7 +15217,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15217 "inc/vcf/validator_detail_v42.hpp"
+#line 15221 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr936;
 		case 62: goto tr937;
@@ -15234,7 +15238,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15238 "inc/vcf/validator_detail_v42.hpp"
+#line 15242 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr931;
 	goto tr684;
@@ -15252,7 +15256,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15256 "inc/vcf/validator_detail_v42.hpp"
+#line 15260 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr939;
 	if ( (*p) < 65 ) {
@@ -15274,7 +15278,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15278 "inc/vcf/validator_detail_v42.hpp"
+#line 15282 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr942;
 		case 59: goto tr940;
@@ -15311,7 +15315,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15315 "inc/vcf/validator_detail_v42.hpp"
+#line 15319 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr940;
 		case 61: goto tr940;
@@ -15347,7 +15351,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15351 "inc/vcf/validator_detail_v42.hpp"
+#line 15355 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr942;
 		case 61: goto tr941;
@@ -15368,7 +15372,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15372 "inc/vcf/validator_detail_v42.hpp"
+#line 15376 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr943;
 		case 45: goto tr943;
@@ -15386,7 +15390,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15390 "inc/vcf/validator_detail_v42.hpp"
+#line 15394 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr944;
 	goto tr684;
@@ -15400,7 +15404,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15404 "inc/vcf/validator_detail_v42.hpp"
+#line 15408 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr945;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15416,7 +15420,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15420 "inc/vcf/validator_detail_v42.hpp"
+#line 15424 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr946;
@@ -15436,7 +15440,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15440 "inc/vcf/validator_detail_v42.hpp"
+#line 15444 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr947;
 		case 62: goto tr949;
@@ -15472,7 +15476,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15476 "inc/vcf/validator_detail_v42.hpp"
+#line 15480 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr947;
 		case 61: goto tr947;
@@ -15508,7 +15512,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15512 "inc/vcf/validator_detail_v42.hpp"
+#line 15516 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr948;
 		case 62: goto tr949;
@@ -15529,7 +15533,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15533 "inc/vcf/validator_detail_v42.hpp"
+#line 15537 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr942;
 	goto tr684;
@@ -15547,7 +15551,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15551 "inc/vcf/validator_detail_v42.hpp"
+#line 15555 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr951;
 	if ( (*p) < 65 ) {
@@ -15569,7 +15573,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15573 "inc/vcf/validator_detail_v42.hpp"
+#line 15577 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr954;
 		case 59: goto tr952;
@@ -15606,7 +15610,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15610 "inc/vcf/validator_detail_v42.hpp"
+#line 15614 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr952;
 		case 61: goto tr952;
@@ -15642,7 +15646,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15646 "inc/vcf/validator_detail_v42.hpp"
+#line 15650 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr954;
 		case 61: goto tr953;
@@ -15663,7 +15667,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15667 "inc/vcf/validator_detail_v42.hpp"
+#line 15671 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr955;
 		case 45: goto tr955;
@@ -15681,7 +15685,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15685 "inc/vcf/validator_detail_v42.hpp"
+#line 15689 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr684;
@@ -15695,7 +15699,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15699 "inc/vcf/validator_detail_v42.hpp"
+#line 15703 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr945;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15711,7 +15715,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15715 "inc/vcf/validator_detail_v42.hpp"
+#line 15719 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr957;
@@ -15731,7 +15735,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15735 "inc/vcf/validator_detail_v42.hpp"
+#line 15739 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr958;
 		case 62: goto tr960;
@@ -15767,7 +15771,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15771 "inc/vcf/validator_detail_v42.hpp"
+#line 15775 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr958;
 		case 61: goto tr958;
@@ -15803,7 +15807,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15807 "inc/vcf/validator_detail_v42.hpp"
+#line 15811 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr959;
 		case 62: goto tr960;
@@ -15824,7 +15828,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15828 "inc/vcf/validator_detail_v42.hpp"
+#line 15832 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr954;
 	goto tr684;
@@ -15842,7 +15846,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 15846 "inc/vcf/validator_detail_v42.hpp"
+#line 15850 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr691;
 		case 65: goto tr909;
@@ -15867,7 +15871,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 15871 "inc/vcf/validator_detail_v42.hpp"
+#line 15875 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr668;
 		case 61: goto tr668;
@@ -15903,7 +15907,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 15907 "inc/vcf/validator_detail_v42.hpp"
+#line 15911 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr667;
 		case 59: goto tr669;
@@ -15933,14 +15937,14 @@ tr962:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 744 "src/vcf/vcf_v42.ragel"
+#line 746 "src/vcf/vcf_v42.ragel"
 	{ {goto st28;} }
 	goto st732;
 st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 15944 "inc/vcf/validator_detail_v42.hpp"
+#line 15948 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 st729:
 	if ( ++p == pe )
@@ -15960,14 +15964,14 @@ tr964:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 745 "src/vcf/vcf_v42.ragel"
+#line 747 "src/vcf/vcf_v42.ragel"
 	{ {goto st731;} }
 	goto st733;
 st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 15971 "inc/vcf/validator_detail_v42.hpp"
+#line 15975 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -16722,7 +16726,7 @@ case 733:
 	case 13: 
 #line 60 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -16775,7 +16779,7 @@ case 733:
 	case 72: 
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -16784,8 +16788,8 @@ case 733:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 	break;
@@ -16800,13 +16804,13 @@ case 733:
 	case 486: 
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
@@ -16822,13 +16826,13 @@ case 733:
 	case 21: 
 #line 214 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.2'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         p--; {goto st728;}
     }
 #line 60 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -16856,12 +16860,12 @@ case 733:
 	case 112: 
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -16873,14 +16877,14 @@ case 733:
 	case 379: 
 	case 380: 
 	case 381: 
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 233 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -16913,14 +16917,14 @@ case 733:
 	case 419: 
 	case 420: 
 	case 421: 
-#line 238 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -16948,14 +16952,14 @@ case 733:
 	case 146: 
 	case 153: 
 	case 164: 
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -16995,14 +16999,14 @@ case 733:
 	case 212: 
 	case 219: 
 	case 230: 
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17041,14 +17045,14 @@ case 733:
 	case 278: 
 	case 285: 
 	case 296: 
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17062,14 +17066,14 @@ case 733:
 	case 312: 
 	case 313: 
 	case 320: 
-#line 282 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17084,14 +17088,14 @@ case 733:
 	case 430: 
 	case 431: 
 	case 432: 
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 289 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17106,14 +17110,14 @@ case 733:
 	case 329: 
 	case 330: 
 	case 370: 
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17154,28 +17158,29 @@ case 733:
 	case 475: 
 	case 476: 
 	case 477: 
-#line 326 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
@@ -17189,54 +17194,54 @@ case 733:
 	case 515: 
 	case 726: 
 	case 727: 
-#line 342 "src/vcf/vcf_v42.ragel"
+#line 344 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 488: 
 	case 489: 
 	case 490: 
-#line 348 "src/vcf/vcf_v42.ragel"
+#line 350 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 491: 
 	case 492: 
-#line 354 "src/vcf/vcf_v42.ragel"
+#line 356 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 493: 
 	case 494: 
-#line 360 "src/vcf/vcf_v42.ragel"
+#line 362 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -17297,14 +17302,14 @@ case 733:
 	case 723: 
 	case 724: 
 	case 725: 
-#line 366 "src/vcf/vcf_v42.ragel"
+#line 368 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -17322,14 +17327,14 @@ case 733:
 	case 668: 
 	case 669: 
 	case 670: 
-#line 372 "src/vcf/vcf_v42.ragel"
+#line 374 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -17338,42 +17343,42 @@ case 733:
 	case 503: 
 	case 659: 
 	case 660: 
-#line 378 "src/vcf/vcf_v42.ragel"
+#line 380 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 507: 
 	case 508: 
-#line 490 "src/vcf/vcf_v42.ragel"
+#line 492 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 518: 
 	case 519: 
-#line 496 "src/vcf/vcf_v42.ragel"
+#line 498 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -17381,31 +17386,32 @@ case 733:
 	case 28: 
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
-#line 326 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
@@ -17416,108 +17422,109 @@ case 733:
 	case 120: 
 #line 226 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 121: 
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 191: 
 	case 192: 
 	case 238: 
-#line 255 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 257: 
 	case 258: 
 	case 304: 
-#line 271 "src/vcf/vcf_v42.ragel"
+#line 272 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 198: 
 	case 199: 
-#line 276 "src/vcf/vcf_v42.ragel"
+#line 277 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 264: 
 	case 265: 
-#line 276 "src/vcf/vcf_v42.ragel"
+#line 277 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17530,19 +17537,19 @@ case 733:
 	case 340: 
 	case 341: 
 	case 342: 
-#line 299 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17555,38 +17562,38 @@ case 733:
 	case 350: 
 	case 351: 
 	case 352: 
-#line 304 "src/vcf/vcf_v42.ragel"
+#line 305 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 98: 
 	case 99: 
 	case 100: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17594,19 +17601,19 @@ case 733:
 	case 400: 
 	case 401: 
 	case 402: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 238 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17616,19 +17623,19 @@ case 733:
 	case 150: 
 	case 151: 
 	case 152: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17638,19 +17645,19 @@ case 733:
 	case 216: 
 	case 217: 
 	case 218: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17660,19 +17667,19 @@ case 733:
 	case 282: 
 	case 283: 
 	case 284: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17682,37 +17689,37 @@ case 733:
 	case 317: 
 	case 318: 
 	case 319: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 282 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 331: 
 	case 332: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17730,19 +17737,19 @@ case 733:
 	case 114: 
 	case 118: 
 	case 119: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17760,19 +17767,19 @@ case 733:
 	case 166: 
 	case 170: 
 	case 171: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17790,19 +17797,19 @@ case 733:
 	case 232: 
 	case 236: 
 	case 237: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17820,19 +17827,19 @@ case 733:
 	case 298: 
 	case 302: 
 	case 303: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17855,19 +17862,19 @@ case 733:
 	case 371: 
 	case 372: 
 	case 373: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17878,19 +17885,19 @@ case 733:
 	case 386: 
 	case 387: 
 	case 388: 
-#line 320 "src/vcf/vcf_v42.ragel"
+#line 321 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st728;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 233 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17902,19 +17909,19 @@ case 733:
 	case 438: 
 	case 439: 
 	case 440: 
-#line 320 "src/vcf/vcf_v42.ragel"
+#line 321 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st728;}
     }
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 289 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
@@ -17965,75 +17972,75 @@ case 733:
 	case 653: 
 	case 654: 
 	case 658: 
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 525: 
 	case 526: 
-#line 394 "src/vcf/vcf_v42.ragel"
+#line 396 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 532: 
 	case 533: 
 	case 534: 
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 401 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 536: 
 	case 537: 
 	case 538: 
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 406 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -18050,38 +18057,38 @@ case 733:
 	case 550: 
 	case 551: 
 	case 552: 
-#line 409 "src/vcf/vcf_v42.ragel"
+#line 411 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 554: 
 	case 555: 
 	case 556: 
-#line 414 "src/vcf/vcf_v42.ragel"
+#line 416 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -18098,129 +18105,129 @@ case 733:
 	case 569: 
 	case 570: 
 	case 571: 
-#line 419 "src/vcf/vcf_v42.ragel"
+#line 421 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 577: 
 	case 578: 
-#line 424 "src/vcf/vcf_v42.ragel"
+#line 426 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 581: 
 	case 582: 
-#line 429 "src/vcf/vcf_v42.ragel"
+#line 431 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 584: 
 	case 585: 
 	case 586: 
-#line 434 "src/vcf/vcf_v42.ragel"
+#line 436 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 590: 
 	case 591: 
 	case 592: 
-#line 439 "src/vcf/vcf_v42.ragel"
+#line 441 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 595: 
 	case 596: 
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 446 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 598: 
 	case 599: 
-#line 449 "src/vcf/vcf_v42.ragel"
+#line 451 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -18237,57 +18244,57 @@ case 733:
 	case 616: 
 	case 617: 
 	case 618: 
-#line 454 "src/vcf/vcf_v42.ragel"
+#line 456 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 603: 
 	case 604: 
 	case 605: 
-#line 459 "src/vcf/vcf_v42.ragel"
+#line 461 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 621: 
 	case 622: 
 	case 623: 
-#line 464 "src/vcf/vcf_v42.ragel"
+#line 466 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -18304,73 +18311,73 @@ case 733:
 	case 636: 
 	case 637: 
 	case 638: 
-#line 469 "src/vcf/vcf_v42.ragel"
+#line 471 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 645: 
 	case 646: 
-#line 474 "src/vcf/vcf_v42.ragel"
+#line 476 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 656: 
 	case 657: 
-#line 479 "src/vcf/vcf_v42.ragel"
+#line 481 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 528: 
 	case 529: 
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 486 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
@@ -18378,514 +18385,515 @@ case 733:
 	case 510: 
 	case 516: 
 	case 517: 
-#line 503 "src/vcf/vcf_v42.ragel"
+#line 505 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st729;}
     }
-#line 496 "src/vcf/vcf_v42.ragel"
+#line 498 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 22: 
 #line 60 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
-#line 326 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 #line 78 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st729;}
     }
 	break;
 	case 343: 
-#line 299 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 304 "src/vcf/vcf_v42.ragel"
+#line 305 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 353: 
-#line 304 "src/vcf/vcf_v42.ragel"
+#line 305 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 333: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 299 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 106: 
 	case 107: 
 	case 108: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 158: 
 	case 159: 
 	case 160: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 224: 
 	case 225: 
 	case 226: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 290: 
 	case 291: 
 	case 292: 
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 115: 
 	case 116: 
 	case 117: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 167: 
 	case 168: 
 	case 169: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 233: 
 	case 234: 
 	case 235: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 299: 
 	case 300: 
 	case 301: 
-#line 315 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st728;}
     }
-#line 310 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
 	case 580: 
-#line 429 "src/vcf/vcf_v42.ragel"
+#line 431 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 594: 
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 446 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 597: 
-#line 449 "src/vcf/vcf_v42.ragel"
+#line 451 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 644: 
-#line 474 "src/vcf/vcf_v42.ragel"
+#line 476 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 655: 
-#line 479 "src/vcf/vcf_v42.ragel"
+#line 481 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 527: 
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 486 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st729;}
     }
-#line 389 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st729;}
     }
-#line 384 "src/vcf/vcf_v42.ragel"
+#line 386 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st729;}
     }
 #line 91 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st729;}
     }
 	break;
 	case 24: 
 #line 221 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st728;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 245 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st728;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 251 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st728;}
     }
-#line 266 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st728;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 233 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st728;}
     }
-#line 238 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st728;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 295 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st728;}
     }
-#line 282 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st728;}
     }
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 289 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st728;}
     }
 #line 65 "src/vcf/vcf_v42.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st728;}
     }
 	break;
-#line 18882 "inc/vcf/validator_detail_v42.hpp"
+#line 18890 "inc/vcf/validator_detail_v42.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 776 "src/vcf/vcf_v42.ragel"
+#line 778 "src/vcf/vcf_v42.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 742 "src/vcf/vcf_v42.ragel"
+#line 746 "src/vcf/vcf_v42.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v42_en_meta_section_skip = 728;
 static const int vcf_v42_en_body_section_skip = 729;
 
 
-#line 748 "src/vcf/vcf_v42.ragel"
+#line 752 "src/vcf/vcf_v42.ragel"
 
 }
 
@@ -60,7 +60,7 @@ namespace ebi
 	cs = vcf_v42_start;
 	}
 
-#line 764 "src/vcf/vcf_v42.ragel"
+#line 768 "src/vcf/vcf_v42.ragel"
 
     }
 
@@ -86,7 +86,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 210 "src/vcf/vcf_v42.ragel"
+#line 214 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_fileformat_section_error(*this,
             "The fileformat declaration is not 'fileformat=VCFv4.2'");
@@ -109,15 +109,15 @@ tr23:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st728;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 326 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -129,8 +129,8 @@ tr23:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -142,15 +142,15 @@ tr25:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st728;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 326 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -162,55 +162,55 @@ tr25:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
     }
 	goto st0;
 tr28:
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
     }
-#line 228 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st728;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 238 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 282 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st728;}
     }
-#line 284 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st728;}
@@ -229,7 +229,7 @@ tr38:
     }
 	goto st0;
 tr121:
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -241,12 +241,12 @@ tr121:
     }
 	goto st0;
 tr129:
-#line 222 "src/vcf/vcf_v42.ragel"
+#line 226 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -258,12 +258,12 @@ tr129:
     }
 	goto st0;
 tr147:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -275,12 +275,12 @@ tr147:
     }
 	goto st0;
 tr156:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -292,17 +292,17 @@ tr156:
     }
 	goto st0;
 tr170:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -314,17 +314,17 @@ tr170:
     }
 	goto st0;
 tr182:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -336,12 +336,12 @@ tr182:
     }
 	goto st0;
 tr189:
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -353,7 +353,7 @@ tr189:
     }
 	goto st0;
 tr192:
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -365,12 +365,12 @@ tr192:
     }
 	goto st0;
 tr202:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -382,12 +382,12 @@ tr202:
     }
 	goto st0;
 tr221:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -399,17 +399,17 @@ tr221:
     }
 	goto st0;
 tr243:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -421,17 +421,17 @@ tr243:
     }
 	goto st0;
 tr255:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -443,7 +443,7 @@ tr255:
     }
 	goto st0;
 tr261:
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -455,12 +455,12 @@ tr261:
     }
 	goto st0;
 tr271:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -472,12 +472,12 @@ tr271:
     }
 	goto st0;
 tr284:
-#line 251 "src/vcf/vcf_v42.ragel"
+#line 255 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -489,12 +489,12 @@ tr284:
     }
 	goto st0;
 tr293:
-#line 272 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -506,12 +506,12 @@ tr293:
     }
 	goto st0;
 tr310:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -523,17 +523,17 @@ tr310:
     }
 	goto st0;
 tr332:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -545,17 +545,17 @@ tr332:
     }
 	goto st0;
 tr344:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -567,7 +567,7 @@ tr344:
     }
 	goto st0;
 tr351:
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -579,12 +579,12 @@ tr351:
     }
 	goto st0;
 tr360:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -596,12 +596,12 @@ tr360:
     }
 	goto st0;
 tr373:
-#line 267 "src/vcf/vcf_v42.ragel"
+#line 271 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -613,12 +613,12 @@ tr373:
     }
 	goto st0;
 tr382:
-#line 272 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -630,12 +630,12 @@ tr382:
     }
 	goto st0;
 tr399:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -647,17 +647,17 @@ tr399:
     }
 	goto st0;
 tr421:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -669,17 +669,17 @@ tr421:
     }
 	goto st0;
 tr433:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -691,7 +691,7 @@ tr433:
     }
 	goto st0;
 tr440:
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 282 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st728;}
@@ -703,12 +703,12 @@ tr440:
     }
 	goto st0;
 tr450:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 282 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st728;}
@@ -720,7 +720,7 @@ tr450:
     }
 	goto st0;
 tr462:
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -732,12 +732,12 @@ tr462:
     }
 	goto st0;
 tr473:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -749,17 +749,17 @@ tr473:
     }
 	goto st0;
 tr478:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 295 "src/vcf/vcf_v42.ragel"
+#line 299 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -771,12 +771,12 @@ tr478:
     }
 	goto st0;
 tr480:
-#line 295 "src/vcf/vcf_v42.ragel"
+#line 299 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -788,17 +788,17 @@ tr480:
     }
 	goto st0;
 tr490:
-#line 295 "src/vcf/vcf_v42.ragel"
+#line 299 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -810,12 +810,12 @@ tr490:
     }
 	goto st0;
 tr493:
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -827,17 +827,17 @@ tr493:
     }
 	goto st0;
 tr503:
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -849,12 +849,12 @@ tr503:
     }
 	goto st0;
 tr506:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -866,7 +866,7 @@ tr506:
     }
 	goto st0;
 tr529:
-#line 228 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st728;}
@@ -878,12 +878,12 @@ tr529:
     }
 	goto st0;
 tr538:
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st728;}
     }
-#line 228 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st728;}
@@ -895,7 +895,7 @@ tr538:
     }
 	goto st0;
 tr545:
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 238 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st728;}
@@ -907,12 +907,12 @@ tr545:
     }
 	goto st0;
 tr556:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 238 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st728;}
@@ -924,7 +924,7 @@ tr556:
     }
 	goto st0;
 tr595:
-#line 284 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st728;}
@@ -936,12 +936,12 @@ tr595:
     }
 	goto st0;
 tr607:
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st728;}
     }
-#line 284 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st728;}
@@ -953,15 +953,15 @@ tr607:
     }
 	goto st0;
 tr615:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 326 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -973,8 +973,8 @@ tr615:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -988,15 +988,15 @@ tr654:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
     }
 	goto st0;
 tr666:
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 342 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st729;}
@@ -1008,7 +1008,7 @@ tr666:
     }
 	goto st0;
 tr670:
-#line 344 "src/vcf/vcf_v42.ragel"
+#line 348 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
         p--; {goto st729;}
@@ -1020,7 +1020,7 @@ tr670:
     }
 	goto st0;
 tr675:
-#line 350 "src/vcf/vcf_v42.ragel"
+#line 354 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
         p--; {goto st729;}
@@ -1032,7 +1032,7 @@ tr675:
     }
 	goto st0;
 tr680:
-#line 356 "src/vcf/vcf_v42.ragel"
+#line 360 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
         p--; {goto st729;}
@@ -1044,7 +1044,7 @@ tr680:
     }
 	goto st0;
 tr684:
-#line 362 "src/vcf/vcf_v42.ragel"
+#line 366 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
         p--; {goto st729;}
@@ -1056,7 +1056,7 @@ tr684:
     }
 	goto st0;
 tr693:
-#line 368 "src/vcf/vcf_v42.ragel"
+#line 372 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
         p--; {goto st729;}
@@ -1068,7 +1068,7 @@ tr693:
     }
 	goto st0;
 tr705:
-#line 374 "src/vcf/vcf_v42.ragel"
+#line 378 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
         p--; {goto st729;}
@@ -1080,12 +1080,12 @@ tr705:
     }
 	goto st0;
 tr713:
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1097,7 +1097,7 @@ tr713:
     }
 	goto st0;
 tr734:
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 490 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
         p--; {goto st729;}
@@ -1109,14 +1109,14 @@ tr734:
     }
 	goto st0;
 tr739:
-#line 499 "src/vcf/vcf_v42.ragel"
+#line 503 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_body_section_error(*this, message_stream.str());
         p--; {goto st729;}
     }
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 496 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1130,7 +1130,7 @@ tr739:
     }
 	goto st0;
 tr751:
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 496 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1144,12 +1144,12 @@ tr751:
     }
 	goto st0;
 tr757:
-#line 390 "src/vcf/vcf_v42.ragel"
+#line 394 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1161,17 +1161,17 @@ tr757:
     }
 	goto st0;
 tr759:
-#line 480 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1183,12 +1183,12 @@ tr759:
     }
 	goto st0;
 tr761:
-#line 480 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1200,12 +1200,12 @@ tr761:
     }
 	goto st0;
 tr768:
-#line 395 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1217,12 +1217,12 @@ tr768:
     }
 	goto st0;
 tr772:
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1234,12 +1234,12 @@ tr772:
     }
 	goto st0;
 tr776:
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 409 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1251,12 +1251,12 @@ tr776:
     }
 	goto st0;
 tr790:
-#line 410 "src/vcf/vcf_v42.ragel"
+#line 414 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1268,12 +1268,12 @@ tr790:
     }
 	goto st0;
 tr795:
-#line 415 "src/vcf/vcf_v42.ragel"
+#line 419 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1285,12 +1285,12 @@ tr795:
     }
 	goto st0;
 tr813:
-#line 420 "src/vcf/vcf_v42.ragel"
+#line 424 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1302,17 +1302,17 @@ tr813:
     }
 	goto st0;
 tr817:
-#line 425 "src/vcf/vcf_v42.ragel"
+#line 429 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1324,12 +1324,12 @@ tr817:
     }
 	goto st0;
 tr819:
-#line 425 "src/vcf/vcf_v42.ragel"
+#line 429 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1341,12 +1341,12 @@ tr819:
     }
 	goto st0;
 tr822:
-#line 430 "src/vcf/vcf_v42.ragel"
+#line 434 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1358,12 +1358,12 @@ tr822:
     }
 	goto st0;
 tr828:
-#line 435 "src/vcf/vcf_v42.ragel"
+#line 439 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1375,17 +1375,17 @@ tr828:
     }
 	goto st0;
 tr833:
-#line 440 "src/vcf/vcf_v42.ragel"
+#line 444 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1397,12 +1397,12 @@ tr833:
     }
 	goto st0;
 tr835:
-#line 440 "src/vcf/vcf_v42.ragel"
+#line 444 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1414,17 +1414,17 @@ tr835:
     }
 	goto st0;
 tr837:
-#line 445 "src/vcf/vcf_v42.ragel"
+#line 449 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1436,12 +1436,12 @@ tr837:
     }
 	goto st0;
 tr839:
-#line 445 "src/vcf/vcf_v42.ragel"
+#line 449 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1453,12 +1453,12 @@ tr839:
     }
 	goto st0;
 tr845:
-#line 455 "src/vcf/vcf_v42.ragel"
+#line 459 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1470,12 +1470,12 @@ tr845:
     }
 	goto st0;
 tr848:
-#line 450 "src/vcf/vcf_v42.ragel"
+#line 454 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1487,12 +1487,12 @@ tr848:
     }
 	goto st0;
 tr863:
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 464 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1504,12 +1504,12 @@ tr863:
     }
 	goto st0;
 tr869:
-#line 465 "src/vcf/vcf_v42.ragel"
+#line 469 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1521,17 +1521,17 @@ tr869:
     }
 	goto st0;
 tr887:
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 474 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1543,12 +1543,12 @@ tr887:
     }
 	goto st0;
 tr889:
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 474 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1560,17 +1560,17 @@ tr889:
     }
 	goto st0;
 tr899:
-#line 475 "src/vcf/vcf_v42.ragel"
+#line 479 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1582,12 +1582,12 @@ tr899:
     }
 	goto st0;
 tr901:
-#line 475 "src/vcf/vcf_v42.ragel"
+#line 479 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -1606,13 +1606,13 @@ tr965:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 342 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st729;}
@@ -1952,8 +1952,8 @@ tr44:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -1972,8 +1972,8 @@ tr52:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -10543,8 +10543,8 @@ tr966:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 #line 31 "src/vcf/vcf_v42.ragel"
@@ -11310,12 +11310,16 @@ tr731:
         try {
           // Handle all columns and build record
           ParsePolicy::handle_body_line(*this);
+            try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_body_section_error(*this, ex.what());
-        } catch (ParsingWarning ex) {
-          ErrorPolicy::handle_body_section_warning(*this, ex.what());
+            } catch (MetaSectionError &ex) {
+                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
+            } catch (BodySectionError &ex) {
+                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            }
+        } catch (BodySectionError ex) {
+            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -11333,7 +11337,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 11337 "inc/vcf/validator_detail_v42.hpp"
+#line 11341 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st511;
 	if ( (*p) < 65 ) {
@@ -11350,8 +11354,8 @@ tr967:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 	goto st511;
@@ -11359,7 +11363,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11363 "inc/vcf/validator_detail_v42.hpp"
+#line 11367 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr744;
@@ -11383,7 +11387,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11387 "inc/vcf/validator_detail_v42.hpp"
+#line 11391 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr745;
 		case 62: goto tr747;
@@ -11419,7 +11423,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11423 "inc/vcf/validator_detail_v42.hpp"
+#line 11427 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr745;
 		case 61: goto tr745;
@@ -11455,7 +11459,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11459 "inc/vcf/validator_detail_v42.hpp"
+#line 11463 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr746;
 		case 62: goto tr747;
@@ -11476,7 +11480,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11480 "inc/vcf/validator_detail_v42.hpp"
+#line 11484 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr748;
 	goto tr666;
@@ -11490,7 +11494,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11494 "inc/vcf/validator_detail_v42.hpp"
+#line 11498 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr749;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11516,7 +11520,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11520 "inc/vcf/validator_detail_v42.hpp"
+#line 11524 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr736;
 		case 10: goto tr731;
@@ -11537,7 +11541,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11541 "inc/vcf/validator_detail_v42.hpp"
+#line 11545 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr752;
@@ -11554,7 +11558,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11558 "inc/vcf/validator_detail_v42.hpp"
+#line 11562 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr736;
 		case 10: goto tr731;
@@ -11573,7 +11577,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11577 "inc/vcf/validator_detail_v42.hpp"
+#line 11581 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 49: goto tr717;
 		case 58: goto tr714;
@@ -11624,7 +11628,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11628 "inc/vcf/validator_detail_v42.hpp"
+#line 11632 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11645,7 +11649,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11649 "inc/vcf/validator_detail_v42.hpp"
+#line 11653 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11666,7 +11670,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11670 "inc/vcf/validator_detail_v42.hpp"
+#line 11674 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11687,7 +11691,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11691 "inc/vcf/validator_detail_v42.hpp"
+#line 11695 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11708,7 +11712,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11712 "inc/vcf/validator_detail_v42.hpp"
+#line 11716 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr758;
@@ -11725,7 +11729,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11729 "inc/vcf/validator_detail_v42.hpp"
+#line 11733 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11744,7 +11748,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11748 "inc/vcf/validator_detail_v42.hpp"
+#line 11752 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11764,7 +11768,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11768 "inc/vcf/validator_detail_v42.hpp"
+#line 11772 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr762;
 	goto tr761;
@@ -11778,7 +11782,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 11782 "inc/vcf/validator_detail_v42.hpp"
+#line 11786 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11799,7 +11803,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 11803 "inc/vcf/validator_detail_v42.hpp"
+#line 11807 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11823,7 +11827,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 11827 "inc/vcf/validator_detail_v42.hpp"
+#line 11831 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr767;
 	if ( (*p) > 58 ) {
@@ -11842,7 +11846,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 11846 "inc/vcf/validator_detail_v42.hpp"
+#line 11850 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr770;
 		case 67: goto tr770;
@@ -11868,7 +11872,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 11872 "inc/vcf/validator_detail_v42.hpp"
+#line 11876 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11885,7 +11889,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 11889 "inc/vcf/validator_detail_v42.hpp"
+#line 11893 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11912,7 +11916,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 11916 "inc/vcf/validator_detail_v42.hpp"
+#line 11920 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr771;
 	if ( (*p) > 58 ) {
@@ -11931,7 +11935,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 11935 "inc/vcf/validator_detail_v42.hpp"
+#line 11939 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr773;
 		case 45: goto tr773;
@@ -11949,7 +11953,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 11953 "inc/vcf/validator_detail_v42.hpp"
+#line 11957 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr774;
 	goto tr772;
@@ -11963,7 +11967,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 11967 "inc/vcf/validator_detail_v42.hpp"
+#line 11971 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -11983,7 +11987,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 11987 "inc/vcf/validator_detail_v42.hpp"
+#line 11991 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr775;
 	if ( (*p) > 58 ) {
@@ -12002,7 +12006,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12006 "inc/vcf/validator_detail_v42.hpp"
+#line 12010 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr777;
 		case 45: goto tr777;
@@ -12023,7 +12027,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12027 "inc/vcf/validator_detail_v42.hpp"
+#line 12031 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr778;
 		case 73: goto tr780;
@@ -12041,7 +12045,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12045 "inc/vcf/validator_detail_v42.hpp"
+#line 12049 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr782;
 	goto tr776;
@@ -12055,7 +12059,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12059 "inc/vcf/validator_detail_v42.hpp"
+#line 12063 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12077,7 +12081,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12081 "inc/vcf/validator_detail_v42.hpp"
+#line 12085 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr784;
 		case 45: goto tr784;
@@ -12095,7 +12099,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12099 "inc/vcf/validator_detail_v42.hpp"
+#line 12103 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr785;
 	goto tr776;
@@ -12109,7 +12113,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12113 "inc/vcf/validator_detail_v42.hpp"
+#line 12117 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12129,7 +12133,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12133 "inc/vcf/validator_detail_v42.hpp"
+#line 12137 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12152,7 +12156,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12156 "inc/vcf/validator_detail_v42.hpp"
+#line 12160 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr786;
 	goto tr776;
@@ -12166,7 +12170,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12170 "inc/vcf/validator_detail_v42.hpp"
+#line 12174 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr787;
 	goto tr776;
@@ -12180,7 +12184,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12184 "inc/vcf/validator_detail_v42.hpp"
+#line 12188 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12198,7 +12202,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12202 "inc/vcf/validator_detail_v42.hpp"
+#line 12206 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr788;
 	goto tr776;
@@ -12212,7 +12216,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12216 "inc/vcf/validator_detail_v42.hpp"
+#line 12220 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr787;
 	goto tr776;
@@ -12226,7 +12230,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12230 "inc/vcf/validator_detail_v42.hpp"
+#line 12234 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr789;
 	if ( (*p) > 58 ) {
@@ -12245,7 +12249,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12249 "inc/vcf/validator_detail_v42.hpp"
+#line 12253 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr791;
 		case 45: goto tr791;
@@ -12263,7 +12267,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12267 "inc/vcf/validator_detail_v42.hpp"
+#line 12271 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr792;
 	goto tr790;
@@ -12277,7 +12281,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12281 "inc/vcf/validator_detail_v42.hpp"
+#line 12285 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12300,7 +12304,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12304 "inc/vcf/validator_detail_v42.hpp"
+#line 12308 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12321,7 +12325,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12325 "inc/vcf/validator_detail_v42.hpp"
+#line 12329 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr794;
 	if ( (*p) > 58 ) {
@@ -12340,7 +12344,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12344 "inc/vcf/validator_detail_v42.hpp"
+#line 12348 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr796;
 		case 45: goto tr796;
@@ -12361,7 +12365,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12365 "inc/vcf/validator_detail_v42.hpp"
+#line 12369 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr797;
 		case 73: goto tr799;
@@ -12379,7 +12383,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 12383 "inc/vcf/validator_detail_v42.hpp"
+#line 12387 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr801;
 	goto tr795;
@@ -12393,7 +12397,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 12397 "inc/vcf/validator_detail_v42.hpp"
+#line 12401 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12414,7 +12418,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12418 "inc/vcf/validator_detail_v42.hpp"
+#line 12422 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr803;
 		case 45: goto tr803;
@@ -12432,7 +12436,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 12436 "inc/vcf/validator_detail_v42.hpp"
+#line 12440 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr804;
 	goto tr795;
@@ -12446,7 +12450,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 12450 "inc/vcf/validator_detail_v42.hpp"
+#line 12454 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12465,7 +12469,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 12469 "inc/vcf/validator_detail_v42.hpp"
+#line 12473 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12487,7 +12491,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 12491 "inc/vcf/validator_detail_v42.hpp"
+#line 12495 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr805;
 	goto tr795;
@@ -12501,7 +12505,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12505 "inc/vcf/validator_detail_v42.hpp"
+#line 12509 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr806;
 	goto tr795;
@@ -12515,7 +12519,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 12519 "inc/vcf/validator_detail_v42.hpp"
+#line 12523 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12532,7 +12536,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 12536 "inc/vcf/validator_detail_v42.hpp"
+#line 12540 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr807;
 	goto tr795;
@@ -12546,7 +12550,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 12550 "inc/vcf/validator_detail_v42.hpp"
+#line 12554 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr806;
 	goto tr795;
@@ -12564,7 +12568,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 12568 "inc/vcf/validator_detail_v42.hpp"
+#line 12572 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12585,7 +12589,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 12589 "inc/vcf/validator_detail_v42.hpp"
+#line 12593 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12606,7 +12610,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 12610 "inc/vcf/validator_detail_v42.hpp"
+#line 12614 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12627,7 +12631,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12631 "inc/vcf/validator_detail_v42.hpp"
+#line 12635 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12648,7 +12652,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12652 "inc/vcf/validator_detail_v42.hpp"
+#line 12656 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr812;
 	if ( (*p) > 58 ) {
@@ -12667,7 +12671,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12671 "inc/vcf/validator_detail_v42.hpp"
+#line 12675 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr814;
@@ -12687,7 +12691,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12691 "inc/vcf/validator_detail_v42.hpp"
+#line 12695 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12716,7 +12720,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12720 "inc/vcf/validator_detail_v42.hpp"
+#line 12724 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12738,7 +12742,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12742 "inc/vcf/validator_detail_v42.hpp"
+#line 12746 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12758,7 +12762,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12762 "inc/vcf/validator_detail_v42.hpp"
+#line 12766 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr820;
 	goto tr819;
@@ -12772,7 +12776,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12776 "inc/vcf/validator_detail_v42.hpp"
+#line 12780 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12789,7 +12793,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12793 "inc/vcf/validator_detail_v42.hpp"
+#line 12797 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr821;
 	if ( (*p) > 58 ) {
@@ -12808,7 +12812,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 12812 "inc/vcf/validator_detail_v42.hpp"
+#line 12816 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr823;
 		case 45: goto tr823;
@@ -12826,7 +12830,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 12830 "inc/vcf/validator_detail_v42.hpp"
+#line 12834 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr824;
 	goto tr822;
@@ -12840,7 +12844,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 12844 "inc/vcf/validator_detail_v42.hpp"
+#line 12848 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12863,7 +12867,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 12867 "inc/vcf/validator_detail_v42.hpp"
+#line 12871 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12884,7 +12888,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 12888 "inc/vcf/validator_detail_v42.hpp"
+#line 12892 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12905,7 +12909,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 12909 "inc/vcf/validator_detail_v42.hpp"
+#line 12913 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr827;
 	if ( (*p) > 58 ) {
@@ -12924,7 +12928,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 12928 "inc/vcf/validator_detail_v42.hpp"
+#line 12932 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr829;
 		case 45: goto tr829;
@@ -12942,7 +12946,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12946 "inc/vcf/validator_detail_v42.hpp"
+#line 12950 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr830;
 	goto tr828;
@@ -12956,7 +12960,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12960 "inc/vcf/validator_detail_v42.hpp"
+#line 12964 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -12979,7 +12983,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12983 "inc/vcf/validator_detail_v42.hpp"
+#line 12987 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13001,7 +13005,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13005 "inc/vcf/validator_detail_v42.hpp"
+#line 13009 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13021,7 +13025,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13025 "inc/vcf/validator_detail_v42.hpp"
+#line 13029 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr836;
 	goto tr835;
@@ -13035,7 +13039,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13039 "inc/vcf/validator_detail_v42.hpp"
+#line 13043 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13052,7 +13056,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13056 "inc/vcf/validator_detail_v42.hpp"
+#line 13060 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13072,7 +13076,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13076 "inc/vcf/validator_detail_v42.hpp"
+#line 13080 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr840;
 	goto tr839;
@@ -13086,7 +13090,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13090 "inc/vcf/validator_detail_v42.hpp"
+#line 13094 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13107,7 +13111,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13111 "inc/vcf/validator_detail_v42.hpp"
+#line 13115 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13128,7 +13132,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13132 "inc/vcf/validator_detail_v42.hpp"
+#line 13136 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 48: goto tr842;
 		case 61: goto tr843;
@@ -13149,7 +13153,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13153 "inc/vcf/validator_detail_v42.hpp"
+#line 13157 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr844;
 	if ( (*p) > 58 ) {
@@ -13168,7 +13172,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13172 "inc/vcf/validator_detail_v42.hpp"
+#line 13176 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr846;
 		case 45: goto tr846;
@@ -13186,7 +13190,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13190 "inc/vcf/validator_detail_v42.hpp"
+#line 13194 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr847;
 	goto tr845;
@@ -13200,7 +13204,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13204 "inc/vcf/validator_detail_v42.hpp"
+#line 13208 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13219,7 +13223,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13223 "inc/vcf/validator_detail_v42.hpp"
+#line 13227 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr849;
 		case 45: goto tr849;
@@ -13240,7 +13244,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13244 "inc/vcf/validator_detail_v42.hpp"
+#line 13248 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr850;
 		case 73: goto tr852;
@@ -13258,7 +13262,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13262 "inc/vcf/validator_detail_v42.hpp"
+#line 13266 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr854;
 	goto tr848;
@@ -13272,7 +13276,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13276 "inc/vcf/validator_detail_v42.hpp"
+#line 13280 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13293,7 +13297,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13297 "inc/vcf/validator_detail_v42.hpp"
+#line 13301 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr856;
 		case 45: goto tr856;
@@ -13311,7 +13315,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13315 "inc/vcf/validator_detail_v42.hpp"
+#line 13319 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr857;
 	goto tr848;
@@ -13325,7 +13329,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13329 "inc/vcf/validator_detail_v42.hpp"
+#line 13333 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13344,7 +13348,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13348 "inc/vcf/validator_detail_v42.hpp"
+#line 13352 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13366,7 +13370,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13370 "inc/vcf/validator_detail_v42.hpp"
+#line 13374 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr858;
 	goto tr848;
@@ -13380,7 +13384,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13384 "inc/vcf/validator_detail_v42.hpp"
+#line 13388 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr859;
 	goto tr848;
@@ -13394,7 +13398,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13398 "inc/vcf/validator_detail_v42.hpp"
+#line 13402 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13411,7 +13415,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13415 "inc/vcf/validator_detail_v42.hpp"
+#line 13419 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr860;
 	goto tr848;
@@ -13425,7 +13429,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13429 "inc/vcf/validator_detail_v42.hpp"
+#line 13433 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr859;
 	goto tr848;
@@ -13443,7 +13447,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13447 "inc/vcf/validator_detail_v42.hpp"
+#line 13451 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13464,7 +13468,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13468 "inc/vcf/validator_detail_v42.hpp"
+#line 13472 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr862;
 	if ( (*p) > 58 ) {
@@ -13483,7 +13487,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13487 "inc/vcf/validator_detail_v42.hpp"
+#line 13491 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr864;
 		case 45: goto tr864;
@@ -13501,7 +13505,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13505 "inc/vcf/validator_detail_v42.hpp"
+#line 13509 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr865;
 	goto tr863;
@@ -13515,7 +13519,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13519 "inc/vcf/validator_detail_v42.hpp"
+#line 13523 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13538,7 +13542,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13542 "inc/vcf/validator_detail_v42.hpp"
+#line 13546 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13560,7 +13564,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13564 "inc/vcf/validator_detail_v42.hpp"
+#line 13568 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr868;
 	if ( (*p) > 58 ) {
@@ -13579,7 +13583,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13583 "inc/vcf/validator_detail_v42.hpp"
+#line 13587 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr870;
 		case 45: goto tr870;
@@ -13600,7 +13604,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13604 "inc/vcf/validator_detail_v42.hpp"
+#line 13608 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr871;
 		case 73: goto tr873;
@@ -13618,7 +13622,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 13622 "inc/vcf/validator_detail_v42.hpp"
+#line 13626 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr875;
 	goto tr869;
@@ -13632,7 +13636,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 13636 "inc/vcf/validator_detail_v42.hpp"
+#line 13640 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13653,7 +13657,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 13657 "inc/vcf/validator_detail_v42.hpp"
+#line 13661 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr877;
 		case 45: goto tr877;
@@ -13671,7 +13675,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 13675 "inc/vcf/validator_detail_v42.hpp"
+#line 13679 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr878;
 	goto tr869;
@@ -13685,7 +13689,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 13689 "inc/vcf/validator_detail_v42.hpp"
+#line 13693 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13704,7 +13708,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 13708 "inc/vcf/validator_detail_v42.hpp"
+#line 13712 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13726,7 +13730,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 13730 "inc/vcf/validator_detail_v42.hpp"
+#line 13734 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr879;
 	goto tr869;
@@ -13740,7 +13744,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 13744 "inc/vcf/validator_detail_v42.hpp"
+#line 13748 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr880;
 	goto tr869;
@@ -13754,7 +13758,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13758 "inc/vcf/validator_detail_v42.hpp"
+#line 13762 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13771,7 +13775,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 13775 "inc/vcf/validator_detail_v42.hpp"
+#line 13779 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr881;
 	goto tr869;
@@ -13785,7 +13789,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 13789 "inc/vcf/validator_detail_v42.hpp"
+#line 13793 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr880;
 	goto tr869;
@@ -13799,7 +13803,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 13803 "inc/vcf/validator_detail_v42.hpp"
+#line 13807 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13820,7 +13824,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 13824 "inc/vcf/validator_detail_v42.hpp"
+#line 13828 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13841,7 +13845,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 13845 "inc/vcf/validator_detail_v42.hpp"
+#line 13849 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13862,7 +13866,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 13866 "inc/vcf/validator_detail_v42.hpp"
+#line 13870 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13883,7 +13887,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 13887 "inc/vcf/validator_detail_v42.hpp"
+#line 13891 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13904,7 +13908,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 13908 "inc/vcf/validator_detail_v42.hpp"
+#line 13912 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13924,7 +13928,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 13928 "inc/vcf/validator_detail_v42.hpp"
+#line 13932 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr890;
 	goto tr889;
@@ -13938,7 +13942,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 13942 "inc/vcf/validator_detail_v42.hpp"
+#line 13946 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13959,7 +13963,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 13963 "inc/vcf/validator_detail_v42.hpp"
+#line 13967 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -13980,7 +13984,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 13984 "inc/vcf/validator_detail_v42.hpp"
+#line 13988 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14001,7 +14005,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14005 "inc/vcf/validator_detail_v42.hpp"
+#line 14009 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14022,7 +14026,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14026 "inc/vcf/validator_detail_v42.hpp"
+#line 14030 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14043,7 +14047,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14047 "inc/vcf/validator_detail_v42.hpp"
+#line 14051 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14064,7 +14068,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14068 "inc/vcf/validator_detail_v42.hpp"
+#line 14072 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14085,7 +14089,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14089 "inc/vcf/validator_detail_v42.hpp"
+#line 14093 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14106,7 +14110,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14110 "inc/vcf/validator_detail_v42.hpp"
+#line 14114 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14127,7 +14131,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14131 "inc/vcf/validator_detail_v42.hpp"
+#line 14135 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14147,7 +14151,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14151 "inc/vcf/validator_detail_v42.hpp"
+#line 14155 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr902;
 	goto tr901;
@@ -14161,7 +14165,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14165 "inc/vcf/validator_detail_v42.hpp"
+#line 14169 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14182,7 +14186,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14186 "inc/vcf/validator_detail_v42.hpp"
+#line 14190 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr730;
 		case 10: goto tr731;
@@ -14220,7 +14224,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14224 "inc/vcf/validator_detail_v42.hpp"
+#line 14228 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr706;
 	if ( (*p) < 65 ) {
@@ -14258,7 +14262,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14262 "inc/vcf/validator_detail_v42.hpp"
+#line 14266 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr711;
 		case 58: goto st502;
@@ -14294,7 +14298,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14298 "inc/vcf/validator_detail_v42.hpp"
+#line 14302 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr903;
 		case 45: goto tr903;
@@ -14312,7 +14316,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14316 "inc/vcf/validator_detail_v42.hpp"
+#line 14320 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr904;
 	goto tr693;
@@ -14326,7 +14330,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14330 "inc/vcf/validator_detail_v42.hpp"
+#line 14334 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr703;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14352,7 +14356,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14356 "inc/vcf/validator_detail_v42.hpp"
+#line 14360 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr703;
 		case 46: goto tr699;
@@ -14382,7 +14386,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14386 "inc/vcf/validator_detail_v42.hpp"
+#line 14390 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr905;
 	goto tr693;
@@ -14396,7 +14400,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14400 "inc/vcf/validator_detail_v42.hpp"
+#line 14404 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr906;
 	goto tr693;
@@ -14410,7 +14414,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14414 "inc/vcf/validator_detail_v42.hpp"
+#line 14418 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr703;
 	goto tr693;
@@ -14428,7 +14432,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14432 "inc/vcf/validator_detail_v42.hpp"
+#line 14436 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr703;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14448,7 +14452,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14452 "inc/vcf/validator_detail_v42.hpp"
+#line 14456 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr907;
 	goto tr693;
@@ -14462,7 +14466,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14466 "inc/vcf/validator_detail_v42.hpp"
+#line 14470 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr906;
 	goto tr693;
@@ -14476,7 +14480,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14480 "inc/vcf/validator_detail_v42.hpp"
+#line 14484 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr685;
 		case 46: goto tr908;
@@ -14515,7 +14519,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14519 "inc/vcf/validator_detail_v42.hpp"
+#line 14523 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr909;
 		case 67: goto tr909;
@@ -14539,7 +14543,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14543 "inc/vcf/validator_detail_v42.hpp"
+#line 14547 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr691;
 		case 44: goto tr692;
@@ -14575,7 +14579,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14579 "inc/vcf/validator_detail_v42.hpp"
+#line 14583 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr911;
 		case 95: goto tr911;
@@ -14599,7 +14603,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14603 "inc/vcf/validator_detail_v42.hpp"
+#line 14607 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 62: goto tr912;
 		case 95: goto tr910;
@@ -14633,7 +14637,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14637 "inc/vcf/validator_detail_v42.hpp"
+#line 14641 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr691;
 		case 44: goto tr692;
@@ -14662,7 +14666,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 14666 "inc/vcf/validator_detail_v42.hpp"
+#line 14670 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr917;
 	if ( (*p) < 65 ) {
@@ -14684,7 +14688,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 14688 "inc/vcf/validator_detail_v42.hpp"
+#line 14692 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr920;
 		case 59: goto tr918;
@@ -14721,7 +14725,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 14725 "inc/vcf/validator_detail_v42.hpp"
+#line 14729 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr918;
 		case 61: goto tr918;
@@ -14757,7 +14761,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 14761 "inc/vcf/validator_detail_v42.hpp"
+#line 14765 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr920;
 		case 61: goto tr919;
@@ -14778,7 +14782,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 14782 "inc/vcf/validator_detail_v42.hpp"
+#line 14786 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr921;
 		case 45: goto tr921;
@@ -14796,7 +14800,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 14800 "inc/vcf/validator_detail_v42.hpp"
+#line 14804 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr922;
 	goto tr684;
@@ -14810,7 +14814,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 14814 "inc/vcf/validator_detail_v42.hpp"
+#line 14818 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr912;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14826,7 +14830,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 14830 "inc/vcf/validator_detail_v42.hpp"
+#line 14834 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr923;
@@ -14846,7 +14850,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 14850 "inc/vcf/validator_detail_v42.hpp"
+#line 14854 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr924;
 		case 62: goto tr926;
@@ -14882,7 +14886,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 14886 "inc/vcf/validator_detail_v42.hpp"
+#line 14890 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr924;
 		case 61: goto tr924;
@@ -14918,7 +14922,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 14922 "inc/vcf/validator_detail_v42.hpp"
+#line 14926 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr925;
 		case 62: goto tr926;
@@ -14939,7 +14943,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 14943 "inc/vcf/validator_detail_v42.hpp"
+#line 14947 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr920;
 	goto tr684;
@@ -14953,7 +14957,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 14957 "inc/vcf/validator_detail_v42.hpp"
+#line 14961 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr928;
 	if ( (*p) < 65 ) {
@@ -14975,7 +14979,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 14979 "inc/vcf/validator_detail_v42.hpp"
+#line 14983 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr931;
 		case 59: goto tr929;
@@ -15012,7 +15016,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15016 "inc/vcf/validator_detail_v42.hpp"
+#line 15020 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr929;
 		case 61: goto tr929;
@@ -15048,7 +15052,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15052 "inc/vcf/validator_detail_v42.hpp"
+#line 15056 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr931;
 		case 61: goto tr930;
@@ -15069,7 +15073,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15073 "inc/vcf/validator_detail_v42.hpp"
+#line 15077 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr932;
 		case 45: goto tr932;
@@ -15087,7 +15091,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15091 "inc/vcf/validator_detail_v42.hpp"
+#line 15095 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr684;
@@ -15101,7 +15105,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15105 "inc/vcf/validator_detail_v42.hpp"
+#line 15109 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr912;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15117,7 +15121,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15121 "inc/vcf/validator_detail_v42.hpp"
+#line 15125 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr934;
@@ -15137,7 +15141,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15141 "inc/vcf/validator_detail_v42.hpp"
+#line 15145 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr935;
 		case 62: goto tr937;
@@ -15173,7 +15177,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15177 "inc/vcf/validator_detail_v42.hpp"
+#line 15181 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr935;
 		case 61: goto tr935;
@@ -15209,7 +15213,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15213 "inc/vcf/validator_detail_v42.hpp"
+#line 15217 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr936;
 		case 62: goto tr937;
@@ -15230,7 +15234,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15234 "inc/vcf/validator_detail_v42.hpp"
+#line 15238 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr931;
 	goto tr684;
@@ -15248,7 +15252,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15252 "inc/vcf/validator_detail_v42.hpp"
+#line 15256 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr939;
 	if ( (*p) < 65 ) {
@@ -15270,7 +15274,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15274 "inc/vcf/validator_detail_v42.hpp"
+#line 15278 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr942;
 		case 59: goto tr940;
@@ -15307,7 +15311,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15311 "inc/vcf/validator_detail_v42.hpp"
+#line 15315 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr940;
 		case 61: goto tr940;
@@ -15343,7 +15347,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15347 "inc/vcf/validator_detail_v42.hpp"
+#line 15351 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr942;
 		case 61: goto tr941;
@@ -15364,7 +15368,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15368 "inc/vcf/validator_detail_v42.hpp"
+#line 15372 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr943;
 		case 45: goto tr943;
@@ -15382,7 +15386,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15386 "inc/vcf/validator_detail_v42.hpp"
+#line 15390 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr944;
 	goto tr684;
@@ -15396,7 +15400,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15400 "inc/vcf/validator_detail_v42.hpp"
+#line 15404 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr945;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15412,7 +15416,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15416 "inc/vcf/validator_detail_v42.hpp"
+#line 15420 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr946;
@@ -15432,7 +15436,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15436 "inc/vcf/validator_detail_v42.hpp"
+#line 15440 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr947;
 		case 62: goto tr949;
@@ -15468,7 +15472,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15472 "inc/vcf/validator_detail_v42.hpp"
+#line 15476 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr947;
 		case 61: goto tr947;
@@ -15504,7 +15508,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15508 "inc/vcf/validator_detail_v42.hpp"
+#line 15512 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr948;
 		case 62: goto tr949;
@@ -15525,7 +15529,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15529 "inc/vcf/validator_detail_v42.hpp"
+#line 15533 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr942;
 	goto tr684;
@@ -15543,7 +15547,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15547 "inc/vcf/validator_detail_v42.hpp"
+#line 15551 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr951;
 	if ( (*p) < 65 ) {
@@ -15565,7 +15569,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15569 "inc/vcf/validator_detail_v42.hpp"
+#line 15573 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr954;
 		case 59: goto tr952;
@@ -15602,7 +15606,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15606 "inc/vcf/validator_detail_v42.hpp"
+#line 15610 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr952;
 		case 61: goto tr952;
@@ -15638,7 +15642,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15642 "inc/vcf/validator_detail_v42.hpp"
+#line 15646 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr954;
 		case 61: goto tr953;
@@ -15659,7 +15663,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15663 "inc/vcf/validator_detail_v42.hpp"
+#line 15667 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr955;
 		case 45: goto tr955;
@@ -15677,7 +15681,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15681 "inc/vcf/validator_detail_v42.hpp"
+#line 15685 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr684;
@@ -15691,7 +15695,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15695 "inc/vcf/validator_detail_v42.hpp"
+#line 15699 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr945;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15707,7 +15711,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15711 "inc/vcf/validator_detail_v42.hpp"
+#line 15715 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr957;
@@ -15727,7 +15731,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15731 "inc/vcf/validator_detail_v42.hpp"
+#line 15735 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr958;
 		case 62: goto tr960;
@@ -15763,7 +15767,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15767 "inc/vcf/validator_detail_v42.hpp"
+#line 15771 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr958;
 		case 61: goto tr958;
@@ -15799,7 +15803,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15803 "inc/vcf/validator_detail_v42.hpp"
+#line 15807 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr959;
 		case 62: goto tr960;
@@ -15820,7 +15824,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15824 "inc/vcf/validator_detail_v42.hpp"
+#line 15828 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr954;
 	goto tr684;
@@ -15838,7 +15842,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 15842 "inc/vcf/validator_detail_v42.hpp"
+#line 15846 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr691;
 		case 65: goto tr909;
@@ -15863,7 +15867,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 15867 "inc/vcf/validator_detail_v42.hpp"
+#line 15871 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr668;
 		case 61: goto tr668;
@@ -15899,7 +15903,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 15903 "inc/vcf/validator_detail_v42.hpp"
+#line 15907 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr667;
 		case 59: goto tr669;
@@ -15929,14 +15933,14 @@ tr962:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 740 "src/vcf/vcf_v42.ragel"
+#line 744 "src/vcf/vcf_v42.ragel"
 	{ {goto st28;} }
 	goto st732;
 st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 15940 "inc/vcf/validator_detail_v42.hpp"
+#line 15944 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 st729:
 	if ( ++p == pe )
@@ -15956,14 +15960,14 @@ tr964:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 741 "src/vcf/vcf_v42.ragel"
+#line 745 "src/vcf/vcf_v42.ragel"
 	{ {goto st731;} }
 	goto st733;
 st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 15967 "inc/vcf/validator_detail_v42.hpp"
+#line 15971 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -16780,8 +16784,8 @@ case 733:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 	break;
@@ -16801,8 +16805,8 @@ case 733:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -16816,7 +16820,7 @@ case 733:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 210 "src/vcf/vcf_v42.ragel"
+#line 214 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_fileformat_section_error(*this,
             "The fileformat declaration is not 'fileformat=VCFv4.2'");
@@ -16850,7 +16854,7 @@ case 733:
 	case 94: 
 	case 101: 
 	case 112: 
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -16869,7 +16873,7 @@ case 733:
 	case 379: 
 	case 380: 
 	case 381: 
-#line 228 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st728;}
@@ -16909,7 +16913,7 @@ case 733:
 	case 419: 
 	case 420: 
 	case 421: 
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 238 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st728;}
@@ -16944,7 +16948,7 @@ case 733:
 	case 146: 
 	case 153: 
 	case 164: 
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -16991,7 +16995,7 @@ case 733:
 	case 212: 
 	case 219: 
 	case 230: 
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -17037,7 +17041,7 @@ case 733:
 	case 278: 
 	case 285: 
 	case 296: 
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -17058,7 +17062,7 @@ case 733:
 	case 312: 
 	case 313: 
 	case 320: 
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 282 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st728;}
@@ -17080,7 +17084,7 @@ case 733:
 	case 430: 
 	case 431: 
 	case 432: 
-#line 284 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st728;}
@@ -17102,7 +17106,7 @@ case 733:
 	case 329: 
 	case 330: 
 	case 370: 
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -17150,15 +17154,15 @@ case 733:
 	case 475: 
 	case 476: 
 	case 477: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 326 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -17170,8 +17174,8 @@ case 733:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -17185,7 +17189,7 @@ case 733:
 	case 515: 
 	case 726: 
 	case 727: 
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 342 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st729;}
@@ -17199,7 +17203,7 @@ case 733:
 	case 488: 
 	case 489: 
 	case 490: 
-#line 344 "src/vcf/vcf_v42.ragel"
+#line 348 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
         p--; {goto st729;}
@@ -17212,7 +17216,7 @@ case 733:
 	break;
 	case 491: 
 	case 492: 
-#line 350 "src/vcf/vcf_v42.ragel"
+#line 354 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
         p--; {goto st729;}
@@ -17225,7 +17229,7 @@ case 733:
 	break;
 	case 493: 
 	case 494: 
-#line 356 "src/vcf/vcf_v42.ragel"
+#line 360 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
         p--; {goto st729;}
@@ -17293,7 +17297,7 @@ case 733:
 	case 723: 
 	case 724: 
 	case 725: 
-#line 362 "src/vcf/vcf_v42.ragel"
+#line 366 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
         p--; {goto st729;}
@@ -17318,7 +17322,7 @@ case 733:
 	case 668: 
 	case 669: 
 	case 670: 
-#line 368 "src/vcf/vcf_v42.ragel"
+#line 372 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
         p--; {goto st729;}
@@ -17334,7 +17338,7 @@ case 733:
 	case 503: 
 	case 659: 
 	case 660: 
-#line 374 "src/vcf/vcf_v42.ragel"
+#line 378 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
         p--; {goto st729;}
@@ -17347,7 +17351,7 @@ case 733:
 	break;
 	case 507: 
 	case 508: 
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 490 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
         p--; {goto st729;}
@@ -17360,7 +17364,7 @@ case 733:
 	break;
 	case 518: 
 	case 519: 
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 496 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -17380,15 +17384,15 @@ case 733:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st728;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 326 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -17400,8 +17404,8 @@ case 733:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -17410,12 +17414,12 @@ case 733:
 	case 80: 
 	case 81: 
 	case 120: 
-#line 222 "src/vcf/vcf_v42.ragel"
+#line 226 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -17427,12 +17431,12 @@ case 733:
     }
 	break;
 	case 121: 
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -17446,12 +17450,12 @@ case 733:
 	case 191: 
 	case 192: 
 	case 238: 
-#line 251 "src/vcf/vcf_v42.ragel"
+#line 255 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -17465,12 +17469,12 @@ case 733:
 	case 257: 
 	case 258: 
 	case 304: 
-#line 267 "src/vcf/vcf_v42.ragel"
+#line 271 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -17483,12 +17487,12 @@ case 733:
 	break;
 	case 198: 
 	case 199: 
-#line 272 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -17501,12 +17505,12 @@ case 733:
 	break;
 	case 264: 
 	case 265: 
-#line 272 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -17526,12 +17530,12 @@ case 733:
 	case 340: 
 	case 341: 
 	case 342: 
-#line 295 "src/vcf/vcf_v42.ragel"
+#line 299 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -17551,12 +17555,12 @@ case 733:
 	case 350: 
 	case 351: 
 	case 352: 
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -17570,12 +17574,12 @@ case 733:
 	case 98: 
 	case 99: 
 	case 100: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -17590,12 +17594,12 @@ case 733:
 	case 400: 
 	case 401: 
 	case 402: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 238 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st728;}
@@ -17612,12 +17616,12 @@ case 733:
 	case 150: 
 	case 151: 
 	case 152: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -17634,12 +17638,12 @@ case 733:
 	case 216: 
 	case 217: 
 	case 218: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -17656,12 +17660,12 @@ case 733:
 	case 282: 
 	case 283: 
 	case 284: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -17678,12 +17682,12 @@ case 733:
 	case 317: 
 	case 318: 
 	case 319: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 282 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st728;}
@@ -17696,12 +17700,12 @@ case 733:
 	break;
 	case 331: 
 	case 332: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -17726,12 +17730,12 @@ case 733:
 	case 114: 
 	case 118: 
 	case 119: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -17756,12 +17760,12 @@ case 733:
 	case 166: 
 	case 170: 
 	case 171: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -17786,12 +17790,12 @@ case 733:
 	case 232: 
 	case 236: 
 	case 237: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -17816,12 +17820,12 @@ case 733:
 	case 298: 
 	case 302: 
 	case 303: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -17851,12 +17855,12 @@ case 733:
 	case 371: 
 	case 372: 
 	case 373: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -17874,12 +17878,12 @@ case 733:
 	case 386: 
 	case 387: 
 	case 388: 
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st728;}
     }
-#line 228 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st728;}
@@ -17898,12 +17902,12 @@ case 733:
 	case 438: 
 	case 439: 
 	case 440: 
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st728;}
     }
-#line 284 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st728;}
@@ -17961,12 +17965,12 @@ case 733:
 	case 653: 
 	case 654: 
 	case 658: 
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -17979,12 +17983,12 @@ case 733:
 	break;
 	case 525: 
 	case 526: 
-#line 390 "src/vcf/vcf_v42.ragel"
+#line 394 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -17998,12 +18002,12 @@ case 733:
 	case 532: 
 	case 533: 
 	case 534: 
-#line 395 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18017,12 +18021,12 @@ case 733:
 	case 536: 
 	case 537: 
 	case 538: 
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18046,12 +18050,12 @@ case 733:
 	case 550: 
 	case 551: 
 	case 552: 
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 409 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18065,12 +18069,12 @@ case 733:
 	case 554: 
 	case 555: 
 	case 556: 
-#line 410 "src/vcf/vcf_v42.ragel"
+#line 414 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18094,12 +18098,12 @@ case 733:
 	case 569: 
 	case 570: 
 	case 571: 
-#line 415 "src/vcf/vcf_v42.ragel"
+#line 419 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18112,12 +18116,12 @@ case 733:
 	break;
 	case 577: 
 	case 578: 
-#line 420 "src/vcf/vcf_v42.ragel"
+#line 424 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18130,12 +18134,12 @@ case 733:
 	break;
 	case 581: 
 	case 582: 
-#line 425 "src/vcf/vcf_v42.ragel"
+#line 429 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18149,12 +18153,12 @@ case 733:
 	case 584: 
 	case 585: 
 	case 586: 
-#line 430 "src/vcf/vcf_v42.ragel"
+#line 434 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18168,12 +18172,12 @@ case 733:
 	case 590: 
 	case 591: 
 	case 592: 
-#line 435 "src/vcf/vcf_v42.ragel"
+#line 439 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18186,12 +18190,12 @@ case 733:
 	break;
 	case 595: 
 	case 596: 
-#line 440 "src/vcf/vcf_v42.ragel"
+#line 444 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18204,12 +18208,12 @@ case 733:
 	break;
 	case 598: 
 	case 599: 
-#line 445 "src/vcf/vcf_v42.ragel"
+#line 449 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18233,12 +18237,12 @@ case 733:
 	case 616: 
 	case 617: 
 	case 618: 
-#line 450 "src/vcf/vcf_v42.ragel"
+#line 454 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18252,12 +18256,12 @@ case 733:
 	case 603: 
 	case 604: 
 	case 605: 
-#line 455 "src/vcf/vcf_v42.ragel"
+#line 459 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18271,12 +18275,12 @@ case 733:
 	case 621: 
 	case 622: 
 	case 623: 
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 464 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18300,12 +18304,12 @@ case 733:
 	case 636: 
 	case 637: 
 	case 638: 
-#line 465 "src/vcf/vcf_v42.ragel"
+#line 469 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18318,12 +18322,12 @@ case 733:
 	break;
 	case 645: 
 	case 646: 
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 474 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18336,12 +18340,12 @@ case 733:
 	break;
 	case 656: 
 	case 657: 
-#line 475 "src/vcf/vcf_v42.ragel"
+#line 479 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18354,12 +18358,12 @@ case 733:
 	break;
 	case 528: 
 	case 529: 
-#line 480 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18374,14 +18378,14 @@ case 733:
 	case 510: 
 	case 516: 
 	case 517: 
-#line 499 "src/vcf/vcf_v42.ragel"
+#line 503 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_body_section_error(*this, message_stream.str());
         p--; {goto st729;}
     }
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 496 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -18405,15 +18409,15 @@ case 733:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st728;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 326 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
@@ -18425,25 +18429,25 @@ case 733:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st729;}
     }
 	break;
 	case 343: 
-#line 295 "src/vcf/vcf_v42.ragel"
+#line 299 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -18455,17 +18459,17 @@ case 733:
     }
 	break;
 	case 353: 
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -18477,17 +18481,17 @@ case 733:
     }
 	break;
 	case 333: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 295 "src/vcf/vcf_v42.ragel"
+#line 299 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
@@ -18501,17 +18505,17 @@ case 733:
 	case 106: 
 	case 107: 
 	case 108: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -18525,17 +18529,17 @@ case 733:
 	case 158: 
 	case 159: 
 	case 160: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -18549,17 +18553,17 @@ case 733:
 	case 224: 
 	case 225: 
 	case 226: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -18573,17 +18577,17 @@ case 733:
 	case 290: 
 	case 291: 
 	case 292: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -18597,17 +18601,17 @@ case 733:
 	case 115: 
 	case 116: 
 	case 117: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
@@ -18621,17 +18625,17 @@ case 733:
 	case 167: 
 	case 168: 
 	case 169: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
@@ -18645,17 +18649,17 @@ case 733:
 	case 233: 
 	case 234: 
 	case 235: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
@@ -18669,17 +18673,17 @@ case 733:
 	case 299: 
 	case 300: 
 	case 301: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 315 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st728;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 310 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
@@ -18691,17 +18695,17 @@ case 733:
     }
 	break;
 	case 580: 
-#line 425 "src/vcf/vcf_v42.ragel"
+#line 429 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18713,17 +18717,17 @@ case 733:
     }
 	break;
 	case 594: 
-#line 440 "src/vcf/vcf_v42.ragel"
+#line 444 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18735,17 +18739,17 @@ case 733:
     }
 	break;
 	case 597: 
-#line 445 "src/vcf/vcf_v42.ragel"
+#line 449 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18757,17 +18761,17 @@ case 733:
     }
 	break;
 	case 644: 
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 474 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18779,17 +18783,17 @@ case 733:
     }
 	break;
 	case 655: 
-#line 475 "src/vcf/vcf_v42.ragel"
+#line 479 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18801,17 +18805,17 @@ case 733:
     }
 	break;
 	case 527: 
-#line 480 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st729;}
     }
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st729;}
     }
-#line 380 "src/vcf/vcf_v42.ragel"
+#line 384 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st729;}
@@ -18823,47 +18827,47 @@ case 733:
     }
 	break;
 	case 24: 
-#line 217 "src/vcf/vcf_v42.ragel"
+#line 221 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st728;}
     }
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st728;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st728;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 266 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st728;}
     }
-#line 228 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st728;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 238 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st728;}
     }
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st728;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 282 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st728;}
     }
-#line 284 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st728;}
@@ -18874,14 +18878,14 @@ case 733:
         p--; {goto st728;}
     }
 	break;
-#line 18878 "inc/vcf/validator_detail_v42.hpp"
+#line 18882 "inc/vcf/validator_detail_v42.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 772 "src/vcf/vcf_v42.ragel"
+#line 776 "src/vcf/vcf_v42.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 771 "src/vcf/vcf_v43.ragel"
+#line 775 "src/vcf/vcf_v43.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v43_en_meta_section_skip = 756;
 static const int vcf_v43_en_body_section_skip = 757;
 
 
-#line 777 "src/vcf/vcf_v43.ragel"
+#line 781 "src/vcf/vcf_v43.ragel"
 
 }
 
@@ -60,7 +60,7 @@ namespace ebi
 	cs = vcf_v43_start;
 	}
 
-#line 793 "src/vcf/vcf_v43.ragel"
+#line 797 "src/vcf/vcf_v43.ragel"
 
     }
 
@@ -86,7 +86,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 210 "src/vcf/vcf_v43.ragel"
+#line 214 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_fileformat_section_error(*this,
             "The fileformat declaration is not 'fileformat=VCFv4.3'");
@@ -109,15 +109,15 @@ tr24:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st756;}
     }
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 326 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -129,8 +129,8 @@ tr24:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -142,15 +142,15 @@ tr26:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st756;}
     }
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 326 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -162,55 +162,55 @@ tr26:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
     }
 	goto st0;
 tr29:
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
     }
-#line 228 "src/vcf/vcf_v43.ragel"
+#line 232 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st756;}
     }
-#line 234 "src/vcf/vcf_v43.ragel"
+#line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
     }
-#line 278 "src/vcf/vcf_v43.ragel"
+#line 282 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st756;}
     }
-#line 284 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st756;}
@@ -229,7 +229,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -241,12 +241,12 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 222 "src/vcf/vcf_v43.ragel"
+#line 226 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -258,12 +258,12 @@ tr133:
     }
 	goto st0;
 tr151:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -275,12 +275,12 @@ tr151:
     }
 	goto st0;
 tr160:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -292,17 +292,17 @@ tr160:
     }
 	goto st0;
 tr174:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -314,17 +314,17 @@ tr174:
     }
 	goto st0;
 tr186:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -336,12 +336,12 @@ tr186:
     }
 	goto st0;
 tr193:
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -353,7 +353,7 @@ tr193:
     }
 	goto st0;
 tr196:
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -365,12 +365,12 @@ tr196:
     }
 	goto st0;
 tr206:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -382,12 +382,12 @@ tr206:
     }
 	goto st0;
 tr225:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -399,17 +399,17 @@ tr225:
     }
 	goto st0;
 tr247:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -421,17 +421,17 @@ tr247:
     }
 	goto st0;
 tr259:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -443,7 +443,7 @@ tr259:
     }
 	goto st0;
 tr265:
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -455,12 +455,12 @@ tr265:
     }
 	goto st0;
 tr275:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -472,12 +472,12 @@ tr275:
     }
 	goto st0;
 tr288:
-#line 251 "src/vcf/vcf_v43.ragel"
+#line 255 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -489,12 +489,12 @@ tr288:
     }
 	goto st0;
 tr297:
-#line 272 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -506,12 +506,12 @@ tr297:
     }
 	goto st0;
 tr314:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -523,17 +523,17 @@ tr314:
     }
 	goto st0;
 tr336:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -545,17 +545,17 @@ tr336:
     }
 	goto st0;
 tr348:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -567,7 +567,7 @@ tr348:
     }
 	goto st0;
 tr355:
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -579,12 +579,12 @@ tr355:
     }
 	goto st0;
 tr364:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -596,12 +596,12 @@ tr364:
     }
 	goto st0;
 tr377:
-#line 267 "src/vcf/vcf_v43.ragel"
+#line 271 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -613,12 +613,12 @@ tr377:
     }
 	goto st0;
 tr386:
-#line 272 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -630,12 +630,12 @@ tr386:
     }
 	goto st0;
 tr403:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -647,17 +647,17 @@ tr403:
     }
 	goto st0;
 tr425:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -669,17 +669,17 @@ tr425:
     }
 	goto st0;
 tr437:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -691,7 +691,7 @@ tr437:
     }
 	goto st0;
 tr444:
-#line 278 "src/vcf/vcf_v43.ragel"
+#line 282 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st756;}
@@ -703,12 +703,12 @@ tr444:
     }
 	goto st0;
 tr454:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 278 "src/vcf/vcf_v43.ragel"
+#line 282 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st756;}
@@ -720,7 +720,7 @@ tr454:
     }
 	goto st0;
 tr466:
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -732,12 +732,12 @@ tr466:
     }
 	goto st0;
 tr477:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -749,17 +749,17 @@ tr477:
     }
 	goto st0;
 tr482:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 299 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -771,12 +771,12 @@ tr482:
     }
 	goto st0;
 tr484:
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 299 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -788,17 +788,17 @@ tr484:
     }
 	goto st0;
 tr494:
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 299 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -810,12 +810,12 @@ tr494:
     }
 	goto st0;
 tr497:
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -827,17 +827,17 @@ tr497:
     }
 	goto st0;
 tr507:
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -849,12 +849,12 @@ tr507:
     }
 	goto st0;
 tr510:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -866,7 +866,7 @@ tr510:
     }
 	goto st0;
 tr533:
-#line 228 "src/vcf/vcf_v43.ragel"
+#line 232 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st756;}
@@ -878,12 +878,12 @@ tr533:
     }
 	goto st0;
 tr542:
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 320 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st756;}
     }
-#line 228 "src/vcf/vcf_v43.ragel"
+#line 232 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st756;}
@@ -895,7 +895,7 @@ tr542:
     }
 	goto st0;
 tr550:
-#line 234 "src/vcf/vcf_v43.ragel"
+#line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st756;}
@@ -907,12 +907,12 @@ tr550:
     }
 	goto st0;
 tr561:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 234 "src/vcf/vcf_v43.ragel"
+#line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st756;}
@@ -924,7 +924,7 @@ tr561:
     }
 	goto st0;
 tr629:
-#line 284 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st756;}
@@ -936,12 +936,12 @@ tr629:
     }
 	goto st0;
 tr641:
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 320 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st756;}
     }
-#line 284 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st756;}
@@ -953,15 +953,15 @@ tr641:
     }
 	goto st0;
 tr650:
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 326 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -973,8 +973,8 @@ tr650:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -988,15 +988,15 @@ tr690:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
     }
 	goto st0;
 tr703:
-#line 338 "src/vcf/vcf_v43.ragel"
+#line 342 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st757;}
@@ -1008,7 +1008,7 @@ tr703:
     }
 	goto st0;
 tr707:
-#line 344 "src/vcf/vcf_v43.ragel"
+#line 348 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
         p--; {goto st757;}
@@ -1020,7 +1020,7 @@ tr707:
     }
 	goto st0;
 tr712:
-#line 350 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
         p--; {goto st757;}
@@ -1032,7 +1032,7 @@ tr712:
     }
 	goto st0;
 tr717:
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
         p--; {goto st757;}
@@ -1044,7 +1044,7 @@ tr717:
     }
 	goto st0;
 tr721:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
         p--; {goto st757;}
@@ -1056,7 +1056,7 @@ tr721:
     }
 	goto st0;
 tr730:
-#line 368 "src/vcf/vcf_v43.ragel"
+#line 372 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
         p--; {goto st757;}
@@ -1068,7 +1068,7 @@ tr730:
     }
 	goto st0;
 tr742:
-#line 374 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
         p--; {goto st757;}
@@ -1080,12 +1080,12 @@ tr742:
     }
 	goto st0;
 tr750:
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1097,7 +1097,7 @@ tr750:
     }
 	goto st0;
 tr764:
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1109,7 +1109,7 @@ tr764:
     }
 	goto st0;
 tr768:
-#line 501 "src/vcf/vcf_v43.ragel"
+#line 505 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
         p--; {goto st757;}
@@ -1121,14 +1121,14 @@ tr768:
     }
 	goto st0;
 tr773:
-#line 514 "src/vcf/vcf_v43.ragel"
+#line 518 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_body_section_error(*this, message_stream.str());
         p--; {goto st757;}
     }
-#line 507 "src/vcf/vcf_v43.ragel"
+#line 511 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1149,7 +1149,7 @@ tr783:
     }
 	goto st0;
 tr787:
-#line 507 "src/vcf/vcf_v43.ragel"
+#line 511 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1163,12 +1163,12 @@ tr787:
     }
 	goto st0;
 tr796:
-#line 390 "src/vcf/vcf_v43.ragel"
+#line 394 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1180,17 +1180,17 @@ tr796:
     }
 	goto st0;
 tr798:
-#line 495 "src/vcf/vcf_v43.ragel"
+#line 499 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1202,12 +1202,12 @@ tr798:
     }
 	goto st0;
 tr800:
-#line 495 "src/vcf/vcf_v43.ragel"
+#line 499 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1219,12 +1219,12 @@ tr800:
     }
 	goto st0;
 tr808:
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 399 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1236,12 +1236,12 @@ tr808:
     }
 	goto st0;
 tr812:
-#line 400 "src/vcf/vcf_v43.ragel"
+#line 404 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1253,12 +1253,12 @@ tr812:
     }
 	goto st0;
 tr818:
-#line 405 "src/vcf/vcf_v43.ragel"
+#line 409 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AD value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1270,12 +1270,12 @@ tr818:
     }
 	goto st0;
 tr822:
-#line 410 "src/vcf/vcf_v43.ragel"
+#line 414 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info ADF value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1287,12 +1287,12 @@ tr822:
     }
 	goto st0;
 tr826:
-#line 415 "src/vcf/vcf_v43.ragel"
+#line 419 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info ADR value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1304,12 +1304,12 @@ tr826:
     }
 	goto st0;
 tr830:
-#line 420 "src/vcf/vcf_v43.ragel"
+#line 424 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1321,12 +1321,12 @@ tr830:
     }
 	goto st0;
 tr844:
-#line 425 "src/vcf/vcf_v43.ragel"
+#line 429 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1338,12 +1338,12 @@ tr844:
     }
 	goto st0;
 tr849:
-#line 430 "src/vcf/vcf_v43.ragel"
+#line 434 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1355,12 +1355,12 @@ tr849:
     }
 	goto st0;
 tr867:
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 439 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1372,17 +1372,17 @@ tr867:
     }
 	goto st0;
 tr871:
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 444 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1394,12 +1394,12 @@ tr871:
     }
 	goto st0;
 tr873:
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 444 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1411,12 +1411,12 @@ tr873:
     }
 	goto st0;
 tr876:
-#line 445 "src/vcf/vcf_v43.ragel"
+#line 449 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1428,12 +1428,12 @@ tr876:
     }
 	goto st0;
 tr882:
-#line 450 "src/vcf/vcf_v43.ragel"
+#line 454 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1445,17 +1445,17 @@ tr882:
     }
 	goto st0;
 tr887:
-#line 455 "src/vcf/vcf_v43.ragel"
+#line 459 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1467,12 +1467,12 @@ tr887:
     }
 	goto st0;
 tr889:
-#line 455 "src/vcf/vcf_v43.ragel"
+#line 459 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1484,17 +1484,17 @@ tr889:
     }
 	goto st0;
 tr891:
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 464 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1506,12 +1506,12 @@ tr891:
     }
 	goto st0;
 tr893:
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 464 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1523,12 +1523,12 @@ tr893:
     }
 	goto st0;
 tr899:
-#line 470 "src/vcf/vcf_v43.ragel"
+#line 474 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1540,12 +1540,12 @@ tr899:
     }
 	goto st0;
 tr902:
-#line 465 "src/vcf/vcf_v43.ragel"
+#line 469 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1557,12 +1557,12 @@ tr902:
     }
 	goto st0;
 tr917:
-#line 475 "src/vcf/vcf_v43.ragel"
+#line 479 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1574,12 +1574,12 @@ tr917:
     }
 	goto st0;
 tr923:
-#line 480 "src/vcf/vcf_v43.ragel"
+#line 484 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1591,17 +1591,17 @@ tr923:
     }
 	goto st0;
 tr941:
-#line 485 "src/vcf/vcf_v43.ragel"
+#line 489 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1613,12 +1613,12 @@ tr941:
     }
 	goto st0;
 tr943:
-#line 485 "src/vcf/vcf_v43.ragel"
+#line 489 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1630,17 +1630,17 @@ tr943:
     }
 	goto st0;
 tr953:
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 494 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1652,12 +1652,12 @@ tr953:
     }
 	goto st0;
 tr955:
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 494 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -1676,13 +1676,13 @@ tr1023:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
     }
-#line 338 "src/vcf/vcf_v43.ragel"
+#line 342 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st757;}
@@ -2026,8 +2026,8 @@ tr45:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -2046,8 +2046,8 @@ tr55:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -2078,8 +2078,8 @@ tr46:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -2098,8 +2098,8 @@ tr56:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -9160,8 +9160,8 @@ tr549:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -10909,8 +10909,8 @@ tr649:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -11355,8 +11355,8 @@ tr1024:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 #line 31 "src/vcf/vcf_v43.ragel"
@@ -12055,12 +12055,16 @@ tr766:
         try {
           // Handle all columns and build record
           ParsePolicy::handle_body_line(*this);
+            try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_body_section_error(*this, ex.what());
-        } catch (ParsingWarning ex) {
-          ErrorPolicy::handle_body_section_warning(*this, ex.what());
+            } catch (MetaSectionError &ex) {
+                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
+            } catch (BodySectionError &ex) {
+                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            }
+        } catch (BodySectionError ex) {
+            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -12078,7 +12082,7 @@ st759:
 	if ( ++p == pe )
 		goto _test_eof759;
 case 759:
-#line 12082 "inc/vcf/validator_detail_v43.hpp"
+#line 12086 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st524;
 	if ( (*p) < 65 ) {
@@ -12095,8 +12099,8 @@ tr1025:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 	goto st524;
@@ -12104,7 +12108,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 12108 "inc/vcf/validator_detail_v43.hpp"
+#line 12112 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr778;
@@ -12128,7 +12132,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 12132 "inc/vcf/validator_detail_v43.hpp"
+#line 12136 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr779;
 		case 62: goto tr781;
@@ -12164,7 +12168,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 12168 "inc/vcf/validator_detail_v43.hpp"
+#line 12172 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr779;
 		case 61: goto tr779;
@@ -12200,7 +12204,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 12204 "inc/vcf/validator_detail_v43.hpp"
+#line 12208 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr780;
 		case 62: goto tr781;
@@ -12221,7 +12225,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 12225 "inc/vcf/validator_detail_v43.hpp"
+#line 12229 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr782;
 	goto tr703;
@@ -12239,12 +12243,16 @@ tr767:
         try {
           // Handle all columns and build record
           ParsePolicy::handle_body_line(*this);
+            try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_body_section_error(*this, ex.what());
-        } catch (ParsingWarning ex) {
-          ErrorPolicy::handle_body_section_warning(*this, ex.what());
+            } catch (MetaSectionError &ex) {
+                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
+            } catch (BodySectionError &ex) {
+                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            }
+        } catch (BodySectionError ex) {
+            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -12262,7 +12270,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 12266 "inc/vcf/validator_detail_v43.hpp"
+#line 12274 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st759;
 	goto tr783;
@@ -12276,7 +12284,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 12280 "inc/vcf/validator_detail_v43.hpp"
+#line 12288 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr785;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12302,7 +12310,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 12306 "inc/vcf/validator_detail_v43.hpp"
+#line 12314 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr766;
@@ -12324,7 +12332,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 12328 "inc/vcf/validator_detail_v43.hpp"
+#line 12336 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr788;
@@ -12341,7 +12349,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 12345 "inc/vcf/validator_detail_v43.hpp"
+#line 12353 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr766;
@@ -12371,7 +12379,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 12375 "inc/vcf/validator_detail_v43.hpp"
+#line 12383 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12400,7 +12408,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 12404 "inc/vcf/validator_detail_v43.hpp"
+#line 12412 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 49: goto tr753;
 		case 65: goto tr754;
@@ -12438,7 +12446,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12442 "inc/vcf/validator_detail_v43.hpp"
+#line 12450 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12468,7 +12476,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12472 "inc/vcf/validator_detail_v43.hpp"
+#line 12480 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12498,7 +12506,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12502 "inc/vcf/validator_detail_v43.hpp"
+#line 12510 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12528,7 +12536,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12532 "inc/vcf/validator_detail_v43.hpp"
+#line 12540 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12558,7 +12566,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12562 "inc/vcf/validator_detail_v43.hpp"
+#line 12570 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr797;
@@ -12575,7 +12583,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12579 "inc/vcf/validator_detail_v43.hpp"
+#line 12587 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12595,7 +12603,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12599 "inc/vcf/validator_detail_v43.hpp"
+#line 12607 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12624,7 +12632,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12628 "inc/vcf/validator_detail_v43.hpp"
+#line 12636 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr801;
 	goto tr800;
@@ -12638,7 +12646,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12642 "inc/vcf/validator_detail_v43.hpp"
+#line 12650 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12660,7 +12668,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12664 "inc/vcf/validator_detail_v43.hpp"
+#line 12672 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12694,7 +12702,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12698 "inc/vcf/validator_detail_v43.hpp"
+#line 12706 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr807;
@@ -12719,7 +12727,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12723 "inc/vcf/validator_detail_v43.hpp"
+#line 12731 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr810;
 		case 67: goto tr810;
@@ -12745,7 +12753,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12749 "inc/vcf/validator_detail_v43.hpp"
+#line 12757 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12763,7 +12771,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12767 "inc/vcf/validator_detail_v43.hpp"
+#line 12775 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12791,7 +12799,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12795 "inc/vcf/validator_detail_v43.hpp"
+#line 12803 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr811;
@@ -12816,7 +12824,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12820 "inc/vcf/validator_detail_v43.hpp"
+#line 12828 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr813;
 		case 45: goto tr813;
@@ -12834,7 +12842,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12838 "inc/vcf/validator_detail_v43.hpp"
+#line 12846 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr814;
 	goto tr812;
@@ -12848,7 +12856,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12852 "inc/vcf/validator_detail_v43.hpp"
+#line 12860 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12869,7 +12877,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12873 "inc/vcf/validator_detail_v43.hpp"
+#line 12881 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr815;
@@ -12896,7 +12904,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12900 "inc/vcf/validator_detail_v43.hpp"
+#line 12908 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr819;
 		case 45: goto tr819;
@@ -12914,7 +12922,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12918 "inc/vcf/validator_detail_v43.hpp"
+#line 12926 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr820;
 	goto tr818;
@@ -12928,7 +12936,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12932 "inc/vcf/validator_detail_v43.hpp"
+#line 12940 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12949,7 +12957,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12953 "inc/vcf/validator_detail_v43.hpp"
+#line 12961 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr821;
@@ -12974,7 +12982,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12978 "inc/vcf/validator_detail_v43.hpp"
+#line 12986 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr823;
 		case 45: goto tr823;
@@ -12992,7 +13000,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12996 "inc/vcf/validator_detail_v43.hpp"
+#line 13004 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr824;
 	goto tr822;
@@ -13006,7 +13014,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 13010 "inc/vcf/validator_detail_v43.hpp"
+#line 13018 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13027,7 +13035,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 13031 "inc/vcf/validator_detail_v43.hpp"
+#line 13039 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr825;
@@ -13052,7 +13060,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 13056 "inc/vcf/validator_detail_v43.hpp"
+#line 13064 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr827;
 		case 45: goto tr827;
@@ -13070,7 +13078,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 13074 "inc/vcf/validator_detail_v43.hpp"
+#line 13082 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr828;
 	goto tr826;
@@ -13084,7 +13092,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 13088 "inc/vcf/validator_detail_v43.hpp"
+#line 13096 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13105,7 +13113,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 13109 "inc/vcf/validator_detail_v43.hpp"
+#line 13117 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr829;
@@ -13130,7 +13138,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 13134 "inc/vcf/validator_detail_v43.hpp"
+#line 13142 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr831;
 		case 45: goto tr831;
@@ -13151,7 +13159,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 13155 "inc/vcf/validator_detail_v43.hpp"
+#line 13163 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr832;
 		case 73: goto tr834;
@@ -13169,7 +13177,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 13173 "inc/vcf/validator_detail_v43.hpp"
+#line 13181 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr836;
 	goto tr830;
@@ -13183,7 +13191,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 13187 "inc/vcf/validator_detail_v43.hpp"
+#line 13195 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13206,7 +13214,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 13210 "inc/vcf/validator_detail_v43.hpp"
+#line 13218 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr838;
 		case 45: goto tr838;
@@ -13224,7 +13232,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 13228 "inc/vcf/validator_detail_v43.hpp"
+#line 13236 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr839;
 	goto tr830;
@@ -13238,7 +13246,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 13242 "inc/vcf/validator_detail_v43.hpp"
+#line 13250 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13259,7 +13267,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 13263 "inc/vcf/validator_detail_v43.hpp"
+#line 13271 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13283,7 +13291,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 13287 "inc/vcf/validator_detail_v43.hpp"
+#line 13295 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr840;
 	goto tr830;
@@ -13297,7 +13305,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 13301 "inc/vcf/validator_detail_v43.hpp"
+#line 13309 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr841;
 	goto tr830;
@@ -13311,7 +13319,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 13315 "inc/vcf/validator_detail_v43.hpp"
+#line 13323 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13330,7 +13338,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 13334 "inc/vcf/validator_detail_v43.hpp"
+#line 13342 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr842;
 	goto tr830;
@@ -13344,7 +13352,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 13348 "inc/vcf/validator_detail_v43.hpp"
+#line 13356 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr841;
 	goto tr830;
@@ -13358,7 +13366,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 13362 "inc/vcf/validator_detail_v43.hpp"
+#line 13370 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr843;
@@ -13383,7 +13391,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 13387 "inc/vcf/validator_detail_v43.hpp"
+#line 13395 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr845;
 		case 45: goto tr845;
@@ -13401,7 +13409,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 13405 "inc/vcf/validator_detail_v43.hpp"
+#line 13413 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr846;
 	goto tr844;
@@ -13415,7 +13423,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 13419 "inc/vcf/validator_detail_v43.hpp"
+#line 13427 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13439,7 +13447,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 13443 "inc/vcf/validator_detail_v43.hpp"
+#line 13451 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13469,7 +13477,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 13473 "inc/vcf/validator_detail_v43.hpp"
+#line 13481 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr848;
@@ -13494,7 +13502,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 13498 "inc/vcf/validator_detail_v43.hpp"
+#line 13506 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr850;
 		case 45: goto tr850;
@@ -13515,7 +13523,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 13519 "inc/vcf/validator_detail_v43.hpp"
+#line 13527 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr851;
 		case 73: goto tr853;
@@ -13533,7 +13541,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 13537 "inc/vcf/validator_detail_v43.hpp"
+#line 13545 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr855;
 	goto tr849;
@@ -13547,7 +13555,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 13551 "inc/vcf/validator_detail_v43.hpp"
+#line 13559 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13569,7 +13577,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 13573 "inc/vcf/validator_detail_v43.hpp"
+#line 13581 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr857;
 		case 45: goto tr857;
@@ -13587,7 +13595,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 13591 "inc/vcf/validator_detail_v43.hpp"
+#line 13599 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr858;
 	goto tr849;
@@ -13601,7 +13609,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 13605 "inc/vcf/validator_detail_v43.hpp"
+#line 13613 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13621,7 +13629,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 13625 "inc/vcf/validator_detail_v43.hpp"
+#line 13633 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13644,7 +13652,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13648 "inc/vcf/validator_detail_v43.hpp"
+#line 13656 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr859;
 	goto tr849;
@@ -13658,7 +13666,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13662 "inc/vcf/validator_detail_v43.hpp"
+#line 13670 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr860;
 	goto tr849;
@@ -13672,7 +13680,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13676 "inc/vcf/validator_detail_v43.hpp"
+#line 13684 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13690,7 +13698,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13694 "inc/vcf/validator_detail_v43.hpp"
+#line 13702 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr861;
 	goto tr849;
@@ -13704,7 +13712,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13708 "inc/vcf/validator_detail_v43.hpp"
+#line 13716 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr860;
 	goto tr849;
@@ -13722,7 +13730,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13726 "inc/vcf/validator_detail_v43.hpp"
+#line 13734 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13752,7 +13760,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13756 "inc/vcf/validator_detail_v43.hpp"
+#line 13764 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13782,7 +13790,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13786 "inc/vcf/validator_detail_v43.hpp"
+#line 13794 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13812,7 +13820,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13816 "inc/vcf/validator_detail_v43.hpp"
+#line 13824 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13842,7 +13850,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13846 "inc/vcf/validator_detail_v43.hpp"
+#line 13854 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr866;
@@ -13867,7 +13875,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13871 "inc/vcf/validator_detail_v43.hpp"
+#line 13879 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr868;
@@ -13887,7 +13895,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13891 "inc/vcf/validator_detail_v43.hpp"
+#line 13899 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13917,7 +13925,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13921 "inc/vcf/validator_detail_v43.hpp"
+#line 13929 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13948,7 +13956,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13952 "inc/vcf/validator_detail_v43.hpp"
+#line 13960 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13977,7 +13985,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13981 "inc/vcf/validator_detail_v43.hpp"
+#line 13989 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr874;
 	goto tr873;
@@ -13991,7 +13999,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13995 "inc/vcf/validator_detail_v43.hpp"
+#line 14003 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14009,7 +14017,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 14013 "inc/vcf/validator_detail_v43.hpp"
+#line 14021 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr875;
@@ -14034,7 +14042,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 14038 "inc/vcf/validator_detail_v43.hpp"
+#line 14046 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr877;
 		case 45: goto tr877;
@@ -14052,7 +14060,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 14056 "inc/vcf/validator_detail_v43.hpp"
+#line 14064 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr878;
 	goto tr876;
@@ -14066,7 +14074,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 14070 "inc/vcf/validator_detail_v43.hpp"
+#line 14078 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14090,7 +14098,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 14094 "inc/vcf/validator_detail_v43.hpp"
+#line 14102 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14120,7 +14128,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 14124 "inc/vcf/validator_detail_v43.hpp"
+#line 14132 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14150,7 +14158,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 14154 "inc/vcf/validator_detail_v43.hpp"
+#line 14162 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr881;
@@ -14175,7 +14183,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 14179 "inc/vcf/validator_detail_v43.hpp"
+#line 14187 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr883;
 		case 45: goto tr883;
@@ -14193,7 +14201,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 14197 "inc/vcf/validator_detail_v43.hpp"
+#line 14205 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr884;
 	goto tr882;
@@ -14207,7 +14215,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 14211 "inc/vcf/validator_detail_v43.hpp"
+#line 14219 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14231,7 +14239,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 14235 "inc/vcf/validator_detail_v43.hpp"
+#line 14243 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14262,7 +14270,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 14266 "inc/vcf/validator_detail_v43.hpp"
+#line 14274 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14291,7 +14299,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 14295 "inc/vcf/validator_detail_v43.hpp"
+#line 14303 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr890;
 	goto tr889;
@@ -14305,7 +14313,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 14309 "inc/vcf/validator_detail_v43.hpp"
+#line 14317 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14323,7 +14331,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 14327 "inc/vcf/validator_detail_v43.hpp"
+#line 14335 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14352,7 +14360,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 14356 "inc/vcf/validator_detail_v43.hpp"
+#line 14364 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr894;
 	goto tr893;
@@ -14366,7 +14374,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 14370 "inc/vcf/validator_detail_v43.hpp"
+#line 14378 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14388,7 +14396,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 14392 "inc/vcf/validator_detail_v43.hpp"
+#line 14400 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14418,7 +14426,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 14422 "inc/vcf/validator_detail_v43.hpp"
+#line 14430 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 48: goto tr896;
@@ -14444,7 +14452,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 14448 "inc/vcf/validator_detail_v43.hpp"
+#line 14456 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr898;
@@ -14469,7 +14477,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 14473 "inc/vcf/validator_detail_v43.hpp"
+#line 14481 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr900;
 		case 45: goto tr900;
@@ -14487,7 +14495,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 14491 "inc/vcf/validator_detail_v43.hpp"
+#line 14499 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr901;
 	goto tr899;
@@ -14501,7 +14509,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 14505 "inc/vcf/validator_detail_v43.hpp"
+#line 14513 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14521,7 +14529,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 14525 "inc/vcf/validator_detail_v43.hpp"
+#line 14533 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr903;
 		case 45: goto tr903;
@@ -14542,7 +14550,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 14546 "inc/vcf/validator_detail_v43.hpp"
+#line 14554 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr904;
 		case 73: goto tr906;
@@ -14560,7 +14568,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 14564 "inc/vcf/validator_detail_v43.hpp"
+#line 14572 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr908;
 	goto tr902;
@@ -14574,7 +14582,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 14578 "inc/vcf/validator_detail_v43.hpp"
+#line 14586 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14596,7 +14604,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14600 "inc/vcf/validator_detail_v43.hpp"
+#line 14608 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr910;
 		case 45: goto tr910;
@@ -14614,7 +14622,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14618 "inc/vcf/validator_detail_v43.hpp"
+#line 14626 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr911;
 	goto tr902;
@@ -14628,7 +14636,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14632 "inc/vcf/validator_detail_v43.hpp"
+#line 14640 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14648,7 +14656,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14652 "inc/vcf/validator_detail_v43.hpp"
+#line 14660 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14671,7 +14679,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14675 "inc/vcf/validator_detail_v43.hpp"
+#line 14683 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr912;
 	goto tr902;
@@ -14685,7 +14693,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14689 "inc/vcf/validator_detail_v43.hpp"
+#line 14697 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr913;
 	goto tr902;
@@ -14699,7 +14707,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14703 "inc/vcf/validator_detail_v43.hpp"
+#line 14711 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14717,7 +14725,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14721 "inc/vcf/validator_detail_v43.hpp"
+#line 14729 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr914;
 	goto tr902;
@@ -14731,7 +14739,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14735 "inc/vcf/validator_detail_v43.hpp"
+#line 14743 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr913;
 	goto tr902;
@@ -14749,7 +14757,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14753 "inc/vcf/validator_detail_v43.hpp"
+#line 14761 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14779,7 +14787,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14783 "inc/vcf/validator_detail_v43.hpp"
+#line 14791 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr916;
@@ -14804,7 +14812,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14808 "inc/vcf/validator_detail_v43.hpp"
+#line 14816 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr918;
 		case 45: goto tr918;
@@ -14822,7 +14830,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14826 "inc/vcf/validator_detail_v43.hpp"
+#line 14834 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr919;
 	goto tr917;
@@ -14836,7 +14844,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14840 "inc/vcf/validator_detail_v43.hpp"
+#line 14848 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14860,7 +14868,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14864 "inc/vcf/validator_detail_v43.hpp"
+#line 14872 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14891,7 +14899,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14895 "inc/vcf/validator_detail_v43.hpp"
+#line 14903 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr922;
@@ -14916,7 +14924,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14920 "inc/vcf/validator_detail_v43.hpp"
+#line 14928 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr924;
 		case 45: goto tr924;
@@ -14937,7 +14945,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14941 "inc/vcf/validator_detail_v43.hpp"
+#line 14949 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr925;
 		case 73: goto tr927;
@@ -14955,7 +14963,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14959 "inc/vcf/validator_detail_v43.hpp"
+#line 14967 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr929;
 	goto tr923;
@@ -14969,7 +14977,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14973 "inc/vcf/validator_detail_v43.hpp"
+#line 14981 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14991,7 +14999,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14995 "inc/vcf/validator_detail_v43.hpp"
+#line 15003 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr931;
 		case 45: goto tr931;
@@ -15009,7 +15017,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 15013 "inc/vcf/validator_detail_v43.hpp"
+#line 15021 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr932;
 	goto tr923;
@@ -15023,7 +15031,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 15027 "inc/vcf/validator_detail_v43.hpp"
+#line 15035 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15043,7 +15051,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 15047 "inc/vcf/validator_detail_v43.hpp"
+#line 15055 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15066,7 +15074,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 15070 "inc/vcf/validator_detail_v43.hpp"
+#line 15078 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr933;
 	goto tr923;
@@ -15080,7 +15088,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 15084 "inc/vcf/validator_detail_v43.hpp"
+#line 15092 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr934;
 	goto tr923;
@@ -15094,7 +15102,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 15098 "inc/vcf/validator_detail_v43.hpp"
+#line 15106 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15112,7 +15120,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 15116 "inc/vcf/validator_detail_v43.hpp"
+#line 15124 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr935;
 	goto tr923;
@@ -15126,7 +15134,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 15130 "inc/vcf/validator_detail_v43.hpp"
+#line 15138 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr934;
 	goto tr923;
@@ -15140,7 +15148,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 15144 "inc/vcf/validator_detail_v43.hpp"
+#line 15152 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15170,7 +15178,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 15174 "inc/vcf/validator_detail_v43.hpp"
+#line 15182 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15200,7 +15208,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 15204 "inc/vcf/validator_detail_v43.hpp"
+#line 15212 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15230,7 +15238,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 15234 "inc/vcf/validator_detail_v43.hpp"
+#line 15242 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15260,7 +15268,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 15264 "inc/vcf/validator_detail_v43.hpp"
+#line 15272 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15290,7 +15298,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 15294 "inc/vcf/validator_detail_v43.hpp"
+#line 15302 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15319,7 +15327,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 15323 "inc/vcf/validator_detail_v43.hpp"
+#line 15331 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr944;
 	goto tr943;
@@ -15333,7 +15341,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 15337 "inc/vcf/validator_detail_v43.hpp"
+#line 15345 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15355,7 +15363,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 15359 "inc/vcf/validator_detail_v43.hpp"
+#line 15367 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15385,7 +15393,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 15389 "inc/vcf/validator_detail_v43.hpp"
+#line 15397 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15415,7 +15423,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 15419 "inc/vcf/validator_detail_v43.hpp"
+#line 15427 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15445,7 +15453,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 15449 "inc/vcf/validator_detail_v43.hpp"
+#line 15457 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15475,7 +15483,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 15479 "inc/vcf/validator_detail_v43.hpp"
+#line 15487 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15505,7 +15513,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 15509 "inc/vcf/validator_detail_v43.hpp"
+#line 15517 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15535,7 +15543,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 15539 "inc/vcf/validator_detail_v43.hpp"
+#line 15547 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15565,7 +15573,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 15569 "inc/vcf/validator_detail_v43.hpp"
+#line 15577 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15595,7 +15603,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 15599 "inc/vcf/validator_detail_v43.hpp"
+#line 15607 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15624,7 +15632,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 15628 "inc/vcf/validator_detail_v43.hpp"
+#line 15636 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr956;
 	goto tr955;
@@ -15638,7 +15646,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 15642 "inc/vcf/validator_detail_v43.hpp"
+#line 15650 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15656,7 +15664,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 15660 "inc/vcf/validator_detail_v43.hpp"
+#line 15668 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr743;
 	if ( (*p) < 65 ) {
@@ -15694,7 +15702,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15698 "inc/vcf/validator_detail_v43.hpp"
+#line 15706 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr748;
 		case 58: goto st516;
@@ -15730,7 +15738,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15734 "inc/vcf/validator_detail_v43.hpp"
+#line 15742 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr957;
 		case 45: goto tr957;
@@ -15748,7 +15756,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15752 "inc/vcf/validator_detail_v43.hpp"
+#line 15760 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr958;
 	goto tr730;
@@ -15762,7 +15770,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15766 "inc/vcf/validator_detail_v43.hpp"
+#line 15774 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr740;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15788,7 +15796,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15792 "inc/vcf/validator_detail_v43.hpp"
+#line 15800 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr740;
 		case 46: goto tr736;
@@ -15818,7 +15826,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15822 "inc/vcf/validator_detail_v43.hpp"
+#line 15830 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr959;
 	goto tr730;
@@ -15832,7 +15840,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15836 "inc/vcf/validator_detail_v43.hpp"
+#line 15844 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr960;
 	goto tr730;
@@ -15846,7 +15854,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15850 "inc/vcf/validator_detail_v43.hpp"
+#line 15858 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr740;
 	goto tr730;
@@ -15864,7 +15872,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15868 "inc/vcf/validator_detail_v43.hpp"
+#line 15876 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr740;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15884,7 +15892,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15888 "inc/vcf/validator_detail_v43.hpp"
+#line 15896 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr961;
 	goto tr730;
@@ -15898,7 +15906,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15902 "inc/vcf/validator_detail_v43.hpp"
+#line 15910 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr960;
 	goto tr730;
@@ -15912,7 +15920,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15916 "inc/vcf/validator_detail_v43.hpp"
+#line 15924 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr722;
 		case 46: goto tr962;
@@ -15951,7 +15959,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15955 "inc/vcf/validator_detail_v43.hpp"
+#line 15963 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr963;
 		case 67: goto tr963;
@@ -15975,7 +15983,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15979 "inc/vcf/validator_detail_v43.hpp"
+#line 15987 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr728;
 		case 44: goto tr729;
@@ -16011,7 +16019,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 16015 "inc/vcf/validator_detail_v43.hpp"
+#line 16023 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr965;
 		case 95: goto tr965;
@@ -16035,7 +16043,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 16039 "inc/vcf/validator_detail_v43.hpp"
+#line 16047 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr966;
 		case 95: goto tr964;
@@ -16069,7 +16077,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 16073 "inc/vcf/validator_detail_v43.hpp"
+#line 16081 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr728;
 		case 44: goto tr729;
@@ -16098,7 +16106,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 16102 "inc/vcf/validator_detail_v43.hpp"
+#line 16110 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr971;
 	if ( (*p) < 65 ) {
@@ -16120,7 +16128,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 16124 "inc/vcf/validator_detail_v43.hpp"
+#line 16132 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr974;
 		case 59: goto tr972;
@@ -16157,7 +16165,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 16161 "inc/vcf/validator_detail_v43.hpp"
+#line 16169 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr972;
 		case 61: goto tr972;
@@ -16193,7 +16201,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 16197 "inc/vcf/validator_detail_v43.hpp"
+#line 16205 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr974;
 		case 61: goto tr973;
@@ -16214,7 +16222,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 16218 "inc/vcf/validator_detail_v43.hpp"
+#line 16226 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr975;
 		case 45: goto tr975;
@@ -16232,7 +16240,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 16236 "inc/vcf/validator_detail_v43.hpp"
+#line 16244 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr976;
 	goto tr721;
@@ -16246,7 +16254,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 16250 "inc/vcf/validator_detail_v43.hpp"
+#line 16258 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr966;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16262,7 +16270,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 16266 "inc/vcf/validator_detail_v43.hpp"
+#line 16274 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr977;
@@ -16282,7 +16290,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 16286 "inc/vcf/validator_detail_v43.hpp"
+#line 16294 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr978;
 		case 62: goto tr980;
@@ -16318,7 +16326,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 16322 "inc/vcf/validator_detail_v43.hpp"
+#line 16330 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr978;
 		case 61: goto tr978;
@@ -16354,7 +16362,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 16358 "inc/vcf/validator_detail_v43.hpp"
+#line 16366 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr979;
 		case 62: goto tr980;
@@ -16375,7 +16383,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 16379 "inc/vcf/validator_detail_v43.hpp"
+#line 16387 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr974;
 	goto tr721;
@@ -16389,7 +16397,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 16393 "inc/vcf/validator_detail_v43.hpp"
+#line 16401 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr982;
 	if ( (*p) < 65 ) {
@@ -16411,7 +16419,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 16415 "inc/vcf/validator_detail_v43.hpp"
+#line 16423 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr985;
 		case 59: goto tr983;
@@ -16448,7 +16456,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 16452 "inc/vcf/validator_detail_v43.hpp"
+#line 16460 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr983;
 		case 61: goto tr983;
@@ -16484,7 +16492,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 16488 "inc/vcf/validator_detail_v43.hpp"
+#line 16496 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr985;
 		case 61: goto tr984;
@@ -16505,7 +16513,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 16509 "inc/vcf/validator_detail_v43.hpp"
+#line 16517 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr986;
 		case 45: goto tr986;
@@ -16523,7 +16531,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 16527 "inc/vcf/validator_detail_v43.hpp"
+#line 16535 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr987;
 	goto tr721;
@@ -16537,7 +16545,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 16541 "inc/vcf/validator_detail_v43.hpp"
+#line 16549 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr966;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16553,7 +16561,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 16557 "inc/vcf/validator_detail_v43.hpp"
+#line 16565 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr988;
@@ -16573,7 +16581,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 16577 "inc/vcf/validator_detail_v43.hpp"
+#line 16585 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr989;
 		case 62: goto tr991;
@@ -16609,7 +16617,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 16613 "inc/vcf/validator_detail_v43.hpp"
+#line 16621 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr989;
 		case 61: goto tr989;
@@ -16645,7 +16653,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 16649 "inc/vcf/validator_detail_v43.hpp"
+#line 16657 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr990;
 		case 62: goto tr991;
@@ -16666,7 +16674,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 16670 "inc/vcf/validator_detail_v43.hpp"
+#line 16678 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr985;
 	goto tr721;
@@ -16684,7 +16692,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 16688 "inc/vcf/validator_detail_v43.hpp"
+#line 16696 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr993;
 	if ( (*p) < 65 ) {
@@ -16706,7 +16714,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 16710 "inc/vcf/validator_detail_v43.hpp"
+#line 16718 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr996;
 		case 59: goto tr994;
@@ -16743,7 +16751,7 @@ st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 16747 "inc/vcf/validator_detail_v43.hpp"
+#line 16755 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr994;
 		case 61: goto tr994;
@@ -16779,7 +16787,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 16783 "inc/vcf/validator_detail_v43.hpp"
+#line 16791 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr996;
 		case 61: goto tr995;
@@ -16800,7 +16808,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 16804 "inc/vcf/validator_detail_v43.hpp"
+#line 16812 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr997;
 		case 45: goto tr997;
@@ -16818,7 +16826,7 @@ st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 16822 "inc/vcf/validator_detail_v43.hpp"
+#line 16830 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr998;
 	goto tr721;
@@ -16832,7 +16840,7 @@ st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 16836 "inc/vcf/validator_detail_v43.hpp"
+#line 16844 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr999;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16848,7 +16856,7 @@ st734:
 	if ( ++p == pe )
 		goto _test_eof734;
 case 734:
-#line 16852 "inc/vcf/validator_detail_v43.hpp"
+#line 16860 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr1000;
@@ -16868,7 +16876,7 @@ st735:
 	if ( ++p == pe )
 		goto _test_eof735;
 case 735:
-#line 16872 "inc/vcf/validator_detail_v43.hpp"
+#line 16880 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1001;
 		case 62: goto tr1003;
@@ -16904,7 +16912,7 @@ st736:
 	if ( ++p == pe )
 		goto _test_eof736;
 case 736:
-#line 16908 "inc/vcf/validator_detail_v43.hpp"
+#line 16916 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1001;
 		case 61: goto tr1001;
@@ -16940,7 +16948,7 @@ st737:
 	if ( ++p == pe )
 		goto _test_eof737;
 case 737:
-#line 16944 "inc/vcf/validator_detail_v43.hpp"
+#line 16952 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1002;
 		case 62: goto tr1003;
@@ -16961,7 +16969,7 @@ st738:
 	if ( ++p == pe )
 		goto _test_eof738;
 case 738:
-#line 16965 "inc/vcf/validator_detail_v43.hpp"
+#line 16973 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr996;
 	goto tr721;
@@ -16979,7 +16987,7 @@ st739:
 	if ( ++p == pe )
 		goto _test_eof739;
 case 739:
-#line 16983 "inc/vcf/validator_detail_v43.hpp"
+#line 16991 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr1005;
 	if ( (*p) < 65 ) {
@@ -17001,7 +17009,7 @@ st740:
 	if ( ++p == pe )
 		goto _test_eof740;
 case 740:
-#line 17005 "inc/vcf/validator_detail_v43.hpp"
+#line 17013 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr1008;
 		case 59: goto tr1006;
@@ -17038,7 +17046,7 @@ st741:
 	if ( ++p == pe )
 		goto _test_eof741;
 case 741:
-#line 17042 "inc/vcf/validator_detail_v43.hpp"
+#line 17050 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1006;
 		case 61: goto tr1006;
@@ -17074,7 +17082,7 @@ st742:
 	if ( ++p == pe )
 		goto _test_eof742;
 case 742:
-#line 17078 "inc/vcf/validator_detail_v43.hpp"
+#line 17086 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr1008;
 		case 61: goto tr1007;
@@ -17095,7 +17103,7 @@ st743:
 	if ( ++p == pe )
 		goto _test_eof743;
 case 743:
-#line 17099 "inc/vcf/validator_detail_v43.hpp"
+#line 17107 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1009;
 		case 45: goto tr1009;
@@ -17113,7 +17121,7 @@ st744:
 	if ( ++p == pe )
 		goto _test_eof744;
 case 744:
-#line 17117 "inc/vcf/validator_detail_v43.hpp"
+#line 17125 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1010;
 	goto tr721;
@@ -17127,7 +17135,7 @@ st745:
 	if ( ++p == pe )
 		goto _test_eof745;
 case 745:
-#line 17131 "inc/vcf/validator_detail_v43.hpp"
+#line 17139 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr999;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17143,7 +17151,7 @@ st746:
 	if ( ++p == pe )
 		goto _test_eof746;
 case 746:
-#line 17147 "inc/vcf/validator_detail_v43.hpp"
+#line 17155 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr1011;
@@ -17163,7 +17171,7 @@ st747:
 	if ( ++p == pe )
 		goto _test_eof747;
 case 747:
-#line 17167 "inc/vcf/validator_detail_v43.hpp"
+#line 17175 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1012;
 		case 62: goto tr1014;
@@ -17199,7 +17207,7 @@ st748:
 	if ( ++p == pe )
 		goto _test_eof748;
 case 748:
-#line 17203 "inc/vcf/validator_detail_v43.hpp"
+#line 17211 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1012;
 		case 61: goto tr1012;
@@ -17235,7 +17243,7 @@ st749:
 	if ( ++p == pe )
 		goto _test_eof749;
 case 749:
-#line 17239 "inc/vcf/validator_detail_v43.hpp"
+#line 17247 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1013;
 		case 62: goto tr1014;
@@ -17256,7 +17264,7 @@ st750:
 	if ( ++p == pe )
 		goto _test_eof750;
 case 750:
-#line 17260 "inc/vcf/validator_detail_v43.hpp"
+#line 17268 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1008;
 	goto tr721;
@@ -17274,7 +17282,7 @@ st751:
 	if ( ++p == pe )
 		goto _test_eof751;
 case 751:
-#line 17278 "inc/vcf/validator_detail_v43.hpp"
+#line 17286 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr728;
 		case 65: goto tr963;
@@ -17299,7 +17307,7 @@ st752:
 	if ( ++p == pe )
 		goto _test_eof752;
 case 752:
-#line 17303 "inc/vcf/validator_detail_v43.hpp"
+#line 17311 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr705;
 		case 61: goto tr705;
@@ -17335,7 +17343,7 @@ st753:
 	if ( ++p == pe )
 		goto _test_eof753;
 case 753:
-#line 17339 "inc/vcf/validator_detail_v43.hpp"
+#line 17347 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr704;
 		case 59: goto tr706;
@@ -17387,7 +17395,7 @@ st754:
 	if ( ++p == pe )
 		goto _test_eof754;
 case 754:
-#line 17391 "inc/vcf/validator_detail_v43.hpp"
+#line 17399 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st758;
 	goto tr690;
@@ -17411,7 +17419,7 @@ st755:
 	if ( ++p == pe )
 		goto _test_eof755;
 case 755:
-#line 17415 "inc/vcf/validator_detail_v43.hpp"
+#line 17423 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -17431,7 +17439,7 @@ st756:
 	if ( ++p == pe )
 		goto _test_eof756;
 case 756:
-#line 17435 "inc/vcf/validator_detail_v43.hpp"
+#line 17443 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1018;
 		case 13: goto tr1019;
@@ -17448,14 +17456,14 @@ tr1018:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 769 "src/vcf/vcf_v43.ragel"
+#line 773 "src/vcf/vcf_v43.ragel"
 	{ {goto st28;} }
 	goto st760;
 st760:
 	if ( ++p == pe )
 		goto _test_eof760;
 case 760:
-#line 17459 "inc/vcf/validator_detail_v43.hpp"
+#line 17467 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 tr1022:
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -17473,7 +17481,7 @@ st757:
 	if ( ++p == pe )
 		goto _test_eof757;
 case 757:
-#line 17477 "inc/vcf/validator_detail_v43.hpp"
+#line 17485 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1021;
 		case 13: goto tr1022;
@@ -17490,14 +17498,14 @@ tr1021:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 770 "src/vcf/vcf_v43.ragel"
+#line 774 "src/vcf/vcf_v43.ragel"
 	{ {goto st759;} }
 	goto st761;
 st761:
 	if ( ++p == pe )
 		goto _test_eof761;
 case 761:
-#line 17501 "inc/vcf/validator_detail_v43.hpp"
+#line 17509 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -18344,8 +18352,8 @@ case 761:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 	break;
@@ -18366,8 +18374,8 @@ case 761:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -18388,7 +18396,7 @@ case 761:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 210 "src/vcf/vcf_v43.ragel"
+#line 214 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_fileformat_section_error(*this,
             "The fileformat declaration is not 'fileformat=VCFv4.3'");
@@ -18422,7 +18430,7 @@ case 761:
 	case 95: 
 	case 102: 
 	case 113: 
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -18441,7 +18449,7 @@ case 761:
 	case 380: 
 	case 381: 
 	case 382: 
-#line 228 "src/vcf/vcf_v43.ragel"
+#line 232 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st756;}
@@ -18481,7 +18489,7 @@ case 761:
 	case 422: 
 	case 423: 
 	case 424: 
-#line 234 "src/vcf/vcf_v43.ragel"
+#line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st756;}
@@ -18516,7 +18524,7 @@ case 761:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -18563,7 +18571,7 @@ case 761:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -18609,7 +18617,7 @@ case 761:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -18630,7 +18638,7 @@ case 761:
 	case 313: 
 	case 314: 
 	case 321: 
-#line 278 "src/vcf/vcf_v43.ragel"
+#line 282 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st756;}
@@ -18652,7 +18660,7 @@ case 761:
 	case 443: 
 	case 444: 
 	case 445: 
-#line 284 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st756;}
@@ -18674,7 +18682,7 @@ case 761:
 	case 330: 
 	case 331: 
 	case 371: 
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -18722,15 +18730,15 @@ case 761:
 	case 489: 
 	case 490: 
 	case 491: 
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 326 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -18742,8 +18750,8 @@ case 761:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -18757,7 +18765,7 @@ case 761:
 	case 528: 
 	case 752: 
 	case 753: 
-#line 338 "src/vcf/vcf_v43.ragel"
+#line 342 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
         p--; {goto st757;}
@@ -18771,7 +18779,7 @@ case 761:
 	case 502: 
 	case 503: 
 	case 504: 
-#line 344 "src/vcf/vcf_v43.ragel"
+#line 348 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
         p--; {goto st757;}
@@ -18784,7 +18792,7 @@ case 761:
 	break;
 	case 505: 
 	case 506: 
-#line 350 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
         p--; {goto st757;}
@@ -18797,7 +18805,7 @@ case 761:
 	break;
 	case 507: 
 	case 508: 
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
         p--; {goto st757;}
@@ -18865,7 +18873,7 @@ case 761:
 	case 749: 
 	case 750: 
 	case 751: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
         p--; {goto st757;}
@@ -18890,7 +18898,7 @@ case 761:
 	case 694: 
 	case 695: 
 	case 696: 
-#line 368 "src/vcf/vcf_v43.ragel"
+#line 372 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
         p--; {goto st757;}
@@ -18906,7 +18914,7 @@ case 761:
 	case 517: 
 	case 685: 
 	case 686: 
-#line 374 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
         p--; {goto st757;}
@@ -18918,7 +18926,7 @@ case 761:
     }
 	break;
 	case 519: 
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -18931,7 +18939,7 @@ case 761:
 	break;
 	case 520: 
 	case 521: 
-#line 501 "src/vcf/vcf_v43.ragel"
+#line 505 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
         p--; {goto st757;}
@@ -18944,7 +18952,7 @@ case 761:
 	break;
 	case 532: 
 	case 533: 
-#line 507 "src/vcf/vcf_v43.ragel"
+#line 511 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -18964,15 +18972,15 @@ case 761:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st756;}
     }
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 326 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -18984,8 +18992,8 @@ case 761:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -18994,12 +19002,12 @@ case 761:
 	case 81: 
 	case 82: 
 	case 121: 
-#line 222 "src/vcf/vcf_v43.ragel"
+#line 226 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -19011,12 +19019,12 @@ case 761:
     }
 	break;
 	case 122: 
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -19030,12 +19038,12 @@ case 761:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 251 "src/vcf/vcf_v43.ragel"
+#line 255 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -19049,12 +19057,12 @@ case 761:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 267 "src/vcf/vcf_v43.ragel"
+#line 271 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -19067,12 +19075,12 @@ case 761:
 	break;
 	case 199: 
 	case 200: 
-#line 272 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -19085,12 +19093,12 @@ case 761:
 	break;
 	case 265: 
 	case 266: 
-#line 272 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -19110,12 +19118,12 @@ case 761:
 	case 341: 
 	case 342: 
 	case 343: 
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 299 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -19135,12 +19143,12 @@ case 761:
 	case 351: 
 	case 352: 
 	case 353: 
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -19154,12 +19162,12 @@ case 761:
 	case 99: 
 	case 100: 
 	case 101: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -19186,12 +19194,12 @@ case 761:
 	case 432: 
 	case 433: 
 	case 434: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 234 "src/vcf/vcf_v43.ragel"
+#line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st756;}
@@ -19208,12 +19216,12 @@ case 761:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -19230,12 +19238,12 @@ case 761:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -19252,12 +19260,12 @@ case 761:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -19274,12 +19282,12 @@ case 761:
 	case 318: 
 	case 319: 
 	case 320: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 278 "src/vcf/vcf_v43.ragel"
+#line 282 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st756;}
@@ -19292,12 +19300,12 @@ case 761:
 	break;
 	case 332: 
 	case 333: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -19322,12 +19330,12 @@ case 761:
 	case 115: 
 	case 119: 
 	case 120: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -19352,12 +19360,12 @@ case 761:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -19382,12 +19390,12 @@ case 761:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -19412,12 +19420,12 @@ case 761:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -19447,12 +19455,12 @@ case 761:
 	case 372: 
 	case 373: 
 	case 374: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -19470,12 +19478,12 @@ case 761:
 	case 387: 
 	case 388: 
 	case 389: 
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 320 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st756;}
     }
-#line 228 "src/vcf/vcf_v43.ragel"
+#line 232 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st756;}
@@ -19495,12 +19503,12 @@ case 761:
 	case 452: 
 	case 453: 
 	case 454: 
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 320 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
         p--; {goto st756;}
     }
-#line 284 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st756;}
@@ -19559,12 +19567,12 @@ case 761:
 	case 679: 
 	case 680: 
 	case 681: 
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19577,12 +19585,12 @@ case 761:
 	break;
 	case 540: 
 	case 541: 
-#line 390 "src/vcf/vcf_v43.ragel"
+#line 394 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19596,12 +19604,12 @@ case 761:
 	case 547: 
 	case 548: 
 	case 549: 
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 399 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19615,12 +19623,12 @@ case 761:
 	case 551: 
 	case 552: 
 	case 553: 
-#line 400 "src/vcf/vcf_v43.ragel"
+#line 404 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19634,12 +19642,12 @@ case 761:
 	case 555: 
 	case 556: 
 	case 557: 
-#line 405 "src/vcf/vcf_v43.ragel"
+#line 409 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AD value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19653,12 +19661,12 @@ case 761:
 	case 559: 
 	case 560: 
 	case 561: 
-#line 410 "src/vcf/vcf_v43.ragel"
+#line 414 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info ADF value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19672,12 +19680,12 @@ case 761:
 	case 563: 
 	case 564: 
 	case 565: 
-#line 415 "src/vcf/vcf_v43.ragel"
+#line 419 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info ADR value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19701,12 +19709,12 @@ case 761:
 	case 577: 
 	case 578: 
 	case 579: 
-#line 420 "src/vcf/vcf_v43.ragel"
+#line 424 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19720,12 +19728,12 @@ case 761:
 	case 581: 
 	case 582: 
 	case 583: 
-#line 425 "src/vcf/vcf_v43.ragel"
+#line 429 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19749,12 +19757,12 @@ case 761:
 	case 596: 
 	case 597: 
 	case 598: 
-#line 430 "src/vcf/vcf_v43.ragel"
+#line 434 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19767,12 +19775,12 @@ case 761:
 	break;
 	case 604: 
 	case 605: 
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 439 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19785,12 +19793,12 @@ case 761:
 	break;
 	case 608: 
 	case 609: 
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 444 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19804,12 +19812,12 @@ case 761:
 	case 611: 
 	case 612: 
 	case 613: 
-#line 445 "src/vcf/vcf_v43.ragel"
+#line 449 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19823,12 +19831,12 @@ case 761:
 	case 617: 
 	case 618: 
 	case 619: 
-#line 450 "src/vcf/vcf_v43.ragel"
+#line 454 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19841,12 +19849,12 @@ case 761:
 	break;
 	case 622: 
 	case 623: 
-#line 455 "src/vcf/vcf_v43.ragel"
+#line 459 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19859,12 +19867,12 @@ case 761:
 	break;
 	case 625: 
 	case 626: 
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 464 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19888,12 +19896,12 @@ case 761:
 	case 643: 
 	case 644: 
 	case 645: 
-#line 465 "src/vcf/vcf_v43.ragel"
+#line 469 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19907,12 +19915,12 @@ case 761:
 	case 630: 
 	case 631: 
 	case 632: 
-#line 470 "src/vcf/vcf_v43.ragel"
+#line 474 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19926,12 +19934,12 @@ case 761:
 	case 648: 
 	case 649: 
 	case 650: 
-#line 475 "src/vcf/vcf_v43.ragel"
+#line 479 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19955,12 +19963,12 @@ case 761:
 	case 663: 
 	case 664: 
 	case 665: 
-#line 480 "src/vcf/vcf_v43.ragel"
+#line 484 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19973,12 +19981,12 @@ case 761:
 	break;
 	case 672: 
 	case 673: 
-#line 485 "src/vcf/vcf_v43.ragel"
+#line 489 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -19991,12 +19999,12 @@ case 761:
 	break;
 	case 683: 
 	case 684: 
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 494 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20009,12 +20017,12 @@ case 761:
 	break;
 	case 543: 
 	case 544: 
-#line 495 "src/vcf/vcf_v43.ragel"
+#line 499 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20029,14 +20037,14 @@ case 761:
 	case 523: 
 	case 530: 
 	case 531: 
-#line 514 "src/vcf/vcf_v43.ragel"
+#line 518 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_body_section_error(*this, message_stream.str());
         p--; {goto st757;}
     }
-#line 507 "src/vcf/vcf_v43.ragel"
+#line 511 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -20060,15 +20068,15 @@ case 761:
         ErrorPolicy::handle_meta_section_error(*this);
         p--; {goto st756;}
     }
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 326 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
@@ -20080,25 +20088,25 @@ case 761:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         p--; {goto st757;}
     }
 	break;
 	case 344: 
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 299 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -20110,17 +20118,17 @@ case 761:
     }
 	break;
 	case 354: 
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -20132,17 +20140,17 @@ case 761:
     }
 	break;
 	case 334: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 299 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
@@ -20156,17 +20164,17 @@ case 761:
 	case 107: 
 	case 108: 
 	case 109: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -20180,17 +20188,17 @@ case 761:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -20204,17 +20212,17 @@ case 761:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -20228,17 +20236,17 @@ case 761:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -20252,17 +20260,17 @@ case 761:
 	case 116: 
 	case 117: 
 	case 118: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
@@ -20276,17 +20284,17 @@ case 761:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
@@ -20300,17 +20308,17 @@ case 761:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
@@ -20324,17 +20332,17 @@ case 761:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 315 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
         p--; {goto st756;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 310 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
@@ -20346,17 +20354,17 @@ case 761:
     }
 	break;
 	case 607: 
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 444 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20368,17 +20376,17 @@ case 761:
     }
 	break;
 	case 621: 
-#line 455 "src/vcf/vcf_v43.ragel"
+#line 459 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20390,17 +20398,17 @@ case 761:
     }
 	break;
 	case 624: 
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 464 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20412,17 +20420,17 @@ case 761:
     }
 	break;
 	case 671: 
-#line 485 "src/vcf/vcf_v43.ragel"
+#line 489 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20434,17 +20442,17 @@ case 761:
     }
 	break;
 	case 682: 
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 494 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20456,17 +20464,17 @@ case 761:
     }
 	break;
 	case 542: 
-#line 495 "src/vcf/vcf_v43.ragel"
+#line 499 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
         p--; {goto st757;}
     }
-#line 385 "src/vcf/vcf_v43.ragel"
+#line 389 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
         p--; {goto st757;}
     }
-#line 380 "src/vcf/vcf_v43.ragel"
+#line 384 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
         p--; {goto st757;}
@@ -20478,47 +20486,47 @@ case 761:
     }
 	break;
 	case 24: 
-#line 217 "src/vcf/vcf_v43.ragel"
+#line 221 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
         p--; {goto st756;}
     }
-#line 240 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
         p--; {goto st756;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
         p--; {goto st756;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
         p--; {goto st756;}
     }
-#line 228 "src/vcf/vcf_v43.ragel"
+#line 232 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
         p--; {goto st756;}
     }
-#line 234 "src/vcf/vcf_v43.ragel"
+#line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
         p--; {goto st756;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 294 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
         p--; {goto st756;}
     }
-#line 278 "src/vcf/vcf_v43.ragel"
+#line 282 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
         p--; {goto st756;}
     }
-#line 284 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
         p--; {goto st756;}
@@ -20529,14 +20537,14 @@ case 761:
         p--; {goto st756;}
     }
 	break;
-#line 20533 "inc/vcf/validator_detail_v43.hpp"
+#line 20541 "inc/vcf/validator_detail_v43.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 801 "src/vcf/vcf_v43.ragel"
+#line 805 "src/vcf/vcf_v43.ragel"
 
     }
     

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 775 "src/vcf/vcf_v43.ragel"
+#line 777 "src/vcf/vcf_v43.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v43_en_meta_section_skip = 756;
 static const int vcf_v43_en_body_section_skip = 757;
 
 
-#line 781 "src/vcf/vcf_v43.ragel"
+#line 783 "src/vcf/vcf_v43.ragel"
 
 }
 
@@ -60,7 +60,7 @@ namespace ebi
 	cs = vcf_v43_start;
 	}
 
-#line 797 "src/vcf/vcf_v43.ragel"
+#line 799 "src/vcf/vcf_v43.ragel"
 
     }
 
@@ -81,56 +81,57 @@ case 1:
 tr0:
 #line 60 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr14:
 #line 214 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.3'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         p--; {goto st756;}
     }
 #line 60 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr24:
 #line 60 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
-#line 326 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
@@ -139,31 +140,32 @@ tr24:
 tr26:
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
-#line 326 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
@@ -172,809 +174,811 @@ tr26:
 tr29:
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
-#line 232 "src/vcf/vcf_v43.ragel"
+#line 233 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st756;}
     }
-#line 238 "src/vcf/vcf_v43.ragel"
+#line 239 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
-#line 282 "src/vcf/vcf_v43.ragel"
+#line 283 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st756;}
     }
-#line 288 "src/vcf/vcf_v43.ragel"
+#line 289 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr39:
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr125:
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr133:
 #line 226 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr151:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr160:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr174:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr186:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr193:
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr196:
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr206:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr225:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr247:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr259:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr265:
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr275:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr288:
-#line 255 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr297:
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 277 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr314:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr336:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr348:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr355:
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr364:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr377:
-#line 271 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr386:
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 277 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr403:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr425:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr437:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr444:
-#line 282 "src/vcf/vcf_v43.ragel"
+#line 283 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr454:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 282 "src/vcf/vcf_v43.ragel"
+#line 283 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr466:
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr477:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr482:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 299 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr484:
-#line 299 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr494:
-#line 299 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 304 "src/vcf/vcf_v43.ragel"
+#line 305 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr497:
-#line 304 "src/vcf/vcf_v43.ragel"
+#line 305 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr507:
-#line 304 "src/vcf/vcf_v43.ragel"
+#line 305 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr510:
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr533:
-#line 232 "src/vcf/vcf_v43.ragel"
+#line 233 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr542:
-#line 320 "src/vcf/vcf_v43.ragel"
+#line 321 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st756;}
     }
-#line 232 "src/vcf/vcf_v43.ragel"
+#line 233 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr550:
-#line 238 "src/vcf/vcf_v43.ragel"
+#line 239 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr561:
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 238 "src/vcf/vcf_v43.ragel"
+#line 239 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr629:
-#line 288 "src/vcf/vcf_v43.ragel"
+#line 289 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr641:
-#line 320 "src/vcf/vcf_v43.ragel"
+#line 321 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st756;}
     }
-#line 288 "src/vcf/vcf_v43.ragel"
+#line 289 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	goto st0;
 tr650:
-#line 326 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
@@ -983,717 +987,717 @@ tr650:
 tr690:
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 	goto st0;
 tr703:
-#line 342 "src/vcf/vcf_v43.ragel"
+#line 344 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr707:
-#line 348 "src/vcf/vcf_v43.ragel"
+#line 350 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr712:
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr717:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr721:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 368 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr730:
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr742:
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 380 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr750:
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr764:
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr768:
-#line 505 "src/vcf/vcf_v43.ragel"
+#line 507 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr773:
-#line 518 "src/vcf/vcf_v43.ragel"
+#line 520 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st757;}
     }
-#line 511 "src/vcf/vcf_v43.ragel"
+#line 513 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr783:
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr787:
-#line 511 "src/vcf/vcf_v43.ragel"
+#line 513 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr796:
-#line 394 "src/vcf/vcf_v43.ragel"
+#line 396 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr798:
-#line 499 "src/vcf/vcf_v43.ragel"
+#line 501 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr800:
-#line 499 "src/vcf/vcf_v43.ragel"
+#line 501 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr808:
-#line 399 "src/vcf/vcf_v43.ragel"
+#line 401 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr812:
-#line 404 "src/vcf/vcf_v43.ragel"
+#line 406 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr818:
-#line 409 "src/vcf/vcf_v43.ragel"
+#line 411 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AD value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AD value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr822:
-#line 414 "src/vcf/vcf_v43.ragel"
+#line 416 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info ADF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info ADF value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr826:
-#line 419 "src/vcf/vcf_v43.ragel"
+#line 421 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info ADR value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info ADR value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr830:
-#line 424 "src/vcf/vcf_v43.ragel"
+#line 426 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr844:
-#line 429 "src/vcf/vcf_v43.ragel"
+#line 431 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr849:
-#line 434 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr867:
-#line 439 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr871:
-#line 444 "src/vcf/vcf_v43.ragel"
+#line 446 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr873:
-#line 444 "src/vcf/vcf_v43.ragel"
+#line 446 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr876:
-#line 449 "src/vcf/vcf_v43.ragel"
+#line 451 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr882:
-#line 454 "src/vcf/vcf_v43.ragel"
+#line 456 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr887:
-#line 459 "src/vcf/vcf_v43.ragel"
+#line 461 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr889:
-#line 459 "src/vcf/vcf_v43.ragel"
+#line 461 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr891:
-#line 464 "src/vcf/vcf_v43.ragel"
+#line 466 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr893:
-#line 464 "src/vcf/vcf_v43.ragel"
+#line 466 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr899:
-#line 474 "src/vcf/vcf_v43.ragel"
+#line 476 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr902:
-#line 469 "src/vcf/vcf_v43.ragel"
+#line 471 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr917:
-#line 479 "src/vcf/vcf_v43.ragel"
+#line 481 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr923:
-#line 484 "src/vcf/vcf_v43.ragel"
+#line 486 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr941:
-#line 489 "src/vcf/vcf_v43.ragel"
+#line 491 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr943:
-#line 489 "src/vcf/vcf_v43.ragel"
+#line 491 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr953:
-#line 494 "src/vcf/vcf_v43.ragel"
+#line 496 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr955:
-#line 494 "src/vcf/vcf_v43.ragel"
+#line 496 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
 tr1023:
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
-#line 342 "src/vcf/vcf_v43.ragel"
+#line 344 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	goto st0;
-#line 1697 "inc/vcf/validator_detail_v43.hpp"
+#line 1701 "inc/vcf/validator_detail_v43.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1802,7 +1806,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1806 "inc/vcf/validator_detail_v43.hpp"
+#line 1810 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1816,7 +1820,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1820 "inc/vcf/validator_detail_v43.hpp"
+#line 1824 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1830,7 +1834,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1834 "inc/vcf/validator_detail_v43.hpp"
+#line 1838 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1844,7 +1848,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1848 "inc/vcf/validator_detail_v43.hpp"
+#line 1852 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1858,7 +1862,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1862 "inc/vcf/validator_detail_v43.hpp"
+#line 1866 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1872,7 +1876,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1876 "inc/vcf/validator_detail_v43.hpp"
+#line 1880 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 51 )
 		goto tr21;
 	goto tr14;
@@ -1886,7 +1890,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1890 "inc/vcf/validator_detail_v43.hpp"
+#line 1894 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -1912,7 +1916,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1916 "inc/vcf/validator_detail_v43.hpp"
+#line 1920 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1965,7 +1969,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1969 "inc/vcf/validator_detail_v43.hpp"
+#line 1973 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1981,7 +1985,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1985 "inc/vcf/validator_detail_v43.hpp"
+#line 1989 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2009,7 +2013,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2013 "inc/vcf/validator_detail_v43.hpp"
+#line 2017 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -2026,8 +2030,8 @@ tr45:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -2046,8 +2050,8 @@ tr55:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -2065,7 +2069,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2069 "inc/vcf/validator_detail_v43.hpp"
+#line 2073 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -2078,8 +2082,8 @@ tr46:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -2098,8 +2102,8 @@ tr56:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -2117,7 +2121,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2121 "inc/vcf/validator_detail_v43.hpp"
+#line 2125 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -2152,7 +2156,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2156 "inc/vcf/validator_detail_v43.hpp"
+#line 2160 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2180,7 +2184,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2184 "inc/vcf/validator_detail_v43.hpp"
+#line 2188 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2206,7 +2210,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2210 "inc/vcf/validator_detail_v43.hpp"
+#line 2214 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2228,7 +2232,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2232 "inc/vcf/validator_detail_v43.hpp"
+#line 2236 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2289,7 +2293,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2293 "inc/vcf/validator_detail_v43.hpp"
+#line 2297 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2317,7 +2321,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2321 "inc/vcf/validator_detail_v43.hpp"
+#line 2325 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
@@ -2341,7 +2345,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2345 "inc/vcf/validator_detail_v43.hpp"
+#line 2349 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2363,7 +2367,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2367 "inc/vcf/validator_detail_v43.hpp"
+#line 2371 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2382,7 +2386,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2386 "inc/vcf/validator_detail_v43.hpp"
+#line 2390 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2402,7 +2406,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2406 "inc/vcf/validator_detail_v43.hpp"
+#line 2410 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2437,7 +2441,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2441 "inc/vcf/validator_detail_v43.hpp"
+#line 2445 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2464,7 +2468,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2468 "inc/vcf/validator_detail_v43.hpp"
+#line 2472 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2496,7 +2500,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2500 "inc/vcf/validator_detail_v43.hpp"
+#line 2504 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2517,7 +2521,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2521 "inc/vcf/validator_detail_v43.hpp"
+#line 2525 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2542,7 +2546,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2546 "inc/vcf/validator_detail_v43.hpp"
+#line 2550 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2577,7 +2581,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2581 "inc/vcf/validator_detail_v43.hpp"
+#line 2585 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2604,7 +2608,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2608 "inc/vcf/validator_detail_v43.hpp"
+#line 2612 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2647,7 +2651,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2651 "inc/vcf/validator_detail_v43.hpp"
+#line 2655 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2675,7 +2679,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2679 "inc/vcf/validator_detail_v43.hpp"
+#line 2683 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2701,7 +2705,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2705 "inc/vcf/validator_detail_v43.hpp"
+#line 2709 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2723,7 +2727,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2727 "inc/vcf/validator_detail_v43.hpp"
+#line 2731 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2763,7 +2767,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2767 "inc/vcf/validator_detail_v43.hpp"
+#line 2771 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2814,7 +2818,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2818 "inc/vcf/validator_detail_v43.hpp"
+#line 2822 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2865,7 +2869,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2869 "inc/vcf/validator_detail_v43.hpp"
+#line 2873 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2908,7 +2912,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2912 "inc/vcf/validator_detail_v43.hpp"
+#line 2916 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2938,7 +2942,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2942 "inc/vcf/validator_detail_v43.hpp"
+#line 2946 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2978,7 +2982,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2982 "inc/vcf/validator_detail_v43.hpp"
+#line 2986 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3008,7 +3012,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3012 "inc/vcf/validator_detail_v43.hpp"
+#line 3016 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -3028,7 +3032,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3032 "inc/vcf/validator_detail_v43.hpp"
+#line 3036 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -3069,7 +3073,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3073 "inc/vcf/validator_detail_v43.hpp"
+#line 3077 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -3097,7 +3101,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3101 "inc/vcf/validator_detail_v43.hpp"
+#line 3105 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -3119,7 +3123,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3123 "inc/vcf/validator_detail_v43.hpp"
+#line 3127 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -3149,7 +3153,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3153 "inc/vcf/validator_detail_v43.hpp"
+#line 3157 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3200,7 +3204,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3204 "inc/vcf/validator_detail_v43.hpp"
+#line 3208 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3251,7 +3255,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3255 "inc/vcf/validator_detail_v43.hpp"
+#line 3259 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3294,7 +3298,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3298 "inc/vcf/validator_detail_v43.hpp"
+#line 3302 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3324,7 +3328,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3328 "inc/vcf/validator_detail_v43.hpp"
+#line 3332 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3354,7 +3358,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3358 "inc/vcf/validator_detail_v43.hpp"
+#line 3362 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3384,7 +3388,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3388 "inc/vcf/validator_detail_v43.hpp"
+#line 3392 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3408,7 +3412,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3412 "inc/vcf/validator_detail_v43.hpp"
+#line 3416 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3426,7 +3430,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3430 "inc/vcf/validator_detail_v43.hpp"
+#line 3434 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3453,7 +3457,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3457 "inc/vcf/validator_detail_v43.hpp"
+#line 3461 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3519,7 +3523,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3523 "inc/vcf/validator_detail_v43.hpp"
+#line 3527 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr136;
 		case 95: goto tr137;
@@ -3543,7 +3547,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3547 "inc/vcf/validator_detail_v43.hpp"
+#line 3551 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st84;
 	goto tr125;
@@ -3641,7 +3645,7 @@ st96:
 	if ( ++p == pe )
 		goto _test_eof96;
 case 96:
-#line 3645 "inc/vcf/validator_detail_v43.hpp"
+#line 3649 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr153;
 		case 92: goto tr154;
@@ -3669,7 +3673,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3673 "inc/vcf/validator_detail_v43.hpp"
+#line 3677 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 92: goto tr157;
@@ -3697,7 +3701,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3701 "inc/vcf/validator_detail_v43.hpp"
+#line 3705 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st99;
 		case 62: goto st113;
@@ -3731,7 +3735,7 @@ st100:
 	if ( ++p == pe )
 		goto _test_eof100;
 case 100:
-#line 3735 "inc/vcf/validator_detail_v43.hpp"
+#line 3739 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st100;
 	if ( (*p) < 48 ) {
@@ -3766,7 +3770,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3770 "inc/vcf/validator_detail_v43.hpp"
+#line 3774 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr165;
 		case 95: goto tr164;
@@ -3793,7 +3797,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3797 "inc/vcf/validator_detail_v43.hpp"
+#line 3801 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st103;
 	goto tr125;
@@ -3828,7 +3832,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3832 "inc/vcf/validator_detail_v43.hpp"
+#line 3836 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 92: goto tr170;
@@ -3856,7 +3860,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3860 "inc/vcf/validator_detail_v43.hpp"
+#line 3864 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr171;
 		case 92: goto tr170;
@@ -3878,7 +3882,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3882 "inc/vcf/validator_detail_v43.hpp"
+#line 3886 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 44: goto tr172;
@@ -3908,7 +3912,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3912 "inc/vcf/validator_detail_v43.hpp"
+#line 3916 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 47: goto tr169;
@@ -3959,7 +3963,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3963 "inc/vcf/validator_detail_v43.hpp"
+#line 3967 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 47: goto tr169;
@@ -4010,7 +4014,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4014 "inc/vcf/validator_detail_v43.hpp"
+#line 4018 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 47: goto tr169;
@@ -4053,7 +4057,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4057 "inc/vcf/validator_detail_v43.hpp"
+#line 4061 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr180;
 		case 92: goto tr170;
@@ -4071,7 +4075,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4075 "inc/vcf/validator_detail_v43.hpp"
+#line 4079 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr153;
 		case 44: goto tr181;
@@ -4101,7 +4105,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4105 "inc/vcf/validator_detail_v43.hpp"
+#line 4109 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4140,7 +4144,7 @@ st114:
 	if ( ++p == pe )
 		goto _test_eof114;
 case 114:
-#line 4144 "inc/vcf/validator_detail_v43.hpp"
+#line 4148 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr183;
 		case 92: goto tr157;
@@ -4162,7 +4166,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4166 "inc/vcf/validator_detail_v43.hpp"
+#line 4170 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 44: goto tr184;
@@ -4182,7 +4186,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4186 "inc/vcf/validator_detail_v43.hpp"
+#line 4190 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 47: goto tr155;
@@ -4233,7 +4237,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4237 "inc/vcf/validator_detail_v43.hpp"
+#line 4241 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 47: goto tr155;
@@ -4284,7 +4288,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4288 "inc/vcf/validator_detail_v43.hpp"
+#line 4292 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr156;
 		case 47: goto tr155;
@@ -4327,7 +4331,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4331 "inc/vcf/validator_detail_v43.hpp"
+#line 4335 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr180;
 		case 92: goto tr157;
@@ -4345,7 +4349,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4349 "inc/vcf/validator_detail_v43.hpp"
+#line 4353 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4369,7 +4373,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4373 "inc/vcf/validator_detail_v43.hpp"
+#line 4377 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto st121;
 		case 95: goto st121;
@@ -4397,7 +4401,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4401 "inc/vcf/validator_detail_v43.hpp"
+#line 4405 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr194;
@@ -4416,7 +4420,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4420 "inc/vcf/validator_detail_v43.hpp"
+#line 4424 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr197;
@@ -4434,7 +4438,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4438 "inc/vcf/validator_detail_v43.hpp"
+#line 4442 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr198;
@@ -4452,7 +4456,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4456 "inc/vcf/validator_detail_v43.hpp"
+#line 4460 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr199;
@@ -4470,7 +4474,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4474 "inc/vcf/validator_detail_v43.hpp"
+#line 4478 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st127;
@@ -4497,7 +4501,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4501 "inc/vcf/validator_detail_v43.hpp"
+#line 4505 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr196;
@@ -4554,7 +4558,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4558 "inc/vcf/validator_detail_v43.hpp"
+#line 4562 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4593,7 +4597,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4597 "inc/vcf/validator_detail_v43.hpp"
+#line 4601 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr211;
 		case 95: goto tr210;
@@ -4620,7 +4624,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4624 "inc/vcf/validator_detail_v43.hpp"
+#line 4628 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr196;
@@ -4718,7 +4722,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4722 "inc/vcf/validator_detail_v43.hpp"
+#line 4726 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 92: goto tr228;
@@ -4746,7 +4750,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4750 "inc/vcf/validator_detail_v43.hpp"
+#line 4754 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr231;
@@ -4774,7 +4778,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4778 "inc/vcf/validator_detail_v43.hpp"
+#line 4782 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4808,7 +4812,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4812 "inc/vcf/validator_detail_v43.hpp"
+#line 4816 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4843,7 +4847,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4847 "inc/vcf/validator_detail_v43.hpp"
+#line 4851 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr238;
 		case 95: goto tr237;
@@ -4870,7 +4874,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 4874 "inc/vcf/validator_detail_v43.hpp"
+#line 4878 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr196;
@@ -4905,7 +4909,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 4909 "inc/vcf/validator_detail_v43.hpp"
+#line 4913 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr243;
@@ -4933,7 +4937,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4937 "inc/vcf/validator_detail_v43.hpp"
+#line 4941 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr244;
 		case 92: goto tr243;
@@ -4955,7 +4959,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 4959 "inc/vcf/validator_detail_v43.hpp"
+#line 4963 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr245;
@@ -4985,7 +4989,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 4989 "inc/vcf/validator_detail_v43.hpp"
+#line 4993 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5036,7 +5040,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5040 "inc/vcf/validator_detail_v43.hpp"
+#line 5044 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5087,7 +5091,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5091 "inc/vcf/validator_detail_v43.hpp"
+#line 5095 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5130,7 +5134,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5134 "inc/vcf/validator_detail_v43.hpp"
+#line 5138 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr243;
@@ -5148,7 +5152,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5152 "inc/vcf/validator_detail_v43.hpp"
+#line 5156 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 44: goto tr254;
@@ -5178,7 +5182,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5182 "inc/vcf/validator_detail_v43.hpp"
+#line 5186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5217,7 +5221,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5221 "inc/vcf/validator_detail_v43.hpp"
+#line 5225 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr256;
 		case 92: goto tr231;
@@ -5239,7 +5243,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5243 "inc/vcf/validator_detail_v43.hpp"
+#line 5247 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr257;
@@ -5259,7 +5263,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5263 "inc/vcf/validator_detail_v43.hpp"
+#line 5267 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5310,7 +5314,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5314 "inc/vcf/validator_detail_v43.hpp"
+#line 5318 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5361,7 +5365,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5365 "inc/vcf/validator_detail_v43.hpp"
+#line 5369 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5404,7 +5408,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5408 "inc/vcf/validator_detail_v43.hpp"
+#line 5412 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr231;
@@ -5422,7 +5426,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5426 "inc/vcf/validator_detail_v43.hpp"
+#line 5430 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5442,7 +5446,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5446 "inc/vcf/validator_detail_v43.hpp"
+#line 5450 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr266;
@@ -5460,7 +5464,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5464 "inc/vcf/validator_detail_v43.hpp"
+#line 5468 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr267;
@@ -5478,7 +5482,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5482 "inc/vcf/validator_detail_v43.hpp"
+#line 5486 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr268;
@@ -5496,7 +5500,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5500 "inc/vcf/validator_detail_v43.hpp"
+#line 5504 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st177;
@@ -5523,7 +5527,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5527 "inc/vcf/validator_detail_v43.hpp"
+#line 5531 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr265;
@@ -5580,7 +5584,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5584 "inc/vcf/validator_detail_v43.hpp"
+#line 5588 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5619,7 +5623,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5623 "inc/vcf/validator_detail_v43.hpp"
+#line 5627 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr280;
 		case 95: goto tr279;
@@ -5646,7 +5650,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5650 "inc/vcf/validator_detail_v43.hpp"
+#line 5654 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr265;
@@ -5723,7 +5727,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5727 "inc/vcf/validator_detail_v43.hpp"
+#line 5731 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	goto tr288;
@@ -5737,7 +5741,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5741 "inc/vcf/validator_detail_v43.hpp"
+#line 5745 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr265;
@@ -5803,7 +5807,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5807 "inc/vcf/validator_detail_v43.hpp"
+#line 5811 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr299;
 	if ( (*p) > 90 ) {
@@ -5822,7 +5826,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5826 "inc/vcf/validator_detail_v43.hpp"
+#line 5830 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr265;
@@ -5920,7 +5924,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 5924 "inc/vcf/validator_detail_v43.hpp"
+#line 5928 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 92: goto tr317;
@@ -5948,7 +5952,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 5952 "inc/vcf/validator_detail_v43.hpp"
+#line 5956 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr320;
@@ -5976,7 +5980,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 5980 "inc/vcf/validator_detail_v43.hpp"
+#line 5984 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6010,7 +6014,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6014 "inc/vcf/validator_detail_v43.hpp"
+#line 6018 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6045,7 +6049,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6049 "inc/vcf/validator_detail_v43.hpp"
+#line 6053 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr327;
 		case 95: goto tr326;
@@ -6072,7 +6076,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6076 "inc/vcf/validator_detail_v43.hpp"
+#line 6080 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr265;
@@ -6107,7 +6111,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6111 "inc/vcf/validator_detail_v43.hpp"
+#line 6115 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr332;
@@ -6135,7 +6139,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6139 "inc/vcf/validator_detail_v43.hpp"
+#line 6143 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr333;
 		case 92: goto tr332;
@@ -6157,7 +6161,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6161 "inc/vcf/validator_detail_v43.hpp"
+#line 6165 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr334;
@@ -6187,7 +6191,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6191 "inc/vcf/validator_detail_v43.hpp"
+#line 6195 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6238,7 +6242,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6242 "inc/vcf/validator_detail_v43.hpp"
+#line 6246 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6289,7 +6293,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6293 "inc/vcf/validator_detail_v43.hpp"
+#line 6297 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6332,7 +6336,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6336 "inc/vcf/validator_detail_v43.hpp"
+#line 6340 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr332;
@@ -6350,7 +6354,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6354 "inc/vcf/validator_detail_v43.hpp"
+#line 6358 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 44: goto tr343;
@@ -6380,7 +6384,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6384 "inc/vcf/validator_detail_v43.hpp"
+#line 6388 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6419,7 +6423,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6423 "inc/vcf/validator_detail_v43.hpp"
+#line 6427 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr345;
 		case 92: goto tr320;
@@ -6441,7 +6445,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6445 "inc/vcf/validator_detail_v43.hpp"
+#line 6449 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr346;
@@ -6461,7 +6465,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6465 "inc/vcf/validator_detail_v43.hpp"
+#line 6469 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6512,7 +6516,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6516 "inc/vcf/validator_detail_v43.hpp"
+#line 6520 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6563,7 +6567,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6567 "inc/vcf/validator_detail_v43.hpp"
+#line 6571 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6606,7 +6610,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6610 "inc/vcf/validator_detail_v43.hpp"
+#line 6614 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr320;
@@ -6624,7 +6628,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6628 "inc/vcf/validator_detail_v43.hpp"
+#line 6632 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6658,7 +6662,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6662 "inc/vcf/validator_detail_v43.hpp"
+#line 6666 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6678,7 +6682,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6682 "inc/vcf/validator_detail_v43.hpp"
+#line 6686 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr356;
@@ -6696,7 +6700,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6700 "inc/vcf/validator_detail_v43.hpp"
+#line 6704 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr357;
@@ -6714,7 +6718,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6718 "inc/vcf/validator_detail_v43.hpp"
+#line 6722 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st243;
@@ -6741,7 +6745,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6745 "inc/vcf/validator_detail_v43.hpp"
+#line 6749 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr355;
@@ -6798,7 +6802,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6802 "inc/vcf/validator_detail_v43.hpp"
+#line 6806 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6837,7 +6841,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6841 "inc/vcf/validator_detail_v43.hpp"
+#line 6845 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr369;
 		case 95: goto tr368;
@@ -6864,7 +6868,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 6868 "inc/vcf/validator_detail_v43.hpp"
+#line 6872 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr355;
@@ -6941,7 +6945,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 6945 "inc/vcf/validator_detail_v43.hpp"
+#line 6949 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	goto tr377;
@@ -6955,7 +6959,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 6959 "inc/vcf/validator_detail_v43.hpp"
+#line 6963 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr355;
@@ -7021,7 +7025,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7025 "inc/vcf/validator_detail_v43.hpp"
+#line 7029 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) > 90 ) {
@@ -7040,7 +7044,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7044 "inc/vcf/validator_detail_v43.hpp"
+#line 7048 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr355;
@@ -7138,7 +7142,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7142 "inc/vcf/validator_detail_v43.hpp"
+#line 7146 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 92: goto tr406;
@@ -7166,7 +7170,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7170 "inc/vcf/validator_detail_v43.hpp"
+#line 7174 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr409;
@@ -7194,7 +7198,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7198 "inc/vcf/validator_detail_v43.hpp"
+#line 7202 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7228,7 +7232,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7232 "inc/vcf/validator_detail_v43.hpp"
+#line 7236 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7263,7 +7267,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7267 "inc/vcf/validator_detail_v43.hpp"
+#line 7271 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr416;
 		case 95: goto tr415;
@@ -7290,7 +7294,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7294 "inc/vcf/validator_detail_v43.hpp"
+#line 7298 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr355;
@@ -7325,7 +7329,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7329 "inc/vcf/validator_detail_v43.hpp"
+#line 7333 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr421;
@@ -7353,7 +7357,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7357 "inc/vcf/validator_detail_v43.hpp"
+#line 7361 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr422;
 		case 92: goto tr421;
@@ -7375,7 +7379,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7379 "inc/vcf/validator_detail_v43.hpp"
+#line 7383 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr423;
@@ -7405,7 +7409,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7409 "inc/vcf/validator_detail_v43.hpp"
+#line 7413 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7456,7 +7460,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7460 "inc/vcf/validator_detail_v43.hpp"
+#line 7464 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7507,7 +7511,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7511 "inc/vcf/validator_detail_v43.hpp"
+#line 7515 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7550,7 +7554,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7554 "inc/vcf/validator_detail_v43.hpp"
+#line 7558 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr421;
@@ -7568,7 +7572,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7572 "inc/vcf/validator_detail_v43.hpp"
+#line 7576 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 44: goto tr432;
@@ -7598,7 +7602,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7602 "inc/vcf/validator_detail_v43.hpp"
+#line 7606 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7637,7 +7641,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7641 "inc/vcf/validator_detail_v43.hpp"
+#line 7645 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr434;
 		case 92: goto tr409;
@@ -7659,7 +7663,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7663 "inc/vcf/validator_detail_v43.hpp"
+#line 7667 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr435;
@@ -7679,7 +7683,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7683 "inc/vcf/validator_detail_v43.hpp"
+#line 7687 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7730,7 +7734,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7734 "inc/vcf/validator_detail_v43.hpp"
+#line 7738 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7781,7 +7785,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7785 "inc/vcf/validator_detail_v43.hpp"
+#line 7789 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7824,7 +7828,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7828 "inc/vcf/validator_detail_v43.hpp"
+#line 7832 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr409;
@@ -7842,7 +7846,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7846 "inc/vcf/validator_detail_v43.hpp"
+#line 7850 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7876,7 +7880,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 7880 "inc/vcf/validator_detail_v43.hpp"
+#line 7884 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -7896,7 +7900,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 7900 "inc/vcf/validator_detail_v43.hpp"
+#line 7904 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr445;
@@ -7914,7 +7918,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 7918 "inc/vcf/validator_detail_v43.hpp"
+#line 7922 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr446;
@@ -7932,7 +7936,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 7936 "inc/vcf/validator_detail_v43.hpp"
+#line 7940 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr447;
@@ -7950,7 +7954,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 7954 "inc/vcf/validator_detail_v43.hpp"
+#line 7958 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr448;
@@ -7968,7 +7972,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 7972 "inc/vcf/validator_detail_v43.hpp"
+#line 7976 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr449;
@@ -7986,7 +7990,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 7990 "inc/vcf/validator_detail_v43.hpp"
+#line 7994 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr450;
@@ -8004,7 +8008,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 8008 "inc/vcf/validator_detail_v43.hpp"
+#line 8012 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st313;
@@ -8031,7 +8035,7 @@ st314:
 	if ( ++p == pe )
 		goto _test_eof314;
 case 314:
-#line 8035 "inc/vcf/validator_detail_v43.hpp"
+#line 8039 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st315;
 	goto tr444;
@@ -8045,7 +8049,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8049 "inc/vcf/validator_detail_v43.hpp"
+#line 8053 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr455;
 	if ( (*p) < 48 ) {
@@ -8070,7 +8074,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8074 "inc/vcf/validator_detail_v43.hpp"
+#line 8078 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st316;
 	if ( (*p) < 48 ) {
@@ -8105,7 +8109,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8109 "inc/vcf/validator_detail_v43.hpp"
+#line 8113 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr459;
 		case 95: goto tr458;
@@ -8132,7 +8136,7 @@ st318:
 	if ( ++p == pe )
 		goto _test_eof318;
 case 318:
-#line 8136 "inc/vcf/validator_detail_v43.hpp"
+#line 8140 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr460;
 	if ( (*p) < 48 ) {
@@ -8157,7 +8161,7 @@ st319:
 	if ( ++p == pe )
 		goto _test_eof319;
 case 319:
-#line 8161 "inc/vcf/validator_detail_v43.hpp"
+#line 8165 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st319;
 	if ( (*p) < 48 ) {
@@ -8192,7 +8196,7 @@ st320:
 	if ( ++p == pe )
 		goto _test_eof320;
 case 320:
-#line 8196 "inc/vcf/validator_detail_v43.hpp"
+#line 8200 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr464;
 		case 62: goto tr465;
@@ -8220,7 +8224,7 @@ st321:
 	if ( ++p == pe )
 		goto _test_eof321;
 case 321:
-#line 8224 "inc/vcf/validator_detail_v43.hpp"
+#line 8228 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8240,7 +8244,7 @@ st322:
 	if ( ++p == pe )
 		goto _test_eof322;
 case 322:
-#line 8244 "inc/vcf/validator_detail_v43.hpp"
+#line 8248 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr467;
@@ -8258,7 +8262,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 8262 "inc/vcf/validator_detail_v43.hpp"
+#line 8266 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr468;
@@ -8276,7 +8280,7 @@ st324:
 	if ( ++p == pe )
 		goto _test_eof324;
 case 324:
-#line 8280 "inc/vcf/validator_detail_v43.hpp"
+#line 8284 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr469;
@@ -8294,7 +8298,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8298 "inc/vcf/validator_detail_v43.hpp"
+#line 8302 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr470;
@@ -8312,7 +8316,7 @@ st326:
 	if ( ++p == pe )
 		goto _test_eof326;
 case 326:
-#line 8316 "inc/vcf/validator_detail_v43.hpp"
+#line 8320 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st327;
@@ -8339,7 +8343,7 @@ st328:
 	if ( ++p == pe )
 		goto _test_eof328;
 case 328:
-#line 8343 "inc/vcf/validator_detail_v43.hpp"
+#line 8347 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st329;
 	goto tr466;
@@ -8396,7 +8400,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 8400 "inc/vcf/validator_detail_v43.hpp"
+#line 8404 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st333;
 	if ( (*p) < 48 ) {
@@ -8435,7 +8439,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 8439 "inc/vcf/validator_detail_v43.hpp"
+#line 8443 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr483;
 		case 95: goto tr481;
@@ -8462,7 +8466,7 @@ st335:
 	if ( ++p == pe )
 		goto _test_eof335;
 case 335:
-#line 8466 "inc/vcf/validator_detail_v43.hpp"
+#line 8470 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 71 )
 		goto st336;
 	goto tr484;
@@ -8555,7 +8559,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 8559 "inc/vcf/validator_detail_v43.hpp"
+#line 8563 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr496;
 	if ( (*p) < 35 ) {
@@ -8577,7 +8581,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 8581 "inc/vcf/validator_detail_v43.hpp"
+#line 8585 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 77 )
 		goto st346;
 	goto tr497;
@@ -8670,7 +8674,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8674 "inc/vcf/validator_detail_v43.hpp"
+#line 8678 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr509;
 	if ( (*p) < 35 ) {
@@ -8692,7 +8696,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8696 "inc/vcf/validator_detail_v43.hpp"
+#line 8700 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st356;
 	goto tr510;
@@ -8790,7 +8794,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 8794 "inc/vcf/validator_detail_v43.hpp"
+#line 8798 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr525;
 		case 92: goto tr526;
@@ -8818,7 +8822,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 8822 "inc/vcf/validator_detail_v43.hpp"
+#line 8826 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 92: goto tr529;
@@ -8846,7 +8850,7 @@ st370:
 	if ( ++p == pe )
 		goto _test_eof370;
 case 370:
-#line 8850 "inc/vcf/validator_detail_v43.hpp"
+#line 8854 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto st371;
 	goto tr510;
@@ -8879,7 +8883,7 @@ st372:
 	if ( ++p == pe )
 		goto _test_eof372;
 case 372:
-#line 8883 "inc/vcf/validator_detail_v43.hpp"
+#line 8887 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr531;
 		case 92: goto tr529;
@@ -8901,7 +8905,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 8905 "inc/vcf/validator_detail_v43.hpp"
+#line 8909 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 62: goto tr532;
@@ -8920,7 +8924,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 8924 "inc/vcf/validator_detail_v43.hpp"
+#line 8928 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8944,7 +8948,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8948 "inc/vcf/validator_detail_v43.hpp"
+#line 8952 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr534;
@@ -8962,7 +8966,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 8966 "inc/vcf/validator_detail_v43.hpp"
+#line 8970 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr535;
@@ -8980,7 +8984,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 8984 "inc/vcf/validator_detail_v43.hpp"
+#line 8988 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr536;
@@ -8998,7 +9002,7 @@ st378:
 	if ( ++p == pe )
 		goto _test_eof378;
 case 378:
-#line 9002 "inc/vcf/validator_detail_v43.hpp"
+#line 9006 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr537;
@@ -9016,7 +9020,7 @@ st379:
 	if ( ++p == pe )
 		goto _test_eof379;
 case 379:
-#line 9020 "inc/vcf/validator_detail_v43.hpp"
+#line 9024 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr538;
@@ -9034,7 +9038,7 @@ st380:
 	if ( ++p == pe )
 		goto _test_eof380;
 case 380:
-#line 9038 "inc/vcf/validator_detail_v43.hpp"
+#line 9042 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr539;
@@ -9052,7 +9056,7 @@ st381:
 	if ( ++p == pe )
 		goto _test_eof381;
 case 381:
-#line 9056 "inc/vcf/validator_detail_v43.hpp"
+#line 9060 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st382;
@@ -9079,7 +9083,7 @@ st383:
 	if ( ++p == pe )
 		goto _test_eof383;
 case 383:
-#line 9083 "inc/vcf/validator_detail_v43.hpp"
+#line 9087 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr543;
@@ -9096,7 +9100,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 9100 "inc/vcf/validator_detail_v43.hpp"
+#line 9104 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 35: goto tr542;
@@ -9160,8 +9164,8 @@ tr549:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -9179,7 +9183,7 @@ st389:
 	if ( ++p == pe )
 		goto _test_eof389;
 case 389:
-#line 9183 "inc/vcf/validator_detail_v43.hpp"
+#line 9187 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr549;
@@ -9199,7 +9203,7 @@ st390:
 	if ( ++p == pe )
 		goto _test_eof390;
 case 390:
-#line 9203 "inc/vcf/validator_detail_v43.hpp"
+#line 9207 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr551;
@@ -9217,7 +9221,7 @@ st391:
 	if ( ++p == pe )
 		goto _test_eof391;
 case 391:
-#line 9221 "inc/vcf/validator_detail_v43.hpp"
+#line 9225 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr552;
@@ -9235,7 +9239,7 @@ st392:
 	if ( ++p == pe )
 		goto _test_eof392;
 case 392:
-#line 9239 "inc/vcf/validator_detail_v43.hpp"
+#line 9243 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr553;
@@ -9253,7 +9257,7 @@ st393:
 	if ( ++p == pe )
 		goto _test_eof393;
 case 393:
-#line 9257 "inc/vcf/validator_detail_v43.hpp"
+#line 9261 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr554;
@@ -9271,7 +9275,7 @@ st394:
 	if ( ++p == pe )
 		goto _test_eof394;
 case 394:
-#line 9275 "inc/vcf/validator_detail_v43.hpp"
+#line 9279 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st395;
@@ -9298,7 +9302,7 @@ st396:
 	if ( ++p == pe )
 		goto _test_eof396;
 case 396:
-#line 9302 "inc/vcf/validator_detail_v43.hpp"
+#line 9306 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st397;
 	goto tr550;
@@ -9391,7 +9395,7 @@ st401:
 	if ( ++p == pe )
 		goto _test_eof401;
 case 401:
-#line 9395 "inc/vcf/validator_detail_v43.hpp"
+#line 9399 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr564;
 		case 59: goto tr563;
@@ -9421,7 +9425,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 9425 "inc/vcf/validator_detail_v43.hpp"
+#line 9429 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr564;
 		case 47: goto tr563;
@@ -9474,7 +9478,7 @@ st403:
 	if ( ++p == pe )
 		goto _test_eof403;
 case 403:
-#line 9478 "inc/vcf/validator_detail_v43.hpp"
+#line 9482 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr564;
 		case 47: goto tr563;
@@ -9527,7 +9531,7 @@ st404:
 	if ( ++p == pe )
 		goto _test_eof404;
 case 404:
-#line 9531 "inc/vcf/validator_detail_v43.hpp"
+#line 9535 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr564;
 		case 47: goto tr563;
@@ -9572,7 +9576,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 9576 "inc/vcf/validator_detail_v43.hpp"
+#line 9580 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr571;
 		case 34: goto tr573;
@@ -9606,7 +9610,7 @@ st406:
 	if ( ++p == pe )
 		goto _test_eof406;
 case 406:
-#line 9610 "inc/vcf/validator_detail_v43.hpp"
+#line 9614 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr575;
 		case 62: goto tr565;
@@ -9627,7 +9631,7 @@ st407:
 	if ( ++p == pe )
 		goto _test_eof407;
 case 407:
-#line 9631 "inc/vcf/validator_detail_v43.hpp"
+#line 9635 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr576;
 	if ( (*p) < 48 ) {
@@ -9652,7 +9656,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9656 "inc/vcf/validator_detail_v43.hpp"
+#line 9660 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st408;
 	if ( (*p) < 48 ) {
@@ -9687,7 +9691,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 9691 "inc/vcf/validator_detail_v43.hpp"
+#line 9695 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr580;
 		case 95: goto tr579;
@@ -9714,7 +9718,7 @@ st410:
 	if ( ++p == pe )
 		goto _test_eof410;
 case 410:
-#line 9718 "inc/vcf/validator_detail_v43.hpp"
+#line 9722 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st411;
 	if ( (*p) < 45 ) {
@@ -9757,7 +9761,7 @@ st412:
 	if ( ++p == pe )
 		goto _test_eof412;
 case 412:
-#line 9761 "inc/vcf/validator_detail_v43.hpp"
+#line 9765 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr586;
 		case 92: goto tr587;
@@ -9785,7 +9789,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9789 "inc/vcf/validator_detail_v43.hpp"
+#line 9793 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st407;
 		case 62: goto st414;
@@ -9801,7 +9805,7 @@ st414:
 	if ( ++p == pe )
 		goto _test_eof414;
 case 414:
-#line 9805 "inc/vcf/validator_detail_v43.hpp"
+#line 9809 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -9827,7 +9831,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9831 "inc/vcf/validator_detail_v43.hpp"
+#line 9835 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr590;
 		case 92: goto tr587;
@@ -9849,7 +9853,7 @@ st416:
 	if ( ++p == pe )
 		goto _test_eof416;
 case 416:
-#line 9853 "inc/vcf/validator_detail_v43.hpp"
+#line 9857 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr586;
 		case 44: goto tr591;
@@ -9889,7 +9893,7 @@ st417:
 	if ( ++p == pe )
 		goto _test_eof417;
 case 417:
-#line 9893 "inc/vcf/validator_detail_v43.hpp"
+#line 9897 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr586;
 		case 47: goto tr585;
@@ -9940,7 +9944,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 9944 "inc/vcf/validator_detail_v43.hpp"
+#line 9948 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr586;
 		case 47: goto tr585;
@@ -9991,7 +9995,7 @@ st419:
 	if ( ++p == pe )
 		goto _test_eof419;
 case 419:
-#line 9995 "inc/vcf/validator_detail_v43.hpp"
+#line 9999 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr586;
 		case 47: goto tr585;
@@ -10034,7 +10038,7 @@ st420:
 	if ( ++p == pe )
 		goto _test_eof420;
 case 420:
-#line 10038 "inc/vcf/validator_detail_v43.hpp"
+#line 10042 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr585;
@@ -10064,7 +10068,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 10068 "inc/vcf/validator_detail_v43.hpp"
+#line 10072 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr586;
 		case 44: goto tr602;
@@ -10128,7 +10132,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 10132 "inc/vcf/validator_detail_v43.hpp"
+#line 10136 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -10158,7 +10162,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 10162 "inc/vcf/validator_detail_v43.hpp"
+#line 10166 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr590;
 		case 44: goto tr602;
@@ -10178,7 +10182,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 10182 "inc/vcf/validator_detail_v43.hpp"
+#line 10186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr583;
 		case 44: goto tr605;
@@ -10208,7 +10212,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 10212 "inc/vcf/validator_detail_v43.hpp"
+#line 10216 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr574;
 		case 34: goto tr563;
@@ -10242,7 +10246,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 10246 "inc/vcf/validator_detail_v43.hpp"
+#line 10250 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr582;
 		case 34: goto tr609;
@@ -10287,7 +10291,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 10291 "inc/vcf/validator_detail_v43.hpp"
+#line 10295 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr585;
 		case 34: goto tr614;
@@ -10330,7 +10334,7 @@ st428:
 	if ( ++p == pe )
 		goto _test_eof428;
 case 428:
-#line 10334 "inc/vcf/validator_detail_v43.hpp"
+#line 10338 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr585;
 		case 34: goto tr614;
@@ -10386,7 +10390,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 10390 "inc/vcf/validator_detail_v43.hpp"
+#line 10394 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr585;
 		case 34: goto tr614;
@@ -10442,7 +10446,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 10446 "inc/vcf/validator_detail_v43.hpp"
+#line 10450 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr585;
 		case 34: goto tr614;
@@ -10489,7 +10493,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 10493 "inc/vcf/validator_detail_v43.hpp"
+#line 10497 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr598;
 		case 34: goto tr624;
@@ -10524,7 +10528,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 10528 "inc/vcf/validator_detail_v43.hpp"
+#line 10532 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr601;
 		case 34: goto tr614;
@@ -10559,7 +10563,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10563 "inc/vcf/validator_detail_v43.hpp"
+#line 10567 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr601;
 		case 34: goto tr628;
@@ -10594,7 +10598,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10598 "inc/vcf/validator_detail_v43.hpp"
+#line 10602 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr585;
 		case 34: goto tr628;
@@ -10623,7 +10627,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10627 "inc/vcf/validator_detail_v43.hpp"
+#line 10631 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr630;
@@ -10641,7 +10645,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10645 "inc/vcf/validator_detail_v43.hpp"
+#line 10649 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr631;
@@ -10659,7 +10663,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10663 "inc/vcf/validator_detail_v43.hpp"
+#line 10667 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr632;
@@ -10677,7 +10681,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10681 "inc/vcf/validator_detail_v43.hpp"
+#line 10685 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr633;
@@ -10695,7 +10699,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10699 "inc/vcf/validator_detail_v43.hpp"
+#line 10703 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr634;
@@ -10713,7 +10717,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10717 "inc/vcf/validator_detail_v43.hpp"
+#line 10721 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr635;
@@ -10731,7 +10735,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10735 "inc/vcf/validator_detail_v43.hpp"
+#line 10739 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr636;
@@ -10749,7 +10753,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 10753 "inc/vcf/validator_detail_v43.hpp"
+#line 10757 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr637;
@@ -10767,7 +10771,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10771 "inc/vcf/validator_detail_v43.hpp"
+#line 10775 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st444;
@@ -10794,7 +10798,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10798 "inc/vcf/validator_detail_v43.hpp"
+#line 10802 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st446;
 	goto tr629;
@@ -10818,7 +10822,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 10822 "inc/vcf/validator_detail_v43.hpp"
+#line 10826 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr641;
 		case 35: goto tr641;
@@ -10873,7 +10877,7 @@ st452:
 	if ( ++p == pe )
 		goto _test_eof452;
 case 452:
-#line 10877 "inc/vcf/validator_detail_v43.hpp"
+#line 10881 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr641;
 		case 62: goto tr648;
@@ -10893,7 +10897,7 @@ st453:
 	if ( ++p == pe )
 		goto _test_eof453;
 case 453:
-#line 10897 "inc/vcf/validator_detail_v43.hpp"
+#line 10901 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr649;
@@ -10909,8 +10913,8 @@ tr649:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -10928,7 +10932,7 @@ st454:
 	if ( ++p == pe )
 		goto _test_eof454;
 case 454:
-#line 10932 "inc/vcf/validator_detail_v43.hpp"
+#line 10936 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 62: goto tr648;
@@ -11255,7 +11259,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 11259 "inc/vcf/validator_detail_v43.hpp"
+#line 11263 "inc/vcf/validator_detail_v43.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr698;
 	goto tr690;
@@ -11279,7 +11283,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 11283 "inc/vcf/validator_detail_v43.hpp"
+#line 11287 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr699;
 		case 10: goto tr700;
@@ -11328,7 +11332,7 @@ st758:
 	if ( ++p == pe )
 		goto _test_eof758;
 case 758:
-#line 11332 "inc/vcf/validator_detail_v43.hpp"
+#line 11336 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr1025;
 	if ( (*p) < 65 ) {
@@ -11355,8 +11359,8 @@ tr1024:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 #line 31 "src/vcf/vcf_v43.ragel"
@@ -11372,7 +11376,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 11376 "inc/vcf/validator_detail_v43.hpp"
+#line 11380 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr704;
 		case 59: goto tr705;
@@ -11427,7 +11431,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 11431 "inc/vcf/validator_detail_v43.hpp"
+#line 11435 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr708;
 		case 45: goto tr708;
@@ -11445,7 +11449,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11449 "inc/vcf/validator_detail_v43.hpp"
+#line 11453 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr710;
 	goto tr707;
@@ -11469,7 +11473,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11473 "inc/vcf/validator_detail_v43.hpp"
+#line 11477 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr711;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11499,7 +11503,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11503 "inc/vcf/validator_detail_v43.hpp"
+#line 11507 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr713;
@@ -11526,7 +11530,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11530 "inc/vcf/validator_detail_v43.hpp"
+#line 11534 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr714;
 		case 59: goto tr716;
@@ -11552,7 +11556,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11556 "inc/vcf/validator_detail_v43.hpp"
+#line 11560 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr718;
 		case 67: goto tr718;
@@ -11586,7 +11590,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 11590 "inc/vcf/validator_detail_v43.hpp"
+#line 11594 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr719;
 		case 65: goto tr720;
@@ -11619,7 +11623,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11623 "inc/vcf/validator_detail_v43.hpp"
+#line 11627 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr722;
 		case 46: goto tr723;
@@ -11658,7 +11662,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 11662 "inc/vcf/validator_detail_v43.hpp"
+#line 11666 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr728;
 		case 44: goto tr729;
@@ -11682,7 +11686,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11686 "inc/vcf/validator_detail_v43.hpp"
+#line 11690 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr731;
 		case 45: goto tr731;
@@ -11707,7 +11711,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11711 "inc/vcf/validator_detail_v43.hpp"
+#line 11715 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr736;
 		case 73: goto tr738;
@@ -11725,7 +11729,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11729 "inc/vcf/validator_detail_v43.hpp"
+#line 11733 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr739;
 	goto tr730;
@@ -11739,7 +11743,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11743 "inc/vcf/validator_detail_v43.hpp"
+#line 11747 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr740;
 		case 69: goto tr741;
@@ -11766,7 +11770,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11770 "inc/vcf/validator_detail_v43.hpp"
+#line 11774 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr744;
 		case 58: goto tr743;
@@ -11802,7 +11806,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11806 "inc/vcf/validator_detail_v43.hpp"
+#line 11810 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto st516;
 	if ( (*p) < 65 ) {
@@ -11846,7 +11850,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11850 "inc/vcf/validator_detail_v43.hpp"
+#line 11854 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr748;
 		case 59: goto tr749;
@@ -11872,7 +11876,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11876 "inc/vcf/validator_detail_v43.hpp"
+#line 11880 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr751;
 		case 49: goto tr753;
@@ -11911,7 +11915,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11915 "inc/vcf/validator_detail_v43.hpp"
+#line 11919 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -11942,7 +11946,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11946 "inc/vcf/validator_detail_v43.hpp"
+#line 11950 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr769;
 	if ( (*p) > 90 ) {
@@ -11971,7 +11975,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11975 "inc/vcf/validator_detail_v43.hpp"
+#line 11979 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 46: goto tr771;
@@ -12005,7 +12009,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 12009 "inc/vcf/validator_detail_v43.hpp"
+#line 12013 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr774;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12031,7 +12035,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 12035 "inc/vcf/validator_detail_v43.hpp"
+#line 12039 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr766;
@@ -12058,13 +12062,13 @@ tr766:
             try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-            } catch (MetaSectionError &ex) {
-                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
-            } catch (BodySectionError &ex) {
-                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            } catch (MetaSectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
+            } catch (BodySectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError ex) {
-            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
+        } catch (BodySectionError &error) {
+            ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -12082,7 +12086,7 @@ st759:
 	if ( ++p == pe )
 		goto _test_eof759;
 case 759:
-#line 12086 "inc/vcf/validator_detail_v43.hpp"
+#line 12090 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st524;
 	if ( (*p) < 65 ) {
@@ -12099,8 +12103,8 @@ tr1025:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 	goto st524;
@@ -12108,7 +12112,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 12112 "inc/vcf/validator_detail_v43.hpp"
+#line 12116 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr778;
@@ -12132,7 +12136,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 12136 "inc/vcf/validator_detail_v43.hpp"
+#line 12140 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr779;
 		case 62: goto tr781;
@@ -12168,7 +12172,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 12172 "inc/vcf/validator_detail_v43.hpp"
+#line 12176 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr779;
 		case 61: goto tr779;
@@ -12204,7 +12208,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 12208 "inc/vcf/validator_detail_v43.hpp"
+#line 12212 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr780;
 		case 62: goto tr781;
@@ -12225,7 +12229,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 12229 "inc/vcf/validator_detail_v43.hpp"
+#line 12233 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr782;
 	goto tr703;
@@ -12246,13 +12250,13 @@ tr767:
             try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-            } catch (MetaSectionError &ex) {
-                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
-            } catch (BodySectionError &ex) {
-                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            } catch (MetaSectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
+            } catch (BodySectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError ex) {
-            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
+        } catch (BodySectionError &error) {
+            ErrorPolicy::handle_error(*this, error);
         }
     }
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -12270,7 +12274,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 12274 "inc/vcf/validator_detail_v43.hpp"
+#line 12278 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st759;
 	goto tr783;
@@ -12284,7 +12288,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 12288 "inc/vcf/validator_detail_v43.hpp"
+#line 12292 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr785;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12310,7 +12314,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 12314 "inc/vcf/validator_detail_v43.hpp"
+#line 12318 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr766;
@@ -12332,7 +12336,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 12336 "inc/vcf/validator_detail_v43.hpp"
+#line 12340 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr788;
@@ -12349,7 +12353,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 12353 "inc/vcf/validator_detail_v43.hpp"
+#line 12357 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr766;
@@ -12379,7 +12383,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 12383 "inc/vcf/validator_detail_v43.hpp"
+#line 12387 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12408,7 +12412,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 12412 "inc/vcf/validator_detail_v43.hpp"
+#line 12416 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 49: goto tr753;
 		case 65: goto tr754;
@@ -12446,7 +12450,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12450 "inc/vcf/validator_detail_v43.hpp"
+#line 12454 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12476,7 +12480,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12480 "inc/vcf/validator_detail_v43.hpp"
+#line 12484 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12506,7 +12510,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12510 "inc/vcf/validator_detail_v43.hpp"
+#line 12514 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12536,7 +12540,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12540 "inc/vcf/validator_detail_v43.hpp"
+#line 12544 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12566,7 +12570,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12570 "inc/vcf/validator_detail_v43.hpp"
+#line 12574 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr797;
@@ -12583,7 +12587,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12587 "inc/vcf/validator_detail_v43.hpp"
+#line 12591 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12603,7 +12607,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12607 "inc/vcf/validator_detail_v43.hpp"
+#line 12611 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12632,7 +12636,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12636 "inc/vcf/validator_detail_v43.hpp"
+#line 12640 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr801;
 	goto tr800;
@@ -12646,7 +12650,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12650 "inc/vcf/validator_detail_v43.hpp"
+#line 12654 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12668,7 +12672,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12672 "inc/vcf/validator_detail_v43.hpp"
+#line 12676 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12702,7 +12706,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12706 "inc/vcf/validator_detail_v43.hpp"
+#line 12710 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr807;
@@ -12727,7 +12731,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12731 "inc/vcf/validator_detail_v43.hpp"
+#line 12735 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr810;
 		case 67: goto tr810;
@@ -12753,7 +12757,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12757 "inc/vcf/validator_detail_v43.hpp"
+#line 12761 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12771,7 +12775,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12775 "inc/vcf/validator_detail_v43.hpp"
+#line 12779 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12799,7 +12803,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12803 "inc/vcf/validator_detail_v43.hpp"
+#line 12807 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr811;
@@ -12824,7 +12828,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12828 "inc/vcf/validator_detail_v43.hpp"
+#line 12832 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr813;
 		case 45: goto tr813;
@@ -12842,7 +12846,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12846 "inc/vcf/validator_detail_v43.hpp"
+#line 12850 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr814;
 	goto tr812;
@@ -12856,7 +12860,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12860 "inc/vcf/validator_detail_v43.hpp"
+#line 12864 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12877,7 +12881,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12881 "inc/vcf/validator_detail_v43.hpp"
+#line 12885 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr815;
@@ -12904,7 +12908,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12908 "inc/vcf/validator_detail_v43.hpp"
+#line 12912 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr819;
 		case 45: goto tr819;
@@ -12922,7 +12926,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12926 "inc/vcf/validator_detail_v43.hpp"
+#line 12930 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr820;
 	goto tr818;
@@ -12936,7 +12940,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12940 "inc/vcf/validator_detail_v43.hpp"
+#line 12944 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -12957,7 +12961,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12961 "inc/vcf/validator_detail_v43.hpp"
+#line 12965 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr821;
@@ -12982,7 +12986,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12986 "inc/vcf/validator_detail_v43.hpp"
+#line 12990 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr823;
 		case 45: goto tr823;
@@ -13000,7 +13004,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 13004 "inc/vcf/validator_detail_v43.hpp"
+#line 13008 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr824;
 	goto tr822;
@@ -13014,7 +13018,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 13018 "inc/vcf/validator_detail_v43.hpp"
+#line 13022 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13035,7 +13039,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 13039 "inc/vcf/validator_detail_v43.hpp"
+#line 13043 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr825;
@@ -13060,7 +13064,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 13064 "inc/vcf/validator_detail_v43.hpp"
+#line 13068 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr827;
 		case 45: goto tr827;
@@ -13078,7 +13082,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 13082 "inc/vcf/validator_detail_v43.hpp"
+#line 13086 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr828;
 	goto tr826;
@@ -13092,7 +13096,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 13096 "inc/vcf/validator_detail_v43.hpp"
+#line 13100 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13113,7 +13117,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 13117 "inc/vcf/validator_detail_v43.hpp"
+#line 13121 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr829;
@@ -13138,7 +13142,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 13142 "inc/vcf/validator_detail_v43.hpp"
+#line 13146 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr831;
 		case 45: goto tr831;
@@ -13159,7 +13163,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 13163 "inc/vcf/validator_detail_v43.hpp"
+#line 13167 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr832;
 		case 73: goto tr834;
@@ -13177,7 +13181,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 13181 "inc/vcf/validator_detail_v43.hpp"
+#line 13185 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr836;
 	goto tr830;
@@ -13191,7 +13195,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 13195 "inc/vcf/validator_detail_v43.hpp"
+#line 13199 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13214,7 +13218,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 13218 "inc/vcf/validator_detail_v43.hpp"
+#line 13222 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr838;
 		case 45: goto tr838;
@@ -13232,7 +13236,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 13236 "inc/vcf/validator_detail_v43.hpp"
+#line 13240 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr839;
 	goto tr830;
@@ -13246,7 +13250,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 13250 "inc/vcf/validator_detail_v43.hpp"
+#line 13254 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13267,7 +13271,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 13271 "inc/vcf/validator_detail_v43.hpp"
+#line 13275 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13291,7 +13295,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 13295 "inc/vcf/validator_detail_v43.hpp"
+#line 13299 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr840;
 	goto tr830;
@@ -13305,7 +13309,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 13309 "inc/vcf/validator_detail_v43.hpp"
+#line 13313 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr841;
 	goto tr830;
@@ -13319,7 +13323,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 13323 "inc/vcf/validator_detail_v43.hpp"
+#line 13327 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13338,7 +13342,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 13342 "inc/vcf/validator_detail_v43.hpp"
+#line 13346 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr842;
 	goto tr830;
@@ -13352,7 +13356,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 13356 "inc/vcf/validator_detail_v43.hpp"
+#line 13360 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr841;
 	goto tr830;
@@ -13366,7 +13370,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 13370 "inc/vcf/validator_detail_v43.hpp"
+#line 13374 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr843;
@@ -13391,7 +13395,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 13395 "inc/vcf/validator_detail_v43.hpp"
+#line 13399 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr845;
 		case 45: goto tr845;
@@ -13409,7 +13413,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 13413 "inc/vcf/validator_detail_v43.hpp"
+#line 13417 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr846;
 	goto tr844;
@@ -13423,7 +13427,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 13427 "inc/vcf/validator_detail_v43.hpp"
+#line 13431 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13447,7 +13451,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 13451 "inc/vcf/validator_detail_v43.hpp"
+#line 13455 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13477,7 +13481,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 13481 "inc/vcf/validator_detail_v43.hpp"
+#line 13485 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr848;
@@ -13502,7 +13506,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 13506 "inc/vcf/validator_detail_v43.hpp"
+#line 13510 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr850;
 		case 45: goto tr850;
@@ -13523,7 +13527,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 13527 "inc/vcf/validator_detail_v43.hpp"
+#line 13531 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr851;
 		case 73: goto tr853;
@@ -13541,7 +13545,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 13545 "inc/vcf/validator_detail_v43.hpp"
+#line 13549 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr855;
 	goto tr849;
@@ -13555,7 +13559,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 13559 "inc/vcf/validator_detail_v43.hpp"
+#line 13563 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13577,7 +13581,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 13581 "inc/vcf/validator_detail_v43.hpp"
+#line 13585 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr857;
 		case 45: goto tr857;
@@ -13595,7 +13599,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 13599 "inc/vcf/validator_detail_v43.hpp"
+#line 13603 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr858;
 	goto tr849;
@@ -13609,7 +13613,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 13613 "inc/vcf/validator_detail_v43.hpp"
+#line 13617 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13629,7 +13633,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 13633 "inc/vcf/validator_detail_v43.hpp"
+#line 13637 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13652,7 +13656,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13656 "inc/vcf/validator_detail_v43.hpp"
+#line 13660 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr859;
 	goto tr849;
@@ -13666,7 +13670,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13670 "inc/vcf/validator_detail_v43.hpp"
+#line 13674 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr860;
 	goto tr849;
@@ -13680,7 +13684,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13684 "inc/vcf/validator_detail_v43.hpp"
+#line 13688 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13698,7 +13702,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13702 "inc/vcf/validator_detail_v43.hpp"
+#line 13706 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr861;
 	goto tr849;
@@ -13712,7 +13716,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13716 "inc/vcf/validator_detail_v43.hpp"
+#line 13720 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr860;
 	goto tr849;
@@ -13730,7 +13734,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13734 "inc/vcf/validator_detail_v43.hpp"
+#line 13738 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13760,7 +13764,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13764 "inc/vcf/validator_detail_v43.hpp"
+#line 13768 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13790,7 +13794,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13794 "inc/vcf/validator_detail_v43.hpp"
+#line 13798 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13820,7 +13824,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13824 "inc/vcf/validator_detail_v43.hpp"
+#line 13828 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13850,7 +13854,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13854 "inc/vcf/validator_detail_v43.hpp"
+#line 13858 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr866;
@@ -13875,7 +13879,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13879 "inc/vcf/validator_detail_v43.hpp"
+#line 13883 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr868;
@@ -13895,7 +13899,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13899 "inc/vcf/validator_detail_v43.hpp"
+#line 13903 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13925,7 +13929,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13929 "inc/vcf/validator_detail_v43.hpp"
+#line 13933 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13956,7 +13960,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13960 "inc/vcf/validator_detail_v43.hpp"
+#line 13964 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -13985,7 +13989,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13989 "inc/vcf/validator_detail_v43.hpp"
+#line 13993 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr874;
 	goto tr873;
@@ -13999,7 +14003,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 14003 "inc/vcf/validator_detail_v43.hpp"
+#line 14007 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14017,7 +14021,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 14021 "inc/vcf/validator_detail_v43.hpp"
+#line 14025 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr875;
@@ -14042,7 +14046,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 14046 "inc/vcf/validator_detail_v43.hpp"
+#line 14050 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr877;
 		case 45: goto tr877;
@@ -14060,7 +14064,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 14064 "inc/vcf/validator_detail_v43.hpp"
+#line 14068 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr878;
 	goto tr876;
@@ -14074,7 +14078,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 14078 "inc/vcf/validator_detail_v43.hpp"
+#line 14082 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14098,7 +14102,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 14102 "inc/vcf/validator_detail_v43.hpp"
+#line 14106 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14128,7 +14132,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 14132 "inc/vcf/validator_detail_v43.hpp"
+#line 14136 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14158,7 +14162,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 14162 "inc/vcf/validator_detail_v43.hpp"
+#line 14166 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr881;
@@ -14183,7 +14187,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 14187 "inc/vcf/validator_detail_v43.hpp"
+#line 14191 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr883;
 		case 45: goto tr883;
@@ -14201,7 +14205,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 14205 "inc/vcf/validator_detail_v43.hpp"
+#line 14209 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr884;
 	goto tr882;
@@ -14215,7 +14219,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 14219 "inc/vcf/validator_detail_v43.hpp"
+#line 14223 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14239,7 +14243,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 14243 "inc/vcf/validator_detail_v43.hpp"
+#line 14247 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14270,7 +14274,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 14274 "inc/vcf/validator_detail_v43.hpp"
+#line 14278 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14299,7 +14303,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 14303 "inc/vcf/validator_detail_v43.hpp"
+#line 14307 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr890;
 	goto tr889;
@@ -14313,7 +14317,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 14317 "inc/vcf/validator_detail_v43.hpp"
+#line 14321 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14331,7 +14335,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 14335 "inc/vcf/validator_detail_v43.hpp"
+#line 14339 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14360,7 +14364,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 14364 "inc/vcf/validator_detail_v43.hpp"
+#line 14368 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr894;
 	goto tr893;
@@ -14374,7 +14378,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 14378 "inc/vcf/validator_detail_v43.hpp"
+#line 14382 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14396,7 +14400,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 14400 "inc/vcf/validator_detail_v43.hpp"
+#line 14404 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14426,7 +14430,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 14430 "inc/vcf/validator_detail_v43.hpp"
+#line 14434 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 48: goto tr896;
@@ -14452,7 +14456,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 14456 "inc/vcf/validator_detail_v43.hpp"
+#line 14460 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr898;
@@ -14477,7 +14481,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 14481 "inc/vcf/validator_detail_v43.hpp"
+#line 14485 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr900;
 		case 45: goto tr900;
@@ -14495,7 +14499,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 14499 "inc/vcf/validator_detail_v43.hpp"
+#line 14503 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr901;
 	goto tr899;
@@ -14509,7 +14513,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 14513 "inc/vcf/validator_detail_v43.hpp"
+#line 14517 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14529,7 +14533,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 14533 "inc/vcf/validator_detail_v43.hpp"
+#line 14537 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr903;
 		case 45: goto tr903;
@@ -14550,7 +14554,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 14554 "inc/vcf/validator_detail_v43.hpp"
+#line 14558 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr904;
 		case 73: goto tr906;
@@ -14568,7 +14572,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 14572 "inc/vcf/validator_detail_v43.hpp"
+#line 14576 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr908;
 	goto tr902;
@@ -14582,7 +14586,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 14586 "inc/vcf/validator_detail_v43.hpp"
+#line 14590 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14604,7 +14608,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14608 "inc/vcf/validator_detail_v43.hpp"
+#line 14612 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr910;
 		case 45: goto tr910;
@@ -14622,7 +14626,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14626 "inc/vcf/validator_detail_v43.hpp"
+#line 14630 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr911;
 	goto tr902;
@@ -14636,7 +14640,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14640 "inc/vcf/validator_detail_v43.hpp"
+#line 14644 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14656,7 +14660,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14660 "inc/vcf/validator_detail_v43.hpp"
+#line 14664 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14679,7 +14683,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14683 "inc/vcf/validator_detail_v43.hpp"
+#line 14687 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr912;
 	goto tr902;
@@ -14693,7 +14697,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14697 "inc/vcf/validator_detail_v43.hpp"
+#line 14701 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr913;
 	goto tr902;
@@ -14707,7 +14711,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14711 "inc/vcf/validator_detail_v43.hpp"
+#line 14715 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14725,7 +14729,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14729 "inc/vcf/validator_detail_v43.hpp"
+#line 14733 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr914;
 	goto tr902;
@@ -14739,7 +14743,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14743 "inc/vcf/validator_detail_v43.hpp"
+#line 14747 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr913;
 	goto tr902;
@@ -14757,7 +14761,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14761 "inc/vcf/validator_detail_v43.hpp"
+#line 14765 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14787,7 +14791,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14791 "inc/vcf/validator_detail_v43.hpp"
+#line 14795 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr916;
@@ -14812,7 +14816,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14816 "inc/vcf/validator_detail_v43.hpp"
+#line 14820 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr918;
 		case 45: goto tr918;
@@ -14830,7 +14834,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14834 "inc/vcf/validator_detail_v43.hpp"
+#line 14838 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr919;
 	goto tr917;
@@ -14844,7 +14848,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14848 "inc/vcf/validator_detail_v43.hpp"
+#line 14852 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14868,7 +14872,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14872 "inc/vcf/validator_detail_v43.hpp"
+#line 14876 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14899,7 +14903,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14903 "inc/vcf/validator_detail_v43.hpp"
+#line 14907 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr789;
 		case 61: goto tr922;
@@ -14924,7 +14928,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14928 "inc/vcf/validator_detail_v43.hpp"
+#line 14932 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr924;
 		case 45: goto tr924;
@@ -14945,7 +14949,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14949 "inc/vcf/validator_detail_v43.hpp"
+#line 14953 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr925;
 		case 73: goto tr927;
@@ -14963,7 +14967,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14967 "inc/vcf/validator_detail_v43.hpp"
+#line 14971 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr929;
 	goto tr923;
@@ -14977,7 +14981,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14981 "inc/vcf/validator_detail_v43.hpp"
+#line 14985 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -14999,7 +15003,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 15003 "inc/vcf/validator_detail_v43.hpp"
+#line 15007 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr931;
 		case 45: goto tr931;
@@ -15017,7 +15021,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 15021 "inc/vcf/validator_detail_v43.hpp"
+#line 15025 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr932;
 	goto tr923;
@@ -15031,7 +15035,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 15035 "inc/vcf/validator_detail_v43.hpp"
+#line 15039 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15051,7 +15055,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 15055 "inc/vcf/validator_detail_v43.hpp"
+#line 15059 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15074,7 +15078,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 15078 "inc/vcf/validator_detail_v43.hpp"
+#line 15082 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr933;
 	goto tr923;
@@ -15088,7 +15092,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 15092 "inc/vcf/validator_detail_v43.hpp"
+#line 15096 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr934;
 	goto tr923;
@@ -15102,7 +15106,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 15106 "inc/vcf/validator_detail_v43.hpp"
+#line 15110 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15120,7 +15124,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 15124 "inc/vcf/validator_detail_v43.hpp"
+#line 15128 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr935;
 	goto tr923;
@@ -15134,7 +15138,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 15138 "inc/vcf/validator_detail_v43.hpp"
+#line 15142 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr934;
 	goto tr923;
@@ -15148,7 +15152,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 15152 "inc/vcf/validator_detail_v43.hpp"
+#line 15156 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15178,7 +15182,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 15182 "inc/vcf/validator_detail_v43.hpp"
+#line 15186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15208,7 +15212,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 15212 "inc/vcf/validator_detail_v43.hpp"
+#line 15216 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15238,7 +15242,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 15242 "inc/vcf/validator_detail_v43.hpp"
+#line 15246 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15268,7 +15272,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 15272 "inc/vcf/validator_detail_v43.hpp"
+#line 15276 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15298,7 +15302,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 15302 "inc/vcf/validator_detail_v43.hpp"
+#line 15306 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15327,7 +15331,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 15331 "inc/vcf/validator_detail_v43.hpp"
+#line 15335 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr944;
 	goto tr943;
@@ -15341,7 +15345,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 15345 "inc/vcf/validator_detail_v43.hpp"
+#line 15349 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15363,7 +15367,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 15367 "inc/vcf/validator_detail_v43.hpp"
+#line 15371 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15393,7 +15397,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 15397 "inc/vcf/validator_detail_v43.hpp"
+#line 15401 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15423,7 +15427,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 15427 "inc/vcf/validator_detail_v43.hpp"
+#line 15431 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15453,7 +15457,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 15457 "inc/vcf/validator_detail_v43.hpp"
+#line 15461 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15483,7 +15487,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 15487 "inc/vcf/validator_detail_v43.hpp"
+#line 15491 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15513,7 +15517,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 15517 "inc/vcf/validator_detail_v43.hpp"
+#line 15521 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15543,7 +15547,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 15547 "inc/vcf/validator_detail_v43.hpp"
+#line 15551 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15573,7 +15577,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 15577 "inc/vcf/validator_detail_v43.hpp"
+#line 15581 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15603,7 +15607,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 15607 "inc/vcf/validator_detail_v43.hpp"
+#line 15611 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15632,7 +15636,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 15636 "inc/vcf/validator_detail_v43.hpp"
+#line 15640 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr956;
 	goto tr955;
@@ -15646,7 +15650,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 15650 "inc/vcf/validator_detail_v43.hpp"
+#line 15654 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr766;
@@ -15664,7 +15668,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 15668 "inc/vcf/validator_detail_v43.hpp"
+#line 15672 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr743;
 	if ( (*p) < 65 ) {
@@ -15702,7 +15706,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15706 "inc/vcf/validator_detail_v43.hpp"
+#line 15710 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr748;
 		case 58: goto st516;
@@ -15738,7 +15742,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15742 "inc/vcf/validator_detail_v43.hpp"
+#line 15746 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr957;
 		case 45: goto tr957;
@@ -15756,7 +15760,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15760 "inc/vcf/validator_detail_v43.hpp"
+#line 15764 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr958;
 	goto tr730;
@@ -15770,7 +15774,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15774 "inc/vcf/validator_detail_v43.hpp"
+#line 15778 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr740;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15796,7 +15800,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15800 "inc/vcf/validator_detail_v43.hpp"
+#line 15804 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr740;
 		case 46: goto tr736;
@@ -15826,7 +15830,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15830 "inc/vcf/validator_detail_v43.hpp"
+#line 15834 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr959;
 	goto tr730;
@@ -15840,7 +15844,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15844 "inc/vcf/validator_detail_v43.hpp"
+#line 15848 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr960;
 	goto tr730;
@@ -15854,7 +15858,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15858 "inc/vcf/validator_detail_v43.hpp"
+#line 15862 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr740;
 	goto tr730;
@@ -15872,7 +15876,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15876 "inc/vcf/validator_detail_v43.hpp"
+#line 15880 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr740;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15892,7 +15896,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15896 "inc/vcf/validator_detail_v43.hpp"
+#line 15900 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr961;
 	goto tr730;
@@ -15906,7 +15910,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15910 "inc/vcf/validator_detail_v43.hpp"
+#line 15914 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr960;
 	goto tr730;
@@ -15920,7 +15924,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15924 "inc/vcf/validator_detail_v43.hpp"
+#line 15928 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr722;
 		case 46: goto tr962;
@@ -15959,7 +15963,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15963 "inc/vcf/validator_detail_v43.hpp"
+#line 15967 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr963;
 		case 67: goto tr963;
@@ -15983,7 +15987,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15987 "inc/vcf/validator_detail_v43.hpp"
+#line 15991 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr728;
 		case 44: goto tr729;
@@ -16019,7 +16023,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 16023 "inc/vcf/validator_detail_v43.hpp"
+#line 16027 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr965;
 		case 95: goto tr965;
@@ -16043,7 +16047,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 16047 "inc/vcf/validator_detail_v43.hpp"
+#line 16051 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr966;
 		case 95: goto tr964;
@@ -16077,7 +16081,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 16081 "inc/vcf/validator_detail_v43.hpp"
+#line 16085 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr728;
 		case 44: goto tr729;
@@ -16106,7 +16110,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 16110 "inc/vcf/validator_detail_v43.hpp"
+#line 16114 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr971;
 	if ( (*p) < 65 ) {
@@ -16128,7 +16132,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 16132 "inc/vcf/validator_detail_v43.hpp"
+#line 16136 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr974;
 		case 59: goto tr972;
@@ -16165,7 +16169,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 16169 "inc/vcf/validator_detail_v43.hpp"
+#line 16173 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr972;
 		case 61: goto tr972;
@@ -16201,7 +16205,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 16205 "inc/vcf/validator_detail_v43.hpp"
+#line 16209 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr974;
 		case 61: goto tr973;
@@ -16222,7 +16226,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 16226 "inc/vcf/validator_detail_v43.hpp"
+#line 16230 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr975;
 		case 45: goto tr975;
@@ -16240,7 +16244,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 16244 "inc/vcf/validator_detail_v43.hpp"
+#line 16248 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr976;
 	goto tr721;
@@ -16254,7 +16258,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 16258 "inc/vcf/validator_detail_v43.hpp"
+#line 16262 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr966;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16270,7 +16274,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 16274 "inc/vcf/validator_detail_v43.hpp"
+#line 16278 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr977;
@@ -16290,7 +16294,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 16294 "inc/vcf/validator_detail_v43.hpp"
+#line 16298 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr978;
 		case 62: goto tr980;
@@ -16326,7 +16330,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 16330 "inc/vcf/validator_detail_v43.hpp"
+#line 16334 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr978;
 		case 61: goto tr978;
@@ -16362,7 +16366,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 16366 "inc/vcf/validator_detail_v43.hpp"
+#line 16370 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr979;
 		case 62: goto tr980;
@@ -16383,7 +16387,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 16387 "inc/vcf/validator_detail_v43.hpp"
+#line 16391 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr974;
 	goto tr721;
@@ -16397,7 +16401,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 16401 "inc/vcf/validator_detail_v43.hpp"
+#line 16405 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr982;
 	if ( (*p) < 65 ) {
@@ -16419,7 +16423,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 16423 "inc/vcf/validator_detail_v43.hpp"
+#line 16427 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr985;
 		case 59: goto tr983;
@@ -16456,7 +16460,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 16460 "inc/vcf/validator_detail_v43.hpp"
+#line 16464 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr983;
 		case 61: goto tr983;
@@ -16492,7 +16496,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 16496 "inc/vcf/validator_detail_v43.hpp"
+#line 16500 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr985;
 		case 61: goto tr984;
@@ -16513,7 +16517,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 16517 "inc/vcf/validator_detail_v43.hpp"
+#line 16521 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr986;
 		case 45: goto tr986;
@@ -16531,7 +16535,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 16535 "inc/vcf/validator_detail_v43.hpp"
+#line 16539 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr987;
 	goto tr721;
@@ -16545,7 +16549,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 16549 "inc/vcf/validator_detail_v43.hpp"
+#line 16553 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr966;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16561,7 +16565,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 16565 "inc/vcf/validator_detail_v43.hpp"
+#line 16569 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr988;
@@ -16581,7 +16585,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 16585 "inc/vcf/validator_detail_v43.hpp"
+#line 16589 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr989;
 		case 62: goto tr991;
@@ -16617,7 +16621,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 16621 "inc/vcf/validator_detail_v43.hpp"
+#line 16625 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr989;
 		case 61: goto tr989;
@@ -16653,7 +16657,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 16657 "inc/vcf/validator_detail_v43.hpp"
+#line 16661 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr990;
 		case 62: goto tr991;
@@ -16674,7 +16678,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 16678 "inc/vcf/validator_detail_v43.hpp"
+#line 16682 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr985;
 	goto tr721;
@@ -16692,7 +16696,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 16696 "inc/vcf/validator_detail_v43.hpp"
+#line 16700 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr993;
 	if ( (*p) < 65 ) {
@@ -16714,7 +16718,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 16718 "inc/vcf/validator_detail_v43.hpp"
+#line 16722 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr996;
 		case 59: goto tr994;
@@ -16751,7 +16755,7 @@ st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 16755 "inc/vcf/validator_detail_v43.hpp"
+#line 16759 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr994;
 		case 61: goto tr994;
@@ -16787,7 +16791,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 16791 "inc/vcf/validator_detail_v43.hpp"
+#line 16795 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr996;
 		case 61: goto tr995;
@@ -16808,7 +16812,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 16812 "inc/vcf/validator_detail_v43.hpp"
+#line 16816 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr997;
 		case 45: goto tr997;
@@ -16826,7 +16830,7 @@ st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 16830 "inc/vcf/validator_detail_v43.hpp"
+#line 16834 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr998;
 	goto tr721;
@@ -16840,7 +16844,7 @@ st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 16844 "inc/vcf/validator_detail_v43.hpp"
+#line 16848 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr999;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16856,7 +16860,7 @@ st734:
 	if ( ++p == pe )
 		goto _test_eof734;
 case 734:
-#line 16860 "inc/vcf/validator_detail_v43.hpp"
+#line 16864 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr1000;
@@ -16876,7 +16880,7 @@ st735:
 	if ( ++p == pe )
 		goto _test_eof735;
 case 735:
-#line 16880 "inc/vcf/validator_detail_v43.hpp"
+#line 16884 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1001;
 		case 62: goto tr1003;
@@ -16912,7 +16916,7 @@ st736:
 	if ( ++p == pe )
 		goto _test_eof736;
 case 736:
-#line 16916 "inc/vcf/validator_detail_v43.hpp"
+#line 16920 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1001;
 		case 61: goto tr1001;
@@ -16948,7 +16952,7 @@ st737:
 	if ( ++p == pe )
 		goto _test_eof737;
 case 737:
-#line 16952 "inc/vcf/validator_detail_v43.hpp"
+#line 16956 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1002;
 		case 62: goto tr1003;
@@ -16969,7 +16973,7 @@ st738:
 	if ( ++p == pe )
 		goto _test_eof738;
 case 738:
-#line 16973 "inc/vcf/validator_detail_v43.hpp"
+#line 16977 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr996;
 	goto tr721;
@@ -16987,7 +16991,7 @@ st739:
 	if ( ++p == pe )
 		goto _test_eof739;
 case 739:
-#line 16991 "inc/vcf/validator_detail_v43.hpp"
+#line 16995 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr1005;
 	if ( (*p) < 65 ) {
@@ -17009,7 +17013,7 @@ st740:
 	if ( ++p == pe )
 		goto _test_eof740;
 case 740:
-#line 17013 "inc/vcf/validator_detail_v43.hpp"
+#line 17017 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr1008;
 		case 59: goto tr1006;
@@ -17046,7 +17050,7 @@ st741:
 	if ( ++p == pe )
 		goto _test_eof741;
 case 741:
-#line 17050 "inc/vcf/validator_detail_v43.hpp"
+#line 17054 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1006;
 		case 61: goto tr1006;
@@ -17082,7 +17086,7 @@ st742:
 	if ( ++p == pe )
 		goto _test_eof742;
 case 742:
-#line 17086 "inc/vcf/validator_detail_v43.hpp"
+#line 17090 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 58: goto tr1008;
 		case 61: goto tr1007;
@@ -17103,7 +17107,7 @@ st743:
 	if ( ++p == pe )
 		goto _test_eof743;
 case 743:
-#line 17107 "inc/vcf/validator_detail_v43.hpp"
+#line 17111 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1009;
 		case 45: goto tr1009;
@@ -17121,7 +17125,7 @@ st744:
 	if ( ++p == pe )
 		goto _test_eof744;
 case 744:
-#line 17125 "inc/vcf/validator_detail_v43.hpp"
+#line 17129 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1010;
 	goto tr721;
@@ -17135,7 +17139,7 @@ st745:
 	if ( ++p == pe )
 		goto _test_eof745;
 case 745:
-#line 17139 "inc/vcf/validator_detail_v43.hpp"
+#line 17143 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr999;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17151,7 +17155,7 @@ st746:
 	if ( ++p == pe )
 		goto _test_eof746;
 case 746:
-#line 17155 "inc/vcf/validator_detail_v43.hpp"
+#line 17159 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr1011;
@@ -17171,7 +17175,7 @@ st747:
 	if ( ++p == pe )
 		goto _test_eof747;
 case 747:
-#line 17175 "inc/vcf/validator_detail_v43.hpp"
+#line 17179 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1012;
 		case 62: goto tr1014;
@@ -17207,7 +17211,7 @@ st748:
 	if ( ++p == pe )
 		goto _test_eof748;
 case 748:
-#line 17211 "inc/vcf/validator_detail_v43.hpp"
+#line 17215 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1012;
 		case 61: goto tr1012;
@@ -17243,7 +17247,7 @@ st749:
 	if ( ++p == pe )
 		goto _test_eof749;
 case 749:
-#line 17247 "inc/vcf/validator_detail_v43.hpp"
+#line 17251 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr1013;
 		case 62: goto tr1014;
@@ -17264,7 +17268,7 @@ st750:
 	if ( ++p == pe )
 		goto _test_eof750;
 case 750:
-#line 17268 "inc/vcf/validator_detail_v43.hpp"
+#line 17272 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1008;
 	goto tr721;
@@ -17282,7 +17286,7 @@ st751:
 	if ( ++p == pe )
 		goto _test_eof751;
 case 751:
-#line 17286 "inc/vcf/validator_detail_v43.hpp"
+#line 17290 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr728;
 		case 65: goto tr963;
@@ -17307,7 +17311,7 @@ st752:
 	if ( ++p == pe )
 		goto _test_eof752;
 case 752:
-#line 17311 "inc/vcf/validator_detail_v43.hpp"
+#line 17315 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 59: goto tr705;
 		case 61: goto tr705;
@@ -17343,7 +17347,7 @@ st753:
 	if ( ++p == pe )
 		goto _test_eof753;
 case 753:
-#line 17347 "inc/vcf/validator_detail_v43.hpp"
+#line 17351 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr704;
 		case 59: goto tr706;
@@ -17395,7 +17399,7 @@ st754:
 	if ( ++p == pe )
 		goto _test_eof754;
 case 754:
-#line 17399 "inc/vcf/validator_detail_v43.hpp"
+#line 17403 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st758;
 	goto tr690;
@@ -17419,7 +17423,7 @@ st755:
 	if ( ++p == pe )
 		goto _test_eof755;
 case 755:
-#line 17423 "inc/vcf/validator_detail_v43.hpp"
+#line 17427 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -17439,7 +17443,7 @@ st756:
 	if ( ++p == pe )
 		goto _test_eof756;
 case 756:
-#line 17443 "inc/vcf/validator_detail_v43.hpp"
+#line 17447 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1018;
 		case 13: goto tr1019;
@@ -17456,14 +17460,14 @@ tr1018:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 773 "src/vcf/vcf_v43.ragel"
+#line 775 "src/vcf/vcf_v43.ragel"
 	{ {goto st28;} }
 	goto st760;
 st760:
 	if ( ++p == pe )
 		goto _test_eof760;
 case 760:
-#line 17467 "inc/vcf/validator_detail_v43.hpp"
+#line 17471 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 tr1022:
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -17481,7 +17485,7 @@ st757:
 	if ( ++p == pe )
 		goto _test_eof757;
 case 757:
-#line 17485 "inc/vcf/validator_detail_v43.hpp"
+#line 17489 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1021;
 		case 13: goto tr1022;
@@ -17498,14 +17502,14 @@ tr1021:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 774 "src/vcf/vcf_v43.ragel"
+#line 776 "src/vcf/vcf_v43.ragel"
 	{ {goto st759;} }
 	goto st761;
 st761:
 	if ( ++p == pe )
 		goto _test_eof761;
 case 761:
-#line 17509 "inc/vcf/validator_detail_v43.hpp"
+#line 17513 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -18289,7 +18293,7 @@ case 761:
 	case 755: 
 #line 60 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18343,7 +18347,7 @@ case 761:
 	case 73: 
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18352,8 +18356,8 @@ case 761:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 	break;
@@ -18369,13 +18373,13 @@ case 761:
 	case 754: 
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
@@ -18384,7 +18388,7 @@ case 761:
 	case 529: 
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -18398,13 +18402,13 @@ case 761:
 	case 21: 
 #line 214 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.3'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         p--; {goto st756;}
     }
 #line 60 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18432,12 +18436,12 @@ case 761:
 	case 113: 
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18449,14 +18453,14 @@ case 761:
 	case 380: 
 	case 381: 
 	case 382: 
-#line 232 "src/vcf/vcf_v43.ragel"
+#line 233 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18489,14 +18493,14 @@ case 761:
 	case 422: 
 	case 423: 
 	case 424: 
-#line 238 "src/vcf/vcf_v43.ragel"
+#line 239 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18524,14 +18528,14 @@ case 761:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18571,14 +18575,14 @@ case 761:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18617,14 +18621,14 @@ case 761:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18638,14 +18642,14 @@ case 761:
 	case 313: 
 	case 314: 
 	case 321: 
-#line 282 "src/vcf/vcf_v43.ragel"
+#line 283 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18660,14 +18664,14 @@ case 761:
 	case 443: 
 	case 444: 
 	case 445: 
-#line 288 "src/vcf/vcf_v43.ragel"
+#line 289 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18682,14 +18686,14 @@ case 761:
 	case 330: 
 	case 331: 
 	case 371: 
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -18730,28 +18734,29 @@ case 761:
 	case 489: 
 	case 490: 
 	case 491: 
-#line 326 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
@@ -18765,54 +18770,54 @@ case 761:
 	case 528: 
 	case 752: 
 	case 753: 
-#line 342 "src/vcf/vcf_v43.ragel"
+#line 344 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 502: 
 	case 503: 
 	case 504: 
-#line 348 "src/vcf/vcf_v43.ragel"
+#line 350 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 505: 
 	case 506: 
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 507: 
 	case 508: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -18873,14 +18878,14 @@ case 761:
 	case 749: 
 	case 750: 
 	case 751: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 368 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -18898,14 +18903,14 @@ case 761:
 	case 694: 
 	case 695: 
 	case 696: 
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -18914,54 +18919,54 @@ case 761:
 	case 517: 
 	case 685: 
 	case 686: 
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 380 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 519: 
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 520: 
 	case 521: 
-#line 505 "src/vcf/vcf_v43.ragel"
+#line 507 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 532: 
 	case 533: 
-#line 511 "src/vcf/vcf_v43.ragel"
+#line 513 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -18969,31 +18974,32 @@ case 761:
 	case 28: 
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
-#line 326 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
@@ -19004,108 +19010,109 @@ case 761:
 	case 121: 
 #line 226 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 122: 
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 192: 
 	case 193: 
 	case 239: 
-#line 255 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 258: 
 	case 259: 
 	case 305: 
-#line 271 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 199: 
 	case 200: 
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 277 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 265: 
 	case 266: 
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 277 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19118,19 +19125,19 @@ case 761:
 	case 341: 
 	case 342: 
 	case 343: 
-#line 299 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19143,38 +19150,38 @@ case 761:
 	case 351: 
 	case 352: 
 	case 353: 
-#line 304 "src/vcf/vcf_v43.ragel"
+#line 305 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 99: 
 	case 100: 
 	case 101: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19194,19 +19201,19 @@ case 761:
 	case 432: 
 	case 433: 
 	case 434: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 238 "src/vcf/vcf_v43.ragel"
+#line 239 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19216,19 +19223,19 @@ case 761:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19238,19 +19245,19 @@ case 761:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19260,19 +19267,19 @@ case 761:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19282,37 +19289,37 @@ case 761:
 	case 318: 
 	case 319: 
 	case 320: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 282 "src/vcf/vcf_v43.ragel"
+#line 283 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 332: 
 	case 333: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19330,19 +19337,19 @@ case 761:
 	case 115: 
 	case 119: 
 	case 120: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19360,19 +19367,19 @@ case 761:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19390,19 +19397,19 @@ case 761:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19420,19 +19427,19 @@ case 761:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19455,19 +19462,19 @@ case 761:
 	case 372: 
 	case 373: 
 	case 374: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19478,19 +19485,19 @@ case 761:
 	case 387: 
 	case 388: 
 	case 389: 
-#line 320 "src/vcf/vcf_v43.ragel"
+#line 321 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st756;}
     }
-#line 232 "src/vcf/vcf_v43.ragel"
+#line 233 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19503,19 +19510,19 @@ case 761:
 	case 452: 
 	case 453: 
 	case 454: 
-#line 320 "src/vcf/vcf_v43.ragel"
+#line 321 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st756;}
     }
-#line 288 "src/vcf/vcf_v43.ragel"
+#line 289 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
@@ -19567,132 +19574,132 @@ case 761:
 	case 679: 
 	case 680: 
 	case 681: 
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 540: 
 	case 541: 
-#line 394 "src/vcf/vcf_v43.ragel"
+#line 396 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 547: 
 	case 548: 
 	case 549: 
-#line 399 "src/vcf/vcf_v43.ragel"
+#line 401 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 551: 
 	case 552: 
 	case 553: 
-#line 404 "src/vcf/vcf_v43.ragel"
+#line 406 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 555: 
 	case 556: 
 	case 557: 
-#line 409 "src/vcf/vcf_v43.ragel"
+#line 411 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AD value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AD value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 559: 
 	case 560: 
 	case 561: 
-#line 414 "src/vcf/vcf_v43.ragel"
+#line 416 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info ADF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info ADF value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 563: 
 	case 564: 
 	case 565: 
-#line 419 "src/vcf/vcf_v43.ragel"
+#line 421 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info ADR value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info ADR value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -19709,38 +19716,38 @@ case 761:
 	case 577: 
 	case 578: 
 	case 579: 
-#line 424 "src/vcf/vcf_v43.ragel"
+#line 426 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 581: 
 	case 582: 
 	case 583: 
-#line 429 "src/vcf/vcf_v43.ragel"
+#line 431 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -19757,129 +19764,129 @@ case 761:
 	case 596: 
 	case 597: 
 	case 598: 
-#line 434 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 604: 
 	case 605: 
-#line 439 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 608: 
 	case 609: 
-#line 444 "src/vcf/vcf_v43.ragel"
+#line 446 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 611: 
 	case 612: 
 	case 613: 
-#line 449 "src/vcf/vcf_v43.ragel"
+#line 451 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 617: 
 	case 618: 
 	case 619: 
-#line 454 "src/vcf/vcf_v43.ragel"
+#line 456 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 622: 
 	case 623: 
-#line 459 "src/vcf/vcf_v43.ragel"
+#line 461 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 625: 
 	case 626: 
-#line 464 "src/vcf/vcf_v43.ragel"
+#line 466 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -19896,57 +19903,57 @@ case 761:
 	case 643: 
 	case 644: 
 	case 645: 
-#line 469 "src/vcf/vcf_v43.ragel"
+#line 471 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 630: 
 	case 631: 
 	case 632: 
-#line 474 "src/vcf/vcf_v43.ragel"
+#line 476 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 648: 
 	case 649: 
 	case 650: 
-#line 479 "src/vcf/vcf_v43.ragel"
+#line 481 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -19963,73 +19970,73 @@ case 761:
 	case 663: 
 	case 664: 
 	case 665: 
-#line 484 "src/vcf/vcf_v43.ragel"
+#line 486 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 672: 
 	case 673: 
-#line 489 "src/vcf/vcf_v43.ragel"
+#line 491 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 683: 
 	case 684: 
-#line 494 "src/vcf/vcf_v43.ragel"
+#line 496 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 543: 
 	case 544: 
-#line 499 "src/vcf/vcf_v43.ragel"
+#line 501 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
@@ -20037,514 +20044,515 @@ case 761:
 	case 523: 
 	case 530: 
 	case 531: 
-#line 518 "src/vcf/vcf_v43.ragel"
+#line 520 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st757;}
     }
-#line 511 "src/vcf/vcf_v43.ragel"
+#line 513 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 22: 
 #line 60 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
-#line 326 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 #line 78 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st757;}
     }
 	break;
 	case 344: 
-#line 299 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 304 "src/vcf/vcf_v43.ragel"
+#line 305 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 354: 
-#line 304 "src/vcf/vcf_v43.ragel"
+#line 305 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 334: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 299 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 107: 
 	case 108: 
 	case 109: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 159: 
 	case 160: 
 	case 161: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 225: 
 	case 226: 
 	case 227: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 291: 
 	case 292: 
 	case 293: 
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 116: 
 	case 117: 
 	case 118: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 168: 
 	case 169: 
 	case 170: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 234: 
 	case 235: 
 	case 236: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 300: 
 	case 301: 
 	case 302: 
-#line 315 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st756;}
     }
-#line 310 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
 	case 607: 
-#line 444 "src/vcf/vcf_v43.ragel"
+#line 446 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 621: 
-#line 459 "src/vcf/vcf_v43.ragel"
+#line 461 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 624: 
-#line 464 "src/vcf/vcf_v43.ragel"
+#line 466 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 671: 
-#line 489 "src/vcf/vcf_v43.ragel"
+#line 491 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 682: 
-#line 494 "src/vcf/vcf_v43.ragel"
+#line 496 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 542: 
-#line 499 "src/vcf/vcf_v43.ragel"
+#line 501 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         p--; {goto st757;}
     }
-#line 389 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st757;}
     }
-#line 384 "src/vcf/vcf_v43.ragel"
+#line 386 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st757;}
     }
 #line 91 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         p--; {goto st757;}
     }
 	break;
 	case 24: 
 #line 221 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st756;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st756;}
     }
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st756;}
     }
-#line 266 "src/vcf/vcf_v43.ragel"
+#line 267 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st756;}
     }
-#line 232 "src/vcf/vcf_v43.ragel"
+#line 233 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st756;}
     }
-#line 238 "src/vcf/vcf_v43.ragel"
+#line 239 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st756;}
     }
-#line 294 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st756;}
     }
-#line 282 "src/vcf/vcf_v43.ragel"
+#line 283 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st756;}
     }
-#line 288 "src/vcf/vcf_v43.ragel"
+#line 289 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st756;}
     }
 #line 65 "src/vcf/vcf_v43.ragel"
 	{
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         p--; {goto st756;}
     }
 	break;
-#line 20541 "inc/vcf/validator_detail_v43.hpp"
+#line 20549 "inc/vcf/validator_detail_v43.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 805 "src/vcf/vcf_v43.ragel"
+#line 807 "src/vcf/vcf_v43.ragel"
 
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ namespace
             return ValidationLevel::stop;
         }
         
-        throw std::invalid_argument("Please choose one of the accepted validation levels");
+        throw std::invalid_argument{"Please choose one of the accepted validation levels"};
     }
     
     ebi::vcf::Version get_version(std::string const & version_str)
@@ -101,7 +101,7 @@ namespace
             return ebi::vcf::Version::v43;
         }
         
-        throw std::invalid_argument("Please choose one of the accepted VCF fileformat versions");
+        throw std::invalid_argument{"Please choose one of the accepted VCF fileformat versions"};
     }
     
     
@@ -130,7 +130,7 @@ namespace
                             std::make_shared<ebi::vcf::Source>(source),
                             std::make_shared<std::vector<ebi::vcf::Record>>(records)));
             default:
-                throw std::invalid_argument("Please choose one of the accepted VCF fileformat versions");
+                throw std::invalid_argument{"Please choose one of the accepted VCF fileformat versions"};
             }
         
         case ValidationLevel::warning:
@@ -151,7 +151,7 @@ namespace
                             std::make_shared<ebi::vcf::Source>(source),
                             std::make_shared<std::vector<ebi::vcf::Record>>(records)));
             default:
-                throw std::invalid_argument("Please choose one of the accepted VCF fileformat versions");
+                throw std::invalid_argument{"Please choose one of the accepted VCF fileformat versions"};
             }
             
         case ValidationLevel::stop:
@@ -172,11 +172,11 @@ namespace
                             std::make_shared<ebi::vcf::Source>(source),
                             std::make_shared<std::vector<ebi::vcf::Record>>(records)));
             default:
-                throw std::invalid_argument("Please choose one of the accepted VCF fileformat versions");
+                throw std::invalid_argument{"Please choose one of the accepted VCF fileformat versions"};
             }
             
         default:
-            throw std::invalid_argument("Please choose one of the accepted validation levels");
+            throw std::invalid_argument{"Please choose one of the accepted validation levels"};
         }
     }
     

--- a/src/vcf/abort_error_policy.cpp
+++ b/src/vcf/abort_error_policy.cpp
@@ -21,6 +21,16 @@ namespace ebi
   namespace vcf
   {
 
+    void AbortErrorPolicy::handle_error(ParsingState &state, const Error &error)
+    {
+        state.m_is_valid = false;
+        throw error;
+    }
+    void AbortErrorPolicy::handle_warning(ParsingState &state, const Error &error)
+    {
+        std::cerr << error.what() << " (warning)" << std::endl;
+    }
+
     void AbortErrorPolicy::handle_fileformat_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;

--- a/src/vcf/abort_error_policy.cpp
+++ b/src/vcf/abort_error_policy.cpp
@@ -16,21 +16,6 @@
 
 #include "vcf/error_policy.hpp"
 
-namespace
-{
-    using namespace ebi::vcf;
-
-    void throw_syntax_error(ParsingState const &)
-    {
-        throw ParsingError("Invalid VCF syntax");
-    }
-
-    void throw_syntax_error(std::string const & msg)
-    {
-        throw ParsingError(msg);
-    }
-}
-
 namespace ebi
 {
   namespace vcf
@@ -39,46 +24,46 @@ namespace ebi
     void AbortErrorPolicy::handle_fileformat_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        throw_syntax_error("Line " + std::to_string(state.n_lines) + ": " + message);
+        throw FileformatError(state.n_lines, message);
     }
 
     void AbortErrorPolicy::handle_meta_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        throw_syntax_error("Line " + std::to_string(state.n_lines) + ": " + message);
+        throw MetaSectionError(state.n_lines, message);
     }
 
     void AbortErrorPolicy::handle_header_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        throw_syntax_error("Line " + std::to_string(state.n_lines) + ": " + message);
+        throw HeaderSectionError(state.n_lines, message);
     }
 
     void AbortErrorPolicy::handle_body_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        throw_syntax_error("Line " + std::to_string(state.n_lines) + ": " + message);
+        throw HeaderSectionError(state.n_lines, message);
     }
 
     
     void AbortErrorPolicy::handle_fileformat_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << FileformatError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
     void AbortErrorPolicy::handle_meta_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << MetaSectionError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
     void AbortErrorPolicy::handle_header_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << HeaderSectionError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
     void AbortErrorPolicy::handle_body_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << BodySectionError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
   }

--- a/src/vcf/abort_error_policy.cpp
+++ b/src/vcf/abort_error_policy.cpp
@@ -20,7 +20,6 @@ namespace ebi
 {
   namespace vcf
   {
-
     void AbortErrorPolicy::handle_error(ParsingState &state, const Error &error)
     {
         state.m_is_valid = false;
@@ -30,51 +29,5 @@ namespace ebi
     {
         std::cerr << error.what() << " (warning)" << std::endl;
     }
-
-    void AbortErrorPolicy::handle_fileformat_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        throw FileformatError(state.n_lines, message);
-    }
-
-    void AbortErrorPolicy::handle_meta_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        throw MetaSectionError(state.n_lines, message);
-    }
-
-    void AbortErrorPolicy::handle_header_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        throw HeaderSectionError(state.n_lines, message);
-    }
-
-    void AbortErrorPolicy::handle_body_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        throw HeaderSectionError(state.n_lines, message);
-    }
-
-    
-    void AbortErrorPolicy::handle_fileformat_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << FileformatError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
-    void AbortErrorPolicy::handle_meta_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << MetaSectionError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
-    void AbortErrorPolicy::handle_header_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << HeaderSectionError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
-    void AbortErrorPolicy::handle_body_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << BodySectionError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
   }
 }

--- a/src/vcf/abort_error_policy.cpp
+++ b/src/vcf/abort_error_policy.cpp
@@ -23,7 +23,7 @@ namespace ebi
     void AbortErrorPolicy::handle_error(ParsingState &state, const Error &error)
     {
         state.m_is_valid = false;
-        throw error;
+        throw;
     }
     void AbortErrorPolicy::handle_warning(ParsingState &state, const Error &error)
     {

--- a/src/vcf/meta_entry.cpp
+++ b/src/vcf/meta_entry.cpp
@@ -26,14 +26,14 @@ namespace ebi
   
     MetaEntry::MetaEntry(size_t line,
                          std::string const & id)
-    : line(line), id{id}, structure{Structure::NoValue}
+    : line{line}, id{id}, structure{Structure::NoValue}
     {
     }
         
     MetaEntry::MetaEntry(size_t line,
                          std::string const & id,
                          std::string const & plain_value)
-    : line(line), id{id}, structure{Structure::PlainValue}, value{plain_value}
+    : line{line}, id{id}, structure{Structure::PlainValue}, value{plain_value}
     {
         check_value();
     }
@@ -41,7 +41,7 @@ namespace ebi
     MetaEntry::MetaEntry(size_t line,
                          std::string const & id,
                          std::map<std::string, std::string> const & key_values)
-    : line(line), id{id}, structure{Structure::KeyValue}, value{key_values}
+    : line{line}, id{id}, structure{Structure::KeyValue}, value{key_values}
     {
         check_value();
     }
@@ -73,7 +73,7 @@ namespace ebi
     void MetaEntryVisitor::operator()(std::string & value) const
     {
         if (find_if(value.begin(), value.end(), [](char c) { return c == '\n'; }) != value.end()) {
-            throw MetaSectionError(entry.line, "Metadata value contains a line break");
+            throw MetaSectionError{entry.line, "Metadata value contains a line break"};
         }
     }
     
@@ -105,10 +105,10 @@ namespace ebi
     {
         // It must contain an ID and Description
         if (value.count("ID") == 0) {
-            throw MetaSectionError(entry.line, "ALT metadata does not contain a field called 'ID'");
+            throw MetaSectionError{entry.line, "ALT metadata does not contain a field called 'ID'"};
         }
         if (value.count("Description") == 0) {
-            throw MetaSectionError(entry.line, "ALT metadata does not contain a field called 'Description'");
+            throw MetaSectionError{entry.line, "ALT metadata does not contain a field called 'Description'"};
         }
         
         // Check ID prefix is "DEL" | "INS" | "DUP" | "INV" | "CNV"
@@ -122,7 +122,7 @@ namespace ebi
             prefix != "DUP" && 
             prefix != "INV" && 
             prefix != "CNV") {
-            throw MetaSectionError(entry.line, "ALT metadata ID does not begin with DEL/INS/DUP/INV/CNV");
+            throw MetaSectionError{entry.line, "ALT metadata ID does not begin with DEL/INS/DUP/INV/CNV"};
         }
     }
     
@@ -130,7 +130,7 @@ namespace ebi
     {
         // It must contain an ID and Description
         if (value.count("ID") == 0) {
-            throw MetaSectionError(entry.line, "contig metadata does not contain a field called 'ID'");
+            throw MetaSectionError{entry.line, "contig metadata does not contain a field called 'ID'"};
         }
     }
     
@@ -138,10 +138,10 @@ namespace ebi
     {
         // It must contain an ID and Description
         if (value.count("ID") == 0) {
-            throw MetaSectionError(entry.line, "FILTER metadata does not contain a field called 'ID'");
+            throw MetaSectionError{entry.line, "FILTER metadata does not contain a field called 'ID'"};
         }
         if (value.count("Description") == 0) {
-            throw MetaSectionError(entry.line, "FILTER metadata does not contain a field called 'Description'");
+            throw MetaSectionError{entry.line, "FILTER metadata does not contain a field called 'Description'"};
         }
     }
     
@@ -149,16 +149,16 @@ namespace ebi
     {
         // It must contain an ID, Number, Type and Description
         if (value.count("ID") == 0) {
-            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'ID'");
+            throw MetaSectionError{entry.line, "FORMAT metadata does not contain a field called 'ID'"};
         }
         if (value.count("Number") == 0) {
-            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'Number'");
+            throw MetaSectionError{entry.line, "FORMAT metadata does not contain a field called 'Number'"};
         }
         if (value.count("Type") == 0) {
-            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'Type'");
+            throw MetaSectionError{entry.line, "FORMAT metadata does not contain a field called 'Type'"};
         }
         if (value.count("Description") == 0) {
-            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'Description'");
+            throw MetaSectionError{entry.line, "FORMAT metadata does not contain a field called 'Description'"};
         }
         
         // Check FORMAT Number
@@ -168,7 +168,7 @@ namespace ebi
             value["Number"] != "R" &&
             value["Number"] != "G" &&
             value["Number"] != ".") {
-            throw MetaSectionError(entry.line, "FORMAT metadata Number is not a number, A, R, G or dot");
+            throw MetaSectionError{entry.line, "FORMAT metadata Number is not a number, A, R, G or dot"};
         }
 
         // Check FORMAT Type
@@ -176,7 +176,7 @@ namespace ebi
             value["Type"] != "Float" &&
             value["Type"] != "Character" &&
             value["Type"] != "String") {
-            throw MetaSectionError(entry.line, "FORMAT metadata Type is not a Integer, Float, Character or String");
+            throw MetaSectionError{entry.line, "FORMAT metadata Type is not a Integer, Float, Character or String"};
         }
     }
     
@@ -184,16 +184,16 @@ namespace ebi
     {
         // It must contain an ID, Number, Type and Description
         if (value.count("ID") == 0) {
-            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'ID'");
+            throw MetaSectionError{entry.line, "INFO metadata does not contain a field called 'ID'"};
         }
         if (value.count("Number") == 0) {
-            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'Number'");
+            throw MetaSectionError{entry.line, "INFO metadata does not contain a field called 'Number'"};
         }
         if (value.count("Type") == 0) {
-            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'Type'");
+            throw MetaSectionError{entry.line, "INFO metadata does not contain a field called 'Type'"};
         }
         if (value.count("Description") == 0) {
-            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'Description'");
+            throw MetaSectionError{entry.line, "INFO metadata does not contain a field called 'Description'"};
         }
         
         // Check INFO Number
@@ -203,7 +203,7 @@ namespace ebi
             value["Number"] != "R" &&
             value["Number"] != "G" &&
             value["Number"] != ".") {
-            throw MetaSectionError(entry.line, "INFO metadata Number is not a number, A, R, G or dot");
+            throw MetaSectionError{entry.line, "INFO metadata Number is not a number, A, R, G or dot"};
         }
 
         // Check INFO Type
@@ -212,7 +212,7 @@ namespace ebi
             value["Type"] != "Flag" &&
             value["Type"] != "Character" &&
             value["Type"] != "String") {
-            throw MetaSectionError(entry.line, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+            throw MetaSectionError{entry.line, "INFO metadata Type is not a Integer, Float, Flag, Character or String"};
         }
     }
     
@@ -220,7 +220,7 @@ namespace ebi
     {
         // It must contain an ID
         if (value.count("ID") == 0) {
-            throw MetaSectionError(entry.line, "SAMPLE metadata does not contain a field called 'ID'");
+            throw MetaSectionError{entry.line, "SAMPLE metadata does not contain a field called 'ID'"};
         }
     }
     

--- a/src/vcf/meta_entry.cpp
+++ b/src/vcf/meta_entry.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <iostream>
+#include "vcf/error.hpp"
 #include "vcf/file_structure.hpp"
 #include "vcf/meta_entry_visitor.hpp"
 
@@ -23,21 +24,24 @@ namespace ebi
   namespace vcf
   {
   
-    MetaEntry::MetaEntry(std::string const & id)
-    : id{id}, structure{Structure::NoValue}
+    MetaEntry::MetaEntry(size_t line,
+                         std::string const & id)
+    : line(line), id{id}, structure{Structure::NoValue}
     {
     }
         
-    MetaEntry::MetaEntry(std::string const & id,
-              std::string const & plain_value)
-    : id{id}, structure{Structure::PlainValue}, value{plain_value}
+    MetaEntry::MetaEntry(size_t line,
+                         std::string const & id,
+                         std::string const & plain_value)
+    : line(line), id{id}, structure{Structure::PlainValue}, value{plain_value}
     {
         check_value();
     }
 
-    MetaEntry::MetaEntry(std::string const & id,
-              std::map<std::string, std::string> const & key_values)
-    : id{id}, structure{Structure::KeyValue}, value{key_values}
+    MetaEntry::MetaEntry(size_t line,
+                         std::string const & id,
+                         std::map<std::string, std::string> const & key_values)
+    : line(line), id{id}, structure{Structure::KeyValue}, value{key_values}
     {
         check_value();
     }
@@ -69,7 +73,7 @@ namespace ebi
     void MetaEntryVisitor::operator()(std::string & value) const
     {
         if (find_if(value.begin(), value.end(), [](char c) { return c == '\n'; }) != value.end()) {
-            throw std::invalid_argument("Metadata value contains a line break");
+            throw MetaSectionError(entry.line, "Metadata value contains a line break");
         }
     }
     
@@ -101,10 +105,10 @@ namespace ebi
     {
         // It must contain an ID and Description
         if (value.count("ID") == 0) {
-            throw std::invalid_argument("ALT metadata does not contain a field called 'ID'");
+            throw MetaSectionError(entry.line, "ALT metadata does not contain a field called 'ID'");
         }
         if (value.count("Description") == 0) {
-            throw std::invalid_argument("ALT metadata does not contain a field called 'Description'");
+            throw MetaSectionError(entry.line, "ALT metadata does not contain a field called 'Description'");
         }
         
         // Check ID prefix is "DEL" | "INS" | "DUP" | "INV" | "CNV"
@@ -118,7 +122,7 @@ namespace ebi
             prefix != "DUP" && 
             prefix != "INV" && 
             prefix != "CNV") {
-            throw std::invalid_argument("ALT metadata ID does not begin with DEL/INS/DUP/INV/CNV");
+            throw MetaSectionError(entry.line, "ALT metadata ID does not begin with DEL/INS/DUP/INV/CNV");
         }
     }
     
@@ -126,7 +130,7 @@ namespace ebi
     {
         // It must contain an ID and Description
         if (value.count("ID") == 0) {
-            throw std::invalid_argument("contig metadata does not contain a field called 'ID'");
+            throw MetaSectionError(entry.line, "contig metadata does not contain a field called 'ID'");
         }
     }
     
@@ -134,10 +138,10 @@ namespace ebi
     {
         // It must contain an ID and Description
         if (value.count("ID") == 0) {
-            throw std::invalid_argument("FILTER metadata does not contain a field called 'ID'");
+            throw MetaSectionError(entry.line, "FILTER metadata does not contain a field called 'ID'");
         }
         if (value.count("Description") == 0) {
-            throw std::invalid_argument("FILTER metadata does not contain a field called 'Description'");
+            throw MetaSectionError(entry.line, "FILTER metadata does not contain a field called 'Description'");
         }
     }
     
@@ -145,16 +149,16 @@ namespace ebi
     {
         // It must contain an ID, Number, Type and Description
         if (value.count("ID") == 0) {
-            throw std::invalid_argument("FORMAT metadata does not contain a field called 'ID'");
+            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'ID'");
         }
         if (value.count("Number") == 0) {
-            throw std::invalid_argument("FORMAT metadata does not contain a field called 'Number'");
+            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'Number'");
         }
         if (value.count("Type") == 0) {
-            throw std::invalid_argument("FORMAT metadata does not contain a field called 'Type'");
+            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'Type'");
         }
         if (value.count("Description") == 0) {
-            throw std::invalid_argument("FORMAT metadata does not contain a field called 'Description'");
+            throw MetaSectionError(entry.line, "FORMAT metadata does not contain a field called 'Description'");
         }
         
         // Check FORMAT Number
@@ -164,7 +168,7 @@ namespace ebi
             value["Number"] != "R" &&
             value["Number"] != "G" &&
             value["Number"] != ".") {
-            throw std::invalid_argument("FORMAT metadata Number is not a number, A, R, G or dot");
+            throw MetaSectionError(entry.line, "FORMAT metadata Number is not a number, A, R, G or dot");
         }
 
         // Check FORMAT Type
@@ -172,7 +176,7 @@ namespace ebi
             value["Type"] != "Float" &&
             value["Type"] != "Character" &&
             value["Type"] != "String") {
-            throw std::invalid_argument("FORMAT metadata Type is not a Integer, Float, Character or String");
+            throw MetaSectionError(entry.line, "FORMAT metadata Type is not a Integer, Float, Character or String");
         }
     }
     
@@ -180,16 +184,16 @@ namespace ebi
     {
         // It must contain an ID, Number, Type and Description
         if (value.count("ID") == 0) {
-            throw std::invalid_argument("INFO metadata does not contain a field called 'ID'");
+            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'ID'");
         }
         if (value.count("Number") == 0) {
-            throw std::invalid_argument("INFO metadata does not contain a field called 'Number'");
+            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'Number'");
         }
         if (value.count("Type") == 0) {
-            throw std::invalid_argument("INFO metadata does not contain a field called 'Type'");
+            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'Type'");
         }
         if (value.count("Description") == 0) {
-            throw std::invalid_argument("INFO metadata does not contain a field called 'Description'");
+            throw MetaSectionError(entry.line, "INFO metadata does not contain a field called 'Description'");
         }
         
         // Check INFO Number
@@ -199,7 +203,7 @@ namespace ebi
             value["Number"] != "R" &&
             value["Number"] != "G" &&
             value["Number"] != ".") {
-            throw std::invalid_argument("INFO metadata Number is not a number, A, R, G or dot");
+            throw MetaSectionError(entry.line, "INFO metadata Number is not a number, A, R, G or dot");
         }
 
         // Check INFO Type
@@ -208,7 +212,7 @@ namespace ebi
             value["Type"] != "Flag" &&
             value["Type"] != "Character" &&
             value["Type"] != "String") {
-            throw std::invalid_argument("INFO metadata Type is not a Integer, Float, Flag, Character or String");
+            throw MetaSectionError(entry.line, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
         }
     }
     
@@ -216,7 +220,7 @@ namespace ebi
     {
         // It must contain an ID
         if (value.count("ID") == 0) {
-            throw std::invalid_argument("SAMPLE metadata does not contain a field called 'ID'");
+            throw MetaSectionError(entry.line, "SAMPLE metadata does not contain a field called 'ID'");
         }
     }
     

--- a/src/vcf/parsing_state.cpp
+++ b/src/vcf/parsing_state.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "vcf/parsing_utils.hpp"
+#include "vcf/parsing_state.hpp"
 
 namespace ebi
 {

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -204,7 +204,7 @@ namespace ebi
                         
                         check_field_cardinality(field.second, values, key_values["Number"], 2); // TODO Assumes ploidy=2
                         check_field_type(field.second, values, key_values["Type"]);
-                    } catch (InfoBodyError ex) {
+                    } catch (Error &ex) {
                         throw InfoBodyError(line, "Info " + key_values["ID"] + "=" + ex.get_raw_message());
                     }
                     
@@ -294,7 +294,7 @@ namespace ebi
                     
                     check_field_cardinality(subfield, values, key_values["Number"], alleles.size());
                     check_field_type(subfield, values, key_values["Type"]);
-                } catch (Error ex) {
+                } catch (Error &ex) {
                     throw SamplesBodyError(line, "Sample #" + std::to_string(i+1) + ", " +
                                                 key_values["ID"] + "=" + ex.get_raw_message());
                 }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -101,10 +101,10 @@ namespace ebi
     void Record::check_chromosome() const
     {
         if (chromosome.find(':') != std::string::npos) {
-            throw ChromosomeBodyError(line, "Chromosome must not contain colons");
+            throw ChromosomeBodyError{line, "Chromosome must not contain colons"};
         }
         if (chromosome.find(' ') != std::string::npos) {
-            throw ChromosomeBodyError(line, "Chromosome must not contain white-spaces");
+            throw ChromosomeBodyError{line, "Chromosome must not contain white-spaces"};
         }
     }
 
@@ -116,7 +116,7 @@ namespace ebi
         
         for (auto & id : ids) {
             if (std::find_if(id.begin(), id.end(), [](char c) { return c == ' ' || c == ';'; }) != id.end()) {
-                throw IdBodyError(line, "ID must not contain semicolons or whitespaces");
+                throw IdBodyError{line, "ID must not contain semicolons or whitespaces"};
             }
         }
     }
@@ -141,8 +141,8 @@ namespace ebi
                     !boost::starts_with(alt_id, "DUP") && 
                     !boost::starts_with(alt_id, "INV") && 
                     !boost::starts_with(alt_id, "CNV")) {
-                    throw AlternateAllelesBodyError(line,
-                            "Alternate ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+                    throw AlternateAllelesBodyError{line,
+                            "Alternate ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"};
                 }
             }
         }
@@ -154,14 +154,14 @@ namespace ebi
         switch (type) {
             case RecordType::NO_VARIATION:
                 if (alternate_alleles.size() > 1) {
-                    throw AlternateAllelesBodyError(line,
-                            "The no-alternate alleles symbol (dot) can not be combined with others");
+                    throw AlternateAllelesBodyError{line,
+                            "The no-alternate alleles symbol (dot) can not be combined with others"};
                 }
                 break;
             case RecordType::SNV:
             case RecordType::MNV:
                 if (alternate == reference_allele) {
-                    throw AlternateAllelesBodyError(line, "Reference and alternate alleles must not be the same");
+                    throw AlternateAllelesBodyError{line, "Reference and alternate alleles must not be the same"};
                 }
             case RecordType::INDEL:
                 // Nothing to check
@@ -177,7 +177,7 @@ namespace ebi
     void Record::check_quality() const
     {
         if (quality < 0) {
-            throw QualityBodyError(line, "Quality is not equal or greater than zero");
+            throw QualityBodyError{line, "Quality is not equal or greater than zero"};
         }
     }
     
@@ -205,7 +205,7 @@ namespace ebi
                         check_field_cardinality(field.second, values, key_values["Number"], 2); // TODO Assumes ploidy=2
                         check_field_type(field.second, values, key_values["Type"]);
                     } catch (Error &ex) {
-                        throw InfoBodyError(line, "Info " + key_values["ID"] + "=" + ex.get_raw_message());
+                        throw InfoBodyError{line, "Info " + key_values["ID"] + "=" + ex.get_raw_message()};
                     }
                     
                     break;
@@ -222,14 +222,14 @@ namespace ebi
         }
             
         if (format[0] != "GT") {
-            throw FormatBodyError(line, "GT must be the first field in the FORMAT column");
+            throw FormatBodyError{line, "GT must be the first field in the FORMAT column"};
         }
     }
 
     void Record::check_samples() const
     {
         if (samples.size() != source->samples_names.size()) {
-            throw SamplesBodyError(line, "The number of samples must match those listed in the header line");
+            throw SamplesBodyError{line, "The number of samples must match those listed in the header line"};
         }
      
         if (samples.size() == 0) {
@@ -267,8 +267,8 @@ namespace ebi
             
             // The number of subfields can't be greater than the number in the FORMAT column
             if (subfields.size() > format.size()) {
-                throw SamplesBodyError(line, "Sample #" + std::to_string(i+1) +
-                        " has more fields than specified in the FORMAT column");
+                throw SamplesBodyError{line, "Sample #" + std::to_string(i+1) +
+                        " has more fields than specified in the FORMAT column"};
             }
             
             std::vector<std::string> alleles;
@@ -295,8 +295,8 @@ namespace ebi
                     check_field_cardinality(subfield, values, key_values["Number"], alleles.size());
                     check_field_type(subfield, values, key_values["Type"]);
                 } catch (Error &ex) {
-                    throw SamplesBodyError(line, "Sample #" + std::to_string(i+1) + ", " +
-                                                key_values["ID"] + "=" + ex.get_raw_message());
+                    throw SamplesBodyError{line, "Sample #" + std::to_string(i+1) + ", " +
+                                                key_values["ID"] + "=" + ex.get_raw_message()};
                 }
             }
         }
@@ -309,8 +309,8 @@ namespace ebi
 
             size_t num_allele = std::stoi(allele);
             if (num_allele > alternate_alleles.size()) {
-                throw SamplesBodyError(line, "Allele index " + std::to_string(num_allele) +
-                        " is greater than the maximum allowed " + std::to_string(alternate_alleles.size()));
+                throw SamplesBodyError{line, "Allele index " + std::to_string(num_allele) +
+                        " is greater than the maximum allowed " + std::to_string(alternate_alleles.size())};
             }
         }
     }
@@ -347,8 +347,8 @@ namespace ebi
             // there will be one empty value that needs to be specifically checked
             if (values.size() != expected && 
                 values.size() > 1 && values[0] != "") {
-                throw Error(line, field + " does not match the meta specification Number=" + number +
-                        ", expected " + std::to_string(expected) + " values");
+                throw Error{line, field + " does not match the meta specification Number=" + number +
+                        ", expected " + std::to_string(expected) + " values"};
                 
             }
         }
@@ -376,24 +376,24 @@ namespace ebi
                     }
                 } else if (type == "Flag") {
                     if (value.size() > 1) {
-                        throw Error(line, "There can be only 0 or 1 value");
+                        throw Error{line, "There can be only 0 or 1 value"};
                     } else if (value.size() == 1) {
                         int numeric_value = std::stoi(value);
                         if (numeric_value != 0 && numeric_value != 1) {
-                            throw Error(line, "A flag must be 0 or 1");
+                            throw Error{line, "A flag must be 0 or 1"};
                         }
                     }
                     // If no flag is provided then there is nothing to check
                 } else if (type == "Character") {
                     // ...check the length is 1
                     if (value.size() > 1) {
-                        throw Error(line, "There can be only one character");
+                        throw Error{line, "There can be only one character"};
                     }
                 } else if (type == "String") {
                     // ...do nothing, it is guaranteed it will be a string
                 } 
             } catch (...) {
-                throw Error(line, field + " does not match the meta specification Type=" + type);
+                throw Error{line, field + " does not match the meta specification Type=" + type};
             }
         }
     }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -256,7 +256,7 @@ namespace ebi
             
             if (!found_in_header) {
                 // If not found in header, a null-value meta entry must be created to make sizes match
-                format_meta.push_back(MetaEntry{""});
+                format_meta.push_back(MetaEntry{line, ""});
             }
         }
         

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <vcf/error.hpp>
 #include "vcf/file_structure.hpp"
 #include "vcf/record.hpp"
 
@@ -22,20 +23,22 @@ namespace ebi
   namespace vcf
   {
 
-    Record::Record(std::string const & chromosome, 
-                         size_t const position, 
-                         std::vector<std::string> const & ids, 
-                         std::string const & reference_allele, 
-                         std::vector<std::string> const & alternate_alleles, 
-                         float const quality, 
-                         std::vector<std::string> const & filters, 
-                         std::map<std::string, std::string> const & info, 
-                         std::vector<std::string> const & format, 
-                         std::vector<std::string> const & samples,
-                         std::shared_ptr<Source> const & source) 
-    : chromosome{chromosome}, 
-        position{position}, 
-        ids{ids}, 
+    Record::Record(size_t const line,
+            std::string const & chromosome,
+            size_t const position,
+            std::vector<std::string> const & ids,
+            std::string const & reference_allele,
+            std::vector<std::string> const & alternate_alleles,
+            float const quality,
+            std::vector<std::string> const & filters,
+            std::map<std::string, std::string> const & info,
+            std::vector<std::string> const & format,
+            std::vector<std::string> const & samples,
+            std::shared_ptr<Source> const & source)
+    : line(line),
+        chromosome{chromosome},
+        position{position},
+        ids{ids},
         reference_allele{reference_allele}, 
         alternate_alleles{alternate_alleles}, 
         types{},
@@ -98,10 +101,10 @@ namespace ebi
     void Record::check_chromosome() const
     {
         if (chromosome.find(':') != std::string::npos) {
-            throw std::invalid_argument("Chromosome must not contain colons");
+            throw ChromosomeBodyError(line, "Chromosome must not contain colons");
         }
         if (chromosome.find(' ') != std::string::npos) {
-            throw std::invalid_argument("Chromosome must not contain white-spaces");
+            throw ChromosomeBodyError(line, "Chromosome must not contain white-spaces");
         }
     }
 
@@ -113,7 +116,7 @@ namespace ebi
         
         for (auto & id : ids) {
             if (std::find_if(id.begin(), id.end(), [](char c) { return c == ' ' || c == ';'; }) != id.end()) {
-                throw std::invalid_argument("ID must not contain semicolons or whitespaces");
+                throw IdBodyError(line, "ID must not contain semicolons or whitespaces");
             }
         }
     }
@@ -138,7 +141,8 @@ namespace ebi
                     !boost::starts_with(alt_id, "DUP") && 
                     !boost::starts_with(alt_id, "INV") && 
                     !boost::starts_with(alt_id, "CNV")) {
-                    throw std::invalid_argument("Alternate ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+                    throw AlternateAllelesBodyError(line,
+                            "Alternate ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
                 }
             }
         }
@@ -150,13 +154,14 @@ namespace ebi
         switch (type) {
             case RecordType::NO_VARIATION:
                 if (alternate_alleles.size() > 1) {
-                    throw std::invalid_argument("The no-alternate alleles symbol (dot) can not be combined with others");
+                    throw AlternateAllelesBodyError(line,
+                            "The no-alternate alleles symbol (dot) can not be combined with others");
                 }
                 break;
             case RecordType::SNV:
             case RecordType::MNV:
                 if (alternate == reference_allele) {
-                    throw std::invalid_argument("Reference and alternate alleles must not be the same");
+                    throw AlternateAllelesBodyError(line, "Reference and alternate alleles must not be the same");
                 }
             case RecordType::INDEL:
                 // Nothing to check
@@ -172,7 +177,7 @@ namespace ebi
     void Record::check_quality() const
     {
         if (quality < 0) {
-            throw std::invalid_argument("Quality is not equal or greater than zero");
+            throw QualityBodyError(line, "Quality is not equal or greater than zero");
         }
     }
     
@@ -199,8 +204,8 @@ namespace ebi
                         
                         check_field_cardinality(field.second, values, key_values["Number"], 2); // TODO Assumes ploidy=2
                         check_field_type(field.second, values, key_values["Type"]);
-                    } catch (std::invalid_argument ex) {
-                        throw std::invalid_argument("Info " + key_values["ID"] + "=" + ex.what());
+                    } catch (InfoBodyError ex) {
+                        throw InfoBodyError(line, "Info " + key_values["ID"] + "=" + ex.get_raw_message());
                     }
                     
                     break;
@@ -217,14 +222,14 @@ namespace ebi
         }
             
         if (format[0] != "GT") {
-            throw std::invalid_argument("GT must be the first field in the FORMAT column");
+            throw FormatBodyError(line, "GT must be the first field in the FORMAT column");
         }
     }
 
     void Record::check_samples() const
     {
         if (samples.size() != source->samples_names.size()) {
-            throw std::invalid_argument("The number of samples must match those listed in the header line");
+            throw SamplesBodyError(line, "The number of samples must match those listed in the header line");
         }
      
         if (samples.size() == 0) {
@@ -262,7 +267,7 @@ namespace ebi
             
             // The number of subfields can't be greater than the number in the FORMAT column
             if (subfields.size() > format.size()) {
-                throw std::invalid_argument("Sample #" + std::to_string(i+1) + 
+                throw SamplesBodyError(line, "Sample #" + std::to_string(i+1) +
                         " has more fields than specified in the FORMAT column");
             }
             
@@ -289,9 +294,9 @@ namespace ebi
                     
                     check_field_cardinality(subfield, values, key_values["Number"], alleles.size());
                     check_field_type(subfield, values, key_values["Type"]);
-                } catch (std::invalid_argument ex) {
-                    throw std::invalid_argument("Sample #" + std::to_string(i+1) + ", " + 
-                                                key_values["ID"] + "=" + ex.what());
+                } catch (Error ex) {
+                    throw SamplesBodyError(line, "Sample #" + std::to_string(i+1) + ", " +
+                                                key_values["ID"] + "=" + ex.get_raw_message());
                 }
             }
         }
@@ -304,7 +309,7 @@ namespace ebi
 
             size_t num_allele = std::stoi(allele);
             if (num_allele > alternate_alleles.size()) {
-                throw std::invalid_argument("Allele index " + std::to_string(num_allele) + 
+                throw SamplesBodyError(line, "Allele index " + std::to_string(num_allele) +
                         " is greater than the maximum allowed " + std::to_string(alternate_alleles.size()));
             }
         }
@@ -342,7 +347,7 @@ namespace ebi
             // there will be one empty value that needs to be specifically checked
             if (values.size() != expected && 
                 values.size() > 1 && values[0] != "") {
-                throw std::invalid_argument(field + " does not match the meta specification Number=" + number + 
+                throw Error(line, field + " does not match the meta specification Number=" + number +
                         ", expected " + std::to_string(expected) + " values");
                 
             }
@@ -371,24 +376,24 @@ namespace ebi
                     }
                 } else if (type == "Flag") {
                     if (value.size() > 1) {
-                        throw std::invalid_argument("There can be only 0 or 1 value");
+                        throw Error(line, "There can be only 0 or 1 value");
                     } else if (value.size() == 1) {
                         int numeric_value = std::stoi(value);
                         if (numeric_value != 0 && numeric_value != 1) {
-                            throw std::invalid_argument("A flag must be 0 or 1");
+                            throw Error(line, "A flag must be 0 or 1");
                         }
                     }
                     // If no flag is provided then there is nothing to check
                 } else if (type == "Character") {
                     // ...check the length is 1
                     if (value.size() > 1) {
-                        throw std::invalid_argument("There can be only one character");
+                        throw Error(line, "There can be only one character");
                     }
                 } else if (type == "String") {
                     // ...do nothing, it is guaranteed it will be a string
                 } 
             } catch (...) {
-                throw std::invalid_argument(field + " does not match the meta specification Type=" + type);
+                throw Error(line, field + " does not match the meta specification Type=" + type);
             }
         }
     }

--- a/src/vcf/report_error_policy.cpp
+++ b/src/vcf/report_error_policy.cpp
@@ -20,6 +20,16 @@ namespace ebi
 {
   namespace vcf
   {
+    void ReportErrorPolicy::handle_error(ParsingState &state, const Error &error)
+    {
+        state.m_is_valid = false;
+        std::cerr << error.what() << std::endl;
+    }
+
+    void ReportErrorPolicy::handle_warning(ParsingState &state, const Error &error)
+    {
+        std::cerr << error.what() << " (warning)" << std::endl;
+    }
 
     void ReportErrorPolicy::handle_fileformat_section_error(ParsingState & state, std::string message)
     {
@@ -65,6 +75,7 @@ namespace ebi
     {
         std::cerr << BodySectionError(state.n_lines, message + " (warning)").what() << std::endl;
     }
+
 
   }
 }

--- a/src/vcf/report_error_policy.cpp
+++ b/src/vcf/report_error_policy.cpp
@@ -30,53 +30,6 @@ namespace ebi
     {
         std::cerr << error.what() << " (warning)" << std::endl;
     }
-
-    void ReportErrorPolicy::handle_fileformat_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        std::cerr << FileformatError(state.n_lines, message).what() << std::endl;
-    }
-
-    void ReportErrorPolicy::handle_meta_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        std::cerr << MetaSectionError(state.n_lines, message).what() << std::endl;
-    }
-
-    void ReportErrorPolicy::handle_header_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        std::cerr << HeaderSectionError(state.n_lines, message).what() << std::endl;
-    }
-
-    void ReportErrorPolicy::handle_body_section_error(ParsingState & state, std::string message)
-    {
-        state.m_is_valid = false;
-        std::cerr << BodySectionError(state.n_lines, message).what() << std::endl;
-    }
-
-    
-    void ReportErrorPolicy::handle_fileformat_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << FileformatError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
-    void ReportErrorPolicy::handle_meta_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << MetaSectionError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
-    void ReportErrorPolicy::handle_header_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << HeaderSectionError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
-    void ReportErrorPolicy::handle_body_section_warning(ParsingState const & state, std::string message)
-    {
-        std::cerr << BodySectionError(state.n_lines, message + " (warning)").what() << std::endl;
-    }
-
-
   }
 }
 

--- a/src/vcf/report_error_policy.cpp
+++ b/src/vcf/report_error_policy.cpp
@@ -24,46 +24,46 @@ namespace ebi
     void ReportErrorPolicy::handle_fileformat_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        std::cerr << "Line " << state.n_lines << ": " << message << std::endl;
+        std::cerr << FileformatError(state.n_lines, message).what() << std::endl;
     }
 
     void ReportErrorPolicy::handle_meta_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        std::cerr << "Line " << state.n_lines << ": " << message << std::endl;
+        std::cerr << MetaSectionError(state.n_lines, message).what() << std::endl;
     }
 
     void ReportErrorPolicy::handle_header_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        std::cerr << "Line " << state.n_lines << ": " << message << std::endl;
+        std::cerr << HeaderSectionError(state.n_lines, message).what() << std::endl;
     }
 
     void ReportErrorPolicy::handle_body_section_error(ParsingState & state, std::string message)
     {
         state.m_is_valid = false;
-        std::cerr << "Line " << state.n_lines << ": " << message << std::endl;
+        std::cerr << BodySectionError(state.n_lines, message).what() << std::endl;
     }
 
     
     void ReportErrorPolicy::handle_fileformat_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << FileformatError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
     void ReportErrorPolicy::handle_meta_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << MetaSectionError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
     void ReportErrorPolicy::handle_header_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << HeaderSectionError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
     void ReportErrorPolicy::handle_body_section_warning(ParsingState const & state, std::string message)
     {
-        std::cerr << "Line " << state.n_lines << ": " << message << " (warning)" << std::endl;
+        std::cerr << BodySectionError(state.n_lines, message + " (warning)").what() << std::endl;
     }
 
   }

--- a/src/vcf/store_parse_policy.cpp
+++ b/src/vcf/store_parse_policy.cpp
@@ -102,8 +102,7 @@ namespace ebi
                 // TODO Throw exception
             }
         } catch (std::invalid_argument ex) {
-            throw ParsingError(ex.what());
-//            throw MetaSectionError(state.n_lines, ex.what());
+            throw MetaSectionError(state.n_lines, ex.what());
         }
     }
 
@@ -206,7 +205,7 @@ namespace ebi
                 state.source
             });
         } catch (std::invalid_argument ex) {
-            throw ParsingError(ex.what());
+            throw BodySectionError(state.n_lines, ex.what());
         }
     }
     

--- a/src/vcf/store_parse_policy.cpp
+++ b/src/vcf/store_parse_policy.cpp
@@ -59,11 +59,11 @@ namespace ebi
         } else if (m_current_token == "VCFv4.3") {
             fileformat_version = Version::v43;
         } else {
-            throw FileformatError(state.n_lines, "Not allowed VCF fileformat version");
+            throw FileformatError{state.n_lines, "Not allowed VCF fileformat version"};
         }
         
         if (fileformat_version != state.source->version) {
-            throw FileformatError(state.n_lines, "Unexpected VCF fileformat version found");
+            throw FileformatError{state.n_lines, "Unexpected VCF fileformat version found"};
         } else {
             state.set_version(fileformat_version);
         }
@@ -99,7 +99,7 @@ namespace ebi
             state.add_meta(MetaEntry{state.n_lines, m_line_typeid, key_values});
 
         } else {
-            // TODO Throw exception
+            throw MetaSectionError{state.n_lines, "Meta line description is not a value, nor a TypeID=value, nor a TypeID=<Key-value pairs>"};
         }
     }
 
@@ -158,15 +158,22 @@ namespace ebi
 
     void StoreParsePolicy::handle_body_line(ParsingState const & state) 
     {
-        // Transform the position token into a size_t
-        auto position = static_cast<size_t>(std::stoi(m_line_tokens["POS"][0]));
+        size_t position;
+        try {
+            // Transform the position token into a size_t
+            position = static_cast<size_t>(std::stoi(m_line_tokens["POS"][0]));
+        } catch (std::invalid_argument ex) {
+            throw PositionBodyError{state.n_lines};
+        }
 
         // Transform all the quality tokens into floating point numbers
-        float quality;
-        try {
-            quality = std::stof(m_line_tokens["QUAL"][0]);
-        } catch (std::invalid_argument ex) {
-            quality = 0;
+        float quality = 0;
+        if (m_line_tokens["QUAL"][0] != ".") {
+            try {
+                quality = std::stof(m_line_tokens["QUAL"][0]);
+            } catch (std::invalid_argument ex) {
+                throw QualityBodyError{state.n_lines};
+            }
         }
 
         // Split the info tokens by the equals (=) symbol

--- a/src/vcf/store_parse_policy.cpp
+++ b/src/vcf/store_parse_policy.cpp
@@ -84,25 +84,22 @@ namespace ebi
     {
         // Put together m_line_typeid and m_grouped_tokens in a single MetaEntry object
         // Add MetaEntry to Source
-        try {
-            if (m_line_typeid == "") { // Plain value
-                state.add_meta(MetaEntry{m_grouped_tokens[0]});
 
-            } else if (m_grouped_tokens.size() == 1) { // TypeID=value
-                state.add_meta(MetaEntry{m_line_typeid, m_grouped_tokens[0]});
+        if (m_line_typeid == "") { // Plain value
+            state.add_meta(MetaEntry{state.n_lines, m_grouped_tokens[0]});
 
-            } else if (m_grouped_tokens.size() % 2 == 0) { // TypeID=<Key-value pairs>
-                auto key_values = std::map<std::string, std::string>{};
-                for (size_t i = 0; i < m_grouped_tokens.size(); i += 2) {
-                    key_values[m_grouped_tokens[i]] = m_grouped_tokens[i+1];
-                }
-                state.add_meta(MetaEntry{m_line_typeid, key_values});
+        } else if (m_grouped_tokens.size() == 1) { // TypeID=value
+            state.add_meta(MetaEntry{state.n_lines, m_line_typeid, m_grouped_tokens[0]});
 
-            } else {
-                // TODO Throw exception
+        } else if (m_grouped_tokens.size() % 2 == 0) { // TypeID=<Key-value pairs>
+            auto key_values = std::map<std::string, std::string>{};
+            for (size_t i = 0; i < m_grouped_tokens.size(); i += 2) {
+                key_values[m_grouped_tokens[i]] = m_grouped_tokens[i+1];
             }
-        } catch (std::invalid_argument ex) {
-            throw MetaSectionError(state.n_lines, ex.what());
+            state.add_meta(MetaEntry{state.n_lines, m_line_typeid, key_values});
+
+        } else {
+            // TODO Throw exception
         }
     }
 

--- a/src/vcf/store_parse_policy.cpp
+++ b/src/vcf/store_parse_policy.cpp
@@ -59,11 +59,11 @@ namespace ebi
         } else if (m_current_token == "VCFv4.3") {
             fileformat_version = Version::v43;
         } else {
-            throw ParsingError("Not allowed VCF fileformat version");
+            throw FileformatError(state.n_lines, "Not allowed VCF fileformat version");
         }
         
         if (fileformat_version != state.source->version) {
-            throw ParsingError("Unexpected VCF fileformat version found");
+            throw FileformatError(state.n_lines, "Unexpected VCF fileformat version found");
         } else {
             state.set_version(fileformat_version);
         }
@@ -103,6 +103,7 @@ namespace ebi
             }
         } catch (std::invalid_argument ex) {
             throw ParsingError(ex.what());
+//            throw MetaSectionError(state.n_lines, ex.what());
         }
     }
 

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -24,7 +24,7 @@ namespace ebi
     void ValidateOptionalPolicy::optional_check_meta_section(ParsingState const & state) const
     {
         if (state.source->meta_entries.find("reference") == state.source->meta_entries.end()) {
-          throw ParsingWarning("A valid 'reference' entry is not listed in the meta section");
+          throw MetaSectionError(state.n_lines, "A valid 'reference' entry is not listed in the meta section");
         }
     }
     
@@ -91,8 +91,10 @@ namespace ebi
 
             if (ploidy > 0) {
                 if (alleles.size() != ploidy) {
-                    throw ParsingWarning("Sample #" + std::to_string(i) + " has " + std::to_string(alleles.size()) + 
-                                         " allele(s), but " + std::to_string(ploidy) + " were found in others");
+                    throw SamplesBodyError(
+                            state.n_lines,
+                            "Sample #" + std::to_string(i) + " has " + std::to_string(alleles.size())
+                                    + " allele(s), but " + std::to_string(ploidy) + " were found in others");
                 }
             } else {
                 ploidy = alleles.size();
@@ -105,7 +107,8 @@ namespace ebi
     void ValidateOptionalPolicy::check_body_entry_position_zero(ParsingState & state, Record & record) const
     {
         if (record.position == 0) {
-            throw ParsingWarning("Position zero should only be used to reference a telomere");
+            throw PositionBodyError(state.n_lines,
+                    "Position zero should only be used to reference a telomere");
         }
     }
     
@@ -113,7 +116,8 @@ namespace ebi
     {
         for (auto & id : record.ids) {
             if (std::find(id.begin(), id.end(), ',') != id.end()) {
-                throw ParsingWarning("Comma found in the ID column; if used as separator, please replace it with semi-colon");
+                throw IdBodyError(state.n_lines,
+                        "Comma found in the ID column; if used as separator, please replace it with semi-colon");
             }
         }
     }
@@ -123,9 +127,10 @@ namespace ebi
         for (size_t i = 0; i < record.alternate_alleles.size(); ++i) {
             auto & alternate = record.alternate_alleles[i];
             auto type = record.types[i];
-            
+
             if (type == RecordType::INDEL && alternate[0] != record.reference_allele[0]) {
-                throw ParsingWarning("Reference and alternate alleles do not share the first nucleotide");
+                throw ReferenceAlleleBodyError(state.n_lines,
+                        "Reference and alternate alleles do not share the first nucleotide");
             }
         }
     }
@@ -146,7 +151,8 @@ namespace ebi
             state.add_well_defined_meta("contig", current_chromosome);
         } else {
             state.add_bad_defined_meta("contig", current_chromosome);
-            throw ParsingWarning("Chromosome/contig '" + current_chromosome + "' is not described in a 'contig' meta description");
+            throw MetaSectionError(state.n_lines,
+                    "Chromosome/contig '" + current_chromosome + "' is not described in a 'contig' meta description");
         }
     }
     
@@ -170,7 +176,8 @@ namespace ebi
                     state.add_well_defined_meta("ALT", alt_id);
                 } else {
                     state.add_bad_defined_meta("ALT", alt_id);
-                    throw ParsingWarning("Alternate '<" + alt_id + ">' is not listed in a valid meta-data ALT entry");
+                    throw MetaSectionError(state.n_lines,
+                            "Alternate '<" + alt_id + ">' is not listed in a valid meta-data ALT entry");
                 }
             }
         }
@@ -192,7 +199,8 @@ namespace ebi
                 state.add_well_defined_meta("FILTER", filter);
             } else {
                 state.add_bad_defined_meta("FILTER", filter);
-                throw ParsingWarning("Filter '" + filter + "' is not listed in a valid meta-data FILTER entry");
+                throw MetaSectionError(state.n_lines,
+                        "Filter '" + filter + "' is not listed in a valid meta-data FILTER entry");
             }
         }
     }
@@ -214,7 +222,8 @@ namespace ebi
                 state.add_well_defined_meta("INFO", id);
             } else {
                 state.add_bad_defined_meta("INFO", id);
-                throw ParsingWarning("Info '" + id + "' is not listed in a valid meta-data INFO entry");
+                throw MetaSectionError(state.n_lines,
+                        "Info '" + id + "' is not listed in a valid meta-data INFO entry");
             }
         }
     }
@@ -233,7 +242,8 @@ namespace ebi
                 state.add_well_defined_meta("FORMAT", fm);
             } else {
                 state.add_bad_defined_meta("FORMAT", fm);
-                throw ParsingWarning("Format '" + fm + "' is not listed in a valid meta-data FORMAT entry");
+                throw MetaSectionError(state.n_lines,
+                        "Format '" + fm + "' is not listed in a valid meta-data FORMAT entry");
             }
         }
     }

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -24,7 +24,7 @@ namespace ebi
     void ValidateOptionalPolicy::optional_check_meta_section(ParsingState const & state) const
     {
         if (state.source->meta_entries.find("reference") == state.source->meta_entries.end()) {
-          throw MetaSectionError(state.n_lines, "A valid 'reference' entry is not listed in the meta section");
+            throw MetaSectionError(state.n_lines, "A valid 'reference' entry is not listed in the meta section");
         }
     }
     

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -24,7 +24,7 @@ namespace ebi
     void ValidateOptionalPolicy::optional_check_meta_section(ParsingState const & state) const
     {
         if (state.source->meta_entries.find("reference") == state.source->meta_entries.end()) {
-            throw MetaSectionError(state.n_lines, "A valid 'reference' entry is not listed in the meta section");
+            throw MetaSectionError{state.n_lines, "A valid 'reference' entry is not listed in the meta section"};
         }
     }
     
@@ -72,8 +72,8 @@ namespace ebi
 //            int current_position = std::stoi(ParsePolicy::column_tokens("POS")[0]);
 //            if (previous_record.chromosome == current_chromosome && 
 //                    previous_record.position > current_position) {
-//                throw ParsingWarning("Genomic position " + current_chromosome + ":" + std::to_string(current_position) + 
-//                                     " is listed after " + previous_record.chromosome + ":" + std::to_string(previous_record.position));
+//                throw ParsingWarning{"Genomic position " + current_chromosome + ":" + std::to_string(current_position) +
+//                                     " is listed after " + previous_record.chromosome + ":" + std::to_string(previous_record.position)};
 //            }
 //        }
     }
@@ -91,10 +91,10 @@ namespace ebi
 
             if (ploidy > 0) {
                 if (alleles.size() != ploidy) {
-                    throw SamplesBodyError(
+                    throw SamplesBodyError{
                             state.n_lines,
                             "Sample #" + std::to_string(i) + " has " + std::to_string(alleles.size())
-                                    + " allele(s), but " + std::to_string(ploidy) + " were found in others");
+                                    + " allele(s), but " + std::to_string(ploidy) + " were found in others"};
                 }
             } else {
                 ploidy = alleles.size();
@@ -107,8 +107,8 @@ namespace ebi
     void ValidateOptionalPolicy::check_body_entry_position_zero(ParsingState & state, Record & record) const
     {
         if (record.position == 0) {
-            throw PositionBodyError(state.n_lines,
-                    "Position zero should only be used to reference a telomere");
+            throw PositionBodyError{state.n_lines,
+                    "Position zero should only be used to reference a telomere"};
         }
     }
     
@@ -116,8 +116,8 @@ namespace ebi
     {
         for (auto & id : record.ids) {
             if (std::find(id.begin(), id.end(), ',') != id.end()) {
-                throw IdBodyError(state.n_lines,
-                        "Comma found in the ID column; if used as separator, please replace it with semi-colon");
+                throw IdBodyError{state.n_lines,
+                        "Comma found in the ID column; if used as separator, please replace it with semi-colon"};
             }
         }
     }
@@ -129,8 +129,8 @@ namespace ebi
             auto type = record.types[i];
 
             if (type == RecordType::INDEL && alternate[0] != record.reference_allele[0]) {
-                throw ReferenceAlleleBodyError(state.n_lines,
-                        "Reference and alternate alleles do not share the first nucleotide");
+                throw ReferenceAlleleBodyError{state.n_lines,
+                        "Reference and alternate alleles do not share the first nucleotide"};
             }
         }
     }
@@ -151,8 +151,8 @@ namespace ebi
             state.add_well_defined_meta("contig", current_chromosome);
         } else {
             state.add_bad_defined_meta("contig", current_chromosome);
-            throw MetaSectionError(state.n_lines,
-                    "Chromosome/contig '" + current_chromosome + "' is not described in a 'contig' meta description");
+            throw ChromosomeBodyError{state.n_lines,
+                    "Chromosome/contig '" + current_chromosome + "' is not described in a 'contig' meta description"};
         }
     }
     
@@ -176,8 +176,8 @@ namespace ebi
                     state.add_well_defined_meta("ALT", alt_id);
                 } else {
                     state.add_bad_defined_meta("ALT", alt_id);
-                    throw MetaSectionError(state.n_lines,
-                            "Alternate '<" + alt_id + ">' is not listed in a valid meta-data ALT entry");
+                    throw AlternateAllelesBodyError{state.n_lines,
+                            "Alternate '<" + alt_id + ">' is not listed in a valid meta-data ALT entry"};
                 }
             }
         }
@@ -199,8 +199,8 @@ namespace ebi
                 state.add_well_defined_meta("FILTER", filter);
             } else {
                 state.add_bad_defined_meta("FILTER", filter);
-                throw MetaSectionError(state.n_lines,
-                        "Filter '" + filter + "' is not listed in a valid meta-data FILTER entry");
+                throw FilterBodyError{state.n_lines,
+                        "Filter '" + filter + "' is not listed in a valid meta-data FILTER entry"};
             }
         }
     }
@@ -222,8 +222,8 @@ namespace ebi
                 state.add_well_defined_meta("INFO", id);
             } else {
                 state.add_bad_defined_meta("INFO", id);
-                throw MetaSectionError(state.n_lines,
-                        "Info '" + id + "' is not listed in a valid meta-data INFO entry");
+                throw InfoBodyError{state.n_lines,
+                        "Info '" + id + "' is not listed in a valid meta-data INFO entry"};
             }
         }
     }
@@ -242,8 +242,8 @@ namespace ebi
                 state.add_well_defined_meta("FORMAT", fm);
             } else {
                 state.add_bad_defined_meta("FORMAT", fm);
-                throw MetaSectionError(state.n_lines,
-                        "Format '" + fm + "' is not listed in a valid meta-data FORMAT entry");
+                throw FormatBodyError{state.n_lines,
+                        "Format '" + fm + "' is not listed in a valid meta-data FORMAT entry"};
             }
         }
     }

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -70,8 +70,8 @@
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 
@@ -81,8 +81,8 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         fhold; fgoto body_section_skip;
@@ -99,8 +99,8 @@
     action fileformat_end {
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (ParsingError error) {
-          ErrorPolicy::handle_meta_section_error(*this, error.what());
+        } catch (FileformatError error) {
+          ErrorPolicy::handle_meta_section_error(*this, error.get_raw_message());
           fhold; fgoto meta_section_skip;
         }  
     }
@@ -176,8 +176,8 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 
@@ -197,14 +197,18 @@
     
     action record_end {
         try {
-          // Handle all columns and build record
-          ParsePolicy::handle_body_line(*this);
-          // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-          OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_body_section_error(*this, ex.what());
-        } catch (ParsingWarning ex) {
-          ErrorPolicy::handle_body_section_warning(*this, ex.what());
+            // Handle all columns and build record
+            ParsePolicy::handle_body_line(*this);
+            try {
+                // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
+                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+            } catch (MetaSectionError &ex) {
+                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
+            } catch (BodySectionError &ex) {
+                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            }
+        } catch (BodySectionError ex) {
+            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
         }
     }
 
@@ -330,8 +334,8 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         fhold; fgoto body_section_skip;

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -58,38 +58,38 @@
     ######### Global section actions #########
 
     action fileformat_section_error {
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_section_error {
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 
     action header_section_error {
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         fhold; fgoto body_section_skip;
     }
 
     action body_section_error {
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
@@ -99,8 +99,8 @@
     action fileformat_end {
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError error) {
-          ErrorPolicy::handle_meta_section_error(*this, error.get_raw_message());
+        } catch (FileformatError &error) {
+          ErrorPolicy::handle_error(*this, error);
           fhold; fgoto meta_section_skip;
         }  
     }
@@ -176,8 +176,8 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 
@@ -202,13 +202,13 @@
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-            } catch (MetaSectionError &ex) {
-                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
-            } catch (BodySectionError &ex) {
-                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            } catch (MetaSectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
+            } catch (BodySectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError ex) {
-            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
+        } catch (BodySectionError &error) {
+            ErrorPolicy::handle_error(*this, error);
         }
     }
 
@@ -217,125 +217,127 @@
 
     # Fileformat line
     action fileformat_error {
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.1'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         fhold; fgoto meta_section_skip;
     } 
 
     # ALT metadata
     action meta_alt_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_alt_id_err {
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         fhold; fgoto meta_section_skip;
     }
     
     # assembly metadata
     action meta_assembly_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # contig metadata
     action meta_contig_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # FILTER metadata
     action meta_filter_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     # FORMAT metadata
     action meta_format_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_format_number_err {
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_format_type_err {
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Type is not a Integer, Float, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Type is not a Integer, Float, Character or String"});
         fhold; fgoto meta_section_skip;
     }
 
     # INFO metadata
     action meta_info_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_info_number_err {
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_info_type_err {
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         fhold; fgoto meta_section_skip;
     }
 
     # PEDIGREE metadata
     action meta_pedigree_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # pedigreeDB metadata
     action meta_pedigreedb_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # SAMPLE metadata
     action meta_sample_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_sample_genomes_err {
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_sample_mixture_err {
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         fhold; fgoto meta_section_skip;
     }
     
     # Metadata generic errors (do not apply to a specific type)
     action meta_id_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_desc_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_url_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         fhold; fgoto meta_section_skip;
     }
     
     # Header errors
     action header_prefix_err {
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         fhold; fgoto body_section_skip;
@@ -345,155 +347,155 @@
 
     # Chromosome
     action chrom_error {
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Position
     action pos_error {
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # ID
     action id_error {
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Reference allele
     action ref_error {
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Alternate alleles
     action alt_error {
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Quality
     action qual_error {
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Filter
     action filter_error {
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Info
     action info_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         fhold; fgoto body_section_skip;
     }
 
     action info_key_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         fhold; fgoto body_section_skip;
     }
     
     action info_value_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AA_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AC_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AF_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AN_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_BQ_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_CIGAR_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         fhold; fgoto body_section_skip;
     }
     
     action info_DB_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_DP_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_END_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_H2_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_H3_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_MQ_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_MQ0_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_NS_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_SB_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_SOMATIC_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_VALIDATED_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_1000G_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     # Format
     action format_error {
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
@@ -501,14 +503,14 @@
     action sample_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         fhold; fgoto body_section_skip;
     }
     
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         fhold; fgoto body_section_skip;
     }
 

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -70,8 +70,8 @@
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 
@@ -81,8 +81,8 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         fhold; fgoto body_section_skip;
@@ -171,8 +171,8 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 
@@ -194,12 +194,16 @@
         try {
           // Handle all columns and build record
           ParsePolicy::handle_body_line(*this);
+            try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_body_section_error(*this, ex.what());
-        } catch (ParsingWarning ex) {
-          ErrorPolicy::handle_body_section_warning(*this, ex.what());
+            } catch (MetaSectionError &ex) {
+                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
+            } catch (BodySectionError &ex) {
+                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            }
+        } catch (BodySectionError ex) {
+            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
         }
     }
 
@@ -325,8 +329,8 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         fhold; fgoto body_section_skip;

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -58,38 +58,38 @@
     ######### Global section actions #########
 
     action fileformat_section_error {
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_section_error {
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 
     action header_section_error {
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         fhold; fgoto body_section_skip;
     }
 
     action body_section_error {
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
@@ -171,8 +171,8 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 
@@ -197,13 +197,13 @@
             try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-            } catch (MetaSectionError &ex) {
-                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
-            } catch (BodySectionError &ex) {
-                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            } catch (MetaSectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
+            } catch (BodySectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError ex) {
-            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
+        } catch (BodySectionError &error) {
+            ErrorPolicy::handle_error(*this, error);
         }
     }
 
@@ -212,125 +212,127 @@
 
     # Fileformat line
     action fileformat_error {
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.2'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         fhold; fgoto meta_section_skip;
     } 
 
     # ALT metadata
     action meta_alt_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_alt_id_err {
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         fhold; fgoto meta_section_skip;
     }
     
     # assembly metadata
     action meta_assembly_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # contig metadata
     action meta_contig_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # FILTER metadata
     action meta_filter_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     # FORMAT metadata
     action meta_format_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_format_number_err {
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_format_type_err {
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Type is not a Integer, Float, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Type is not a Integer, Float, Character or String"});
         fhold; fgoto meta_section_skip;
     }
 
     # INFO metadata
     action meta_info_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_info_number_err {
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_info_type_err {
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         fhold; fgoto meta_section_skip;
     }
 
     # PEDIGREE metadata
     action meta_pedigree_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # pedigreeDB metadata
     action meta_pedigreedb_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # SAMPLE metadata
     action meta_sample_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_sample_genomes_err {
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_sample_mixture_err {
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         fhold; fgoto meta_section_skip;
     }
     
     # Metadata generic errors (do not apply to a specific type)
     action meta_id_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_desc_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_url_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         fhold; fgoto meta_section_skip;
     }
     
     # Header errors
     action header_prefix_err {
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         fhold; fgoto body_section_skip;
@@ -340,155 +342,155 @@
 
     # Chromosome
     action chrom_error {
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Position
     action pos_error {
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # ID
     action id_error {
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Reference allele
     action ref_error {
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Alternate alleles
     action alt_error {
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Quality
     action qual_error {
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Filter
     action filter_error {
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Info
     action info_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         fhold; fgoto body_section_skip;
     }
 
     action info_key_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         fhold; fgoto body_section_skip;
     }
     
     action info_value_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AA_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AC_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AF_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AN_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_BQ_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_CIGAR_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         fhold; fgoto body_section_skip;
     }
     
     action info_DB_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_DP_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_END_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_H2_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_H3_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_MQ_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_MQ0_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_NS_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_SB_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_SOMATIC_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_VALIDATED_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_1000G_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     # Format
     action format_error {
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
@@ -496,14 +498,14 @@
     action sample_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         fhold; fgoto body_section_skip;
     }
     
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         fhold; fgoto body_section_skip;
     }
 

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -70,8 +70,8 @@
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
     }
 
@@ -81,8 +81,8 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         fhold; fgoto body_section_skip;
@@ -171,8 +171,8 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.what());
+        } catch (MetaSectionError ex) {
+          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
         }
     }
 
@@ -194,12 +194,16 @@
         try {
           // Handle all columns and build record
           ParsePolicy::handle_body_line(*this);
+            try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-        } catch (ParsingError ex) {
-          ErrorPolicy::handle_body_section_error(*this, ex.what());
-        } catch (ParsingWarning ex) {
-          ErrorPolicy::handle_body_section_warning(*this, ex.what());
+            } catch (MetaSectionError &ex) {
+                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
+            } catch (BodySectionError &ex) {
+                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            }
+        } catch (BodySectionError ex) {
+            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
         }
     }
 
@@ -325,8 +329,8 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (ParsingWarning warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.what());
+        } catch (MetaSectionError warn) {
+          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
         }
         
         fhold; fgoto body_section_skip;

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -58,38 +58,38 @@
     ######### Global section actions #########
 
     action fileformat_section_error {
-        ErrorPolicy::handle_fileformat_section_error(*this);
+        ErrorPolicy::handle_error(*this, FileformatError{n_lines});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_section_error {
-        ErrorPolicy::handle_meta_section_error(*this);
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
     }
 
     action header_section_error {
-        ErrorPolicy::handle_header_section_error(*this);
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         fhold; fgoto body_section_skip;
     }
 
     action body_section_error {
-        ErrorPolicy::handle_body_section_error(*this);
+        ErrorPolicy::handle_error(*this, BodySectionError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
@@ -171,8 +171,8 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError ex) {
-          ErrorPolicy::handle_meta_section_error(*this, ex.get_raw_message());
+        } catch (MetaSectionError &error) {
+          ErrorPolicy::handle_error(*this, error);
         }
     }
 
@@ -197,13 +197,13 @@
             try {
           // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
           OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
-            } catch (MetaSectionError &ex) {
-                ErrorPolicy::handle_meta_section_warning(*this, ex.get_raw_message());
-            } catch (BodySectionError &ex) {
-                ErrorPolicy::handle_body_section_warning(*this, ex.get_raw_message());
+            } catch (MetaSectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
+            } catch (BodySectionError &warn) {
+                ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError ex) {
-            ErrorPolicy::handle_body_section_error(*this, ex.get_raw_message());
+        } catch (BodySectionError &error) {
+            ErrorPolicy::handle_error(*this, error);
         }
     }
 
@@ -212,125 +212,127 @@
 
     # Fileformat line
     action fileformat_error {
-        ErrorPolicy::handle_fileformat_section_error(*this,
-            "The fileformat declaration is not 'fileformat=VCFv4.3'");
+        ErrorPolicy::handle_error(*this,
+            FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         fhold; fgoto meta_section_skip;
     } 
 
     # ALT metadata
     action meta_alt_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in ALT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in ALT metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_alt_id_err {
-        ErrorPolicy::handle_meta_section_error(*this, "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines,
+            "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         fhold; fgoto meta_section_skip;
     }
     
     # assembly metadata
     action meta_assembly_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in assembly metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in assembly metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # contig metadata
     action meta_contig_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in contig metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in contig metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # FILTER metadata
     action meta_filter_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FILTER metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FILTER metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     # FORMAT metadata
     action meta_format_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in FORMAT metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in FORMAT metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_format_number_err {
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_format_type_err {
-        ErrorPolicy::handle_meta_section_error(*this, "FORMAT metadata Type is not a Integer, Float, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "FORMAT metadata Type is not a Integer, Float, Character or String"});
         fhold; fgoto meta_section_skip;
     }
 
     # INFO metadata
     action meta_info_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in INFO metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in INFO metadata"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_info_number_err {
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Number is not a number, A, R, G or dot");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_info_type_err {
-        ErrorPolicy::handle_meta_section_error(*this, "INFO metadata Type is not a Integer, Float, Flag, Character or String");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         fhold; fgoto meta_section_skip;
     }
 
     # PEDIGREE metadata
     action meta_pedigree_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in PEDIGREE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # pedigreeDB metadata
     action meta_pedigreedb_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in pedigreeDB metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     # SAMPLE metadata
     action meta_sample_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Error in SAMPLE metadata");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_sample_genomes_err {
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_sample_mixture_err {
-        ErrorPolicy::handle_meta_section_error(*this, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         fhold; fgoto meta_section_skip;
     }
     
     # Metadata generic errors (do not apply to a specific type)
     action meta_id_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         fhold; fgoto meta_section_skip;
     }
     
     action meta_desc_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata description string is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata description string is not valid"});
         fhold; fgoto meta_section_skip;
     }
 
     action meta_url_err {
-        ErrorPolicy::handle_meta_section_error(*this, "Metadata URL is not valid");
+        ErrorPolicy::handle_error(*this, MetaSectionError{n_lines, "Metadata URL is not valid"});
         fhold; fgoto meta_section_skip;
     }
     
     # Header errors
     action header_prefix_err {
-        ErrorPolicy::handle_header_section_error(*this, "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO");
+        ErrorPolicy::handle_error(*this, HeaderSectionError{n_lines,
+            "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
         
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError warn) {
-          ErrorPolicy::handle_meta_section_warning(*this, warn.get_raw_message());
+        } catch (MetaSectionError &warn) {
+          ErrorPolicy::handle_warning(*this, warn);
         }
         
         fhold; fgoto body_section_skip;
@@ -340,170 +342,170 @@
 
     # Chromosome
     action chrom_error {
-        ErrorPolicy::handle_body_section_error(*this, "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)");
+        ErrorPolicy::handle_error(*this, ChromosomeBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Position
     action pos_error {
-        ErrorPolicy::handle_body_section_error(*this, "Position is not a positive number");
+        ErrorPolicy::handle_error(*this, PositionBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # ID
     action id_error {
-        ErrorPolicy::handle_body_section_error(*this, "ID is not a single dot or a list of strings without semicolons or whitespaces");
+        ErrorPolicy::handle_error(*this, IdBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Reference allele
     action ref_error {
-        ErrorPolicy::handle_body_section_error(*this, "Reference is not a string of bases");
+        ErrorPolicy::handle_error(*this, ReferenceAlleleBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Alternate alleles
     action alt_error {
-        ErrorPolicy::handle_body_section_error(*this, "Alternate is not a single dot or a comma-separated list of bases");
+        ErrorPolicy::handle_error(*this, AlternateAllelesBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Quality
     action qual_error {
-        ErrorPolicy::handle_body_section_error(*this, "Quality is not a single dot or a positive number");
+        ErrorPolicy::handle_error(*this, QualityBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Filter
     action filter_error {
-        ErrorPolicy::handle_body_section_error(*this, "Filter is not a single dot or a semicolon-separated list of strings");
+        ErrorPolicy::handle_error(*this, FilterBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
     # Info
     action info_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info is not a single dot or a semicolon-separated list of key-value pairs");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         fhold; fgoto body_section_skip;
     }
 
     action info_key_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info key is not a sequence of alphanumeric and/or punctuation characters");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         fhold; fgoto body_section_skip;
     }
     
     action info_value_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AA_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AA value is not a single dot or a string of bases");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AA value is not a single dot or a string of bases"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AC_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AC value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AC value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AD_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AD value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AD value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_ADF_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info ADF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info ADF value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_ADR_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info ADR value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info ADR value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
-    
+
     action info_AF_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AF value is not a comma-separated list of numbers");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AF value is not a comma-separated list of numbers"});
         fhold; fgoto body_section_skip;
     }
     
     action info_AN_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info AN value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info AN value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_BQ_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info BQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info BQ value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_CIGAR_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info CIGAR value is not an alphanumeric string");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info CIGAR value is not an alphanumeric string"});
         fhold; fgoto body_section_skip;
     }
     
     action info_DB_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info DB is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DB is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_DP_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info DP value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info DP value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_END_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info END value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info END value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_H2_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info H2 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H2 is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_H3_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info H3 is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info H3 is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_MQ_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_MQ0_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info MQ0 value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info MQ0 value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_NS_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info NS value is not an integer number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info NS value is not an integer number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_SB_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info SB value is not a number");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SB value is not a number"});
         fhold; fgoto body_section_skip;
     }
     
     action info_SOMATIC_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info SOMATIC is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info SOMATIC is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_VALIDATED_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info VALIDATED is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info VALIDATED is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     action info_1000G_error {
-        ErrorPolicy::handle_body_section_error(*this, "Info 1000G is not a flag (with 1/0/no value)");
+        ErrorPolicy::handle_error(*this, InfoBodyError{n_lines, "Info 1000G is not a flag (with 1/0/no value)"});
         fhold; fgoto body_section_skip;
     }
     
     # Format
     action format_error {
-        ErrorPolicy::handle_body_section_error(*this, "Format is not a colon-separated list of alphanumeric strings");
+        ErrorPolicy::handle_error(*this, FormatBodyError{n_lines});
         fhold; fgoto body_section_skip;
     }
 
@@ -511,14 +513,14 @@
     action sample_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         fhold; fgoto body_section_skip;
     }
     
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_body_section_error(*this, message_stream.str());
+        ErrorPolicy::handle_error(*this, SamplesBodyError{n_lines, message_stream.str()});
         fhold; fgoto body_section_skip;
     }
 

--- a/test/input_files/failed/failed_fileformat_000.vcf
+++ b/test/input_files/failed/failed_fileformat_000.vcf
@@ -1,4 +1,4 @@
-##fileformat=
+##qformat=
 ##CauseOfFailure=Empty fileformat
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
 1	123	.	TC	T	.	.	.

--- a/test/input_files/failed/failed_fileformat_000.vcf
+++ b/test/input_files/failed/failed_fileformat_000.vcf
@@ -1,4 +1,4 @@
-##qformat=
+##fileformat=
 ##CauseOfFailure=Empty fileformat
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
 1	123	.	TC	T	.	.	.

--- a/test/vcf/metaentry_test.cpp
+++ b/test/vcf/metaentry_test.cpp
@@ -21,6 +21,7 @@
 #include "catch/catch.hpp"
 
 #include "vcf/file_structure.hpp"
+#include "vcf/error.hpp"
 
 namespace ebi
 {
@@ -36,12 +37,12 @@ namespace ebi
             
             SECTION ("It should work with any ID and source")
             {
-                CHECK_NOTHROW( (vcf::MetaEntry { "reference" }) );
+                CHECK_NOTHROW( (vcf::MetaEntry { 1, "reference" }) );
             }
             
             SECTION ("No value should be assigned")
             {
-                auto meta = vcf::MetaEntry { "reference" } ;
+                auto meta = vcf::MetaEntry { 1, "reference" } ;
                 
                 CHECK( meta.id == "reference" );
                 CHECK( meta.structure == vcf::MetaEntry::Structure::NoValue );
@@ -63,12 +64,12 @@ namespace ebi
             
             SECTION("Correct arguments")
             {
-                CHECK_NOTHROW( (vcf::MetaEntry { "assembly", "GRCh37" }) );
+                CHECK_NOTHROW( (vcf::MetaEntry { 1, "assembly", "GRCh37" }) );
             }
             
             SECTION("A one-line string value should be assigned")
             {
-                auto meta = vcf::MetaEntry { "assembly", "GRCh37" } ;
+                auto meta = vcf::MetaEntry { 1, "assembly", "GRCh37" } ;
                         
                 CHECK( meta.structure == vcf::MetaEntry::Structure::PlainValue );
                 CHECK( meta.id == "assembly" );
@@ -79,8 +80,8 @@ namespace ebi
                 
             SECTION("A multi-line string value should throw an error")
             {
-                CHECK_THROWS_AS( (vcf::MetaEntry { "assembly", "GRCh37\nGRCh37" } ),
-                                std::invalid_argument);
+                CHECK_THROWS_AS( (vcf::MetaEntry { 1, "assembly", "GRCh37\nGRCh37" } ),
+                                vcf::MetaSectionError);
             }
     }
 
@@ -95,7 +96,8 @@ namespace ebi
             
         SECTION("Correct arguments")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                            1,
                             "contig",
                             { {"ID", "contig_1"} }} ) );
         }
@@ -103,7 +105,8 @@ namespace ebi
         
         SECTION("A key-pair map should be assigned")
         {
-            auto meta = vcf::MetaEntry {  
+            auto meta = vcf::MetaEntry {
+                            1,
                             "contig",
                             { {"ID", "contig_1"} }} ;
 
@@ -128,77 +131,91 @@ namespace ebi
             
         SECTION("ID and Description presence")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "INS"}, {"Description", "tag_description"} }
                             } ) );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {  
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"Description", "tag_description"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {  
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "TAG_ID"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
         
         SECTION("ID prefixes")
         {
             CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "DEL"}, {"Description", "tag_description"} }
                             } ) );
                               
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "INS"}, {"Description", "tag_description"} }
                             } ) );
                              
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "DUP"}, {"Description", "tag_description"} }
                             } ) );
                              
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "INV"}, {"Description", "tag_description"} }
                             } ) );
                              
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "CNV"}, {"Description", "tag_description"} }
                             } ) );
                                
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "DEL:FOO"}, {"Description", "tag_description"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "INS:FOO"}, {"Description", "tag_description"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "DUP:FOO"}, {"Description", "tag_description"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "INV:FOO"}, {"Description", "tag_description"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "CNV:FOO"}, {"Description", "tag_description"} }
                             } ) );
                                   
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "ALT",
                                 { {"ID", "CNV:FOO:BAR"}, {"Description", "tag_description"} }
                             } ) );
@@ -217,21 +234,24 @@ namespace ebi
             
         SECTION("ID presence")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "contig",
                                 { {"ID", "contig_1"} }
                             } ) );
                                 
             CHECK_NOTHROW( (vcf::MetaEntry { 
+                                1,
                                 "contig",
                                 { {"ID", "contig_2"}, {"Description", "tag_description"} }
                             } ) );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {  
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "contig",
                                 { {"Description", "tag_description"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
     }
     
@@ -246,22 +266,25 @@ namespace ebi
             
         SECTION("ID and Description presence")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FILTER",
                                 { {"ID", "Filter1"}, {"Description", "tag_description"} }
                             } ) );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {  
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FILTER",
                                 { {"Description", "tag_description"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {  
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FILTER",
                                 { {"ID", "TAG_ID"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
     }
     
@@ -276,109 +299,127 @@ namespace ebi
             
         SECTION("ID, Number, Type and Description presence")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"Number", "1"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "String"} }
                             }),
-                            std::invalid_argument ); 
+                            vcf::MetaSectionError );
         }
         
         SECTION("Number field values")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "10"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "A"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "R"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "G"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                             
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "."}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                             
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "10a"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "D"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
         
         SECTION("Type field values")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "10"}, {"Type", "Integer"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "A"}, {"Type", "Float"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "R"}, {"Type", "Character"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "G"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                             
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "."}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "FORMAT",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "int"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
     }
     
@@ -393,114 +434,133 @@ namespace ebi
             
         SECTION("ID, Number, Type and Description presence")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"Number", "1"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "String"} }
                             }),
-                            std::invalid_argument ); 
+                            vcf::MetaSectionError );
         }
         
         SECTION("Number field values")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "10"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "A"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "R"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "G"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                             
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "."}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                             
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "10a"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "D"}, {"Type", "String"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
         
         SECTION("Type field values")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "10"}, {"Type", "Integer"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "A"}, {"Type", "Float"}, {"Description", "Genotype"} }
                             } ) );
                                      
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "A"}, {"Type", "Flag"}, {"Description", "Genotype"} }
                             } ) );
                                
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "R"}, {"Type", "Character"}, {"Description", "Genotype"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "G"}, {"Type", "String"}, {"Description", "Genotype"} }
                             } ) );
                             
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "."}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry { 
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "INFO",
                                 { {"ID", "GT"}, {"Number", "1"}, {"Type", "int"}, {"Description", "Genotype"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
     }
     
@@ -515,21 +575,24 @@ namespace ebi
             
         SECTION("ID presence")
         {
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "SAMPLE",
                                 { {"ID", "Sample_1"} }
                             } ) );
                                 
-            CHECK_NOTHROW( (vcf::MetaEntry { 
+            CHECK_NOTHROW( (vcf::MetaEntry {
+                                1,
                                 "SAMPLE",
                                 { {"ID", "Sample_2"}, {"Genomes", "genome_1,genome_2"}, {"Mixtures", "mixture_1"} }
                             } ) );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {  
+            CHECK_THROWS_AS( (vcf::MetaEntry {
+                                1,
                                 "SAMPLE",
                                 { {"Genomes", "genome_1,genome_2"} }
                             }),
-                            std::invalid_argument );
+                            vcf::MetaSectionError );
         }
     }
 }

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <memory>
+#include <vcf/error.hpp>
 
 #include "catch/catch.hpp"
 
@@ -23,7 +24,7 @@
 namespace ebi
 {
     
-    TEST_CASE("Record constructor", "[constructor]") 
+    TEST_CASE("Record constructor", "[constructor]")
     {
         auto source = vcf::Source {
             "Example VCF source",
@@ -79,7 +80,8 @@ namespace ebi
          
         SECTION("Correct arguments") 
         {
-            CHECK_NOTHROW( (vcf::Record { 
+            CHECK_NOTHROW( (vcf::Record {
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -92,7 +94,8 @@ namespace ebi
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)} ) );
                 
-            CHECK_NOTHROW( (vcf::Record{ 
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { }, 
@@ -108,7 +111,8 @@ namespace ebi
 
         SECTION("Chromosome with whitespaces") 
         {
-            CHECK_THROWS_AS( (vcf::Record{ 
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
                                 "chr 1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -120,12 +124,13 @@ namespace ebi
                                 { "GT", "DP" }, 
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}),
-                            std::invalid_argument);
+                            vcf::ChromosomeBodyError);
         }
 
         SECTION("Chromosome with colons") 
         {
-            CHECK_THROWS_AS( (vcf::Record{ 
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
                                 "chr:1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -137,12 +142,13 @@ namespace ebi
                                 { "GT", "DP" }, 
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}),
-                            std::invalid_argument);
+                            vcf::ChromosomeBodyError);
         }
 
         SECTION("ID with whitespaces") 
         {
-            CHECK_THROWS_AS( (vcf::Record{ 
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id 123", "id456" }, 
@@ -154,12 +160,13 @@ namespace ebi
                                 { "GT", "DP" }, 
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}),
-                            std::invalid_argument);
+                            vcf::IdBodyError);
         }
 
         SECTION("Different length alleles")
         {
-            CHECK_NOTHROW( (vcf::Record{ 
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -172,7 +179,8 @@ namespace ebi
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}) );
                                 
-            CHECK_NOTHROW( (vcf::Record{ 
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -188,8 +196,9 @@ namespace ebi
         
         SECTION("Same length alleles") 
         {
-            CHECK_NOTHROW( (vcf::Record{ 
-                                "chr1", 
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
                                 123456, 
                                 { "id123", "id456" }, 
                                 "A", 
@@ -204,8 +213,9 @@ namespace ebi
 
         SECTION("Same alleles") 
         {
-            CHECK_THROWS_AS( (vcf::Record{ 
-                                "chr1", 
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
+                                "chr1",
                                 123456, 
                                 { "id123", "id456" }, 
                                 "A", 
@@ -216,12 +226,13 @@ namespace ebi
                                 { "GT", "DP" }, 
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}),
-                            std::invalid_argument);
+                            vcf::AlternateAllelesBodyError);
         }
 
         SECTION("Less-than-zero quality") 
         {
-            CHECK_THROWS_AS( (vcf::Record{ 
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -233,12 +244,13 @@ namespace ebi
                                 { "GT", "DP" }, 
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}),
-                            std::invalid_argument);
+                            vcf::QualityBodyError);
         }
 
         SECTION("Emtpy INFO") 
         {
-            CHECK_NOTHROW( (vcf::Record{ 
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -254,7 +266,8 @@ namespace ebi
 
         SECTION("Single-field format") 
         {
-            CHECK_NOTHROW( (vcf::Record{ 
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -267,7 +280,8 @@ namespace ebi
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}) );
                                 
-            CHECK_THROWS_AS( (vcf::Record{ 
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -279,12 +293,13 @@ namespace ebi
                                 { "DP" }, 
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}),
-                            std::invalid_argument);
+                            vcf::FormatBodyError);
         }
         
         SECTION("Multi-field format") 
         {
-            CHECK_NOTHROW( (vcf::Record{ 
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
@@ -297,19 +312,20 @@ namespace ebi
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}) );
                                 
-            CHECK_THROWS_AS( (vcf::Record{ 
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
                                 "chr1", 
                                 123456, 
                                 { "id123", "id456" }, 
                                 "A", 
-                                { "A", "C" }, 
+                                { "T", "C" },
                                 1.0, 
                                 { "PASS" }, 
                                 { {"AN", "12,7"}, {"AF", "0.5,0.3"} }, 
                                 { "DP", "GT" }, 
                                 { "0|1" },
                                 std::make_shared<vcf::Source>(source)}),
-                            std::invalid_argument);
+                            vcf::FormatBodyError);
         }
         
     }

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -15,11 +15,11 @@
  */
 
 #include <memory>
-#include <vcf/error.hpp>
 
 #include "catch/catch.hpp"
 
 #include "vcf/file_structure.hpp"
+#include "vcf/error.hpp"
 
 namespace ebi
 {
@@ -35,6 +35,7 @@ namespace ebi
             
         source.meta_entries.emplace("FORMAT",
             vcf::MetaEntry{
+                1,
                 "FORMAT",
                 {
                     { "ID", "GT" },
@@ -46,6 +47,7 @@ namespace ebi
            
         source.meta_entries.emplace("FORMAT",
             vcf::MetaEntry{
+                1,
                 "FORMAT",
                 {
                     { "ID", "DP" },
@@ -57,6 +59,7 @@ namespace ebi
 
         source.meta_entries.emplace("INFO",
             vcf::MetaEntry{
+                1,
                 "INFO",
                 {
                     { "ID", "AN" },
@@ -68,6 +71,7 @@ namespace ebi
            
         source.meta_entries.emplace("INFO",
             vcf::MetaEntry{
+                1,
                 "INFO",
                 {
                     { "ID", "AF" },


### PR DESCRIPTION
This PR implements a error hierarchy to locate the errors programmaticaly, instead of leaving the location inside a string.

Highlights:
- `Error` is the parent class, and it inherits `std::runtime_error`.
- At the moment, an `Error` (or inheriting class) can receive a line number (from the input file), and a message.
- Every `Error`  (or inheriting class), has a default message, so only the line is mandatory.
- If a `Error` is `throw`n, it's advisable to `catch` it as a reference, to enable polymorphism.
- `ErrorPolicy` now only defines two methods: `handle_error` and `handle_warning`, so it is effectively decoupled from the location.
- `ParsingWarning` and `ParsingError` were removed. Use a combination of `Error` and `ErrorPolicy::handle_*`.
- Record and MetaEntry have their line number, in order to be able to construct an `Error`.
- Updated tests.

This PR allows for next steps:
- A new ErrorPolicy could be added that stores the errors for a future vcf_fixer.