### PR TITLE
fix bug when input file doesn't exist.

### DIFF
--- a/inc/util/stream_utils.hpp
+++ b/inc/util/stream_utils.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STREAM_UTILS_HPP
+#define STREAM_UTILS_HPP
+
+#include <iostream>
+
+namespace ebi
+{
+  namespace util
+  {
+    template <typename Container>
+    std::istream & readline(std::istream & stream, Container & container)
+    {
+        char c;
+        container.clear();
+
+        // using operator bool: http://www.cplusplus.com/reference/ios/ios/fail/
+        // `stream.get()` sets failbit as well on eof
+        do {
+            stream.get(c);
+            container.push_back(c);
+        } while (stream && c != '\n');
+
+        return stream;
+    }
+  }
+}
+
+#endif  /* STREAM_UTILS_HPP */
+

--- a/inc/util/string_utils.hpp
+++ b/inc/util/string_utils.hpp
@@ -15,7 +15,7 @@
  */
 
 #ifndef STRING_UTILS_HPP
-#define	STRING_UTILS_HPP
+#define STRING_UTILS_HPP
 
 #include <cstring>
 #include <string>
@@ -25,31 +25,29 @@ namespace ebi
 {
   namespace util
   {
-    
     template<typename C>
     void string_split(std::string const & s, char const * delims, C & ret)
     {
         C output;
         char const* p = s.c_str();
         char const* q = strpbrk(p+1, delims);
-        
+
         // Insert first to last-1 elements
         for( ; q != NULL; q = strpbrk(p, delims) )
         {
-          output.push_back(typename C::value_type(p, q));
-          p = q + 1;
+            output.push_back(typename C::value_type(p, q));
+            p = q + 1;
         }
-        
+
         // Insert last element
         if (p < &(s.back()) + 1) {
             output.push_back(typename C::value_type(p));
         }
-        
+
         output.swap(ret);
     }
-    
   }
 }
 
-#endif	/* STRING_UTILS_HPP */
+#endif  /* STRING_UTILS_HPP */
 

--- a/test/vcf/input_files_test.cpp
+++ b/test/vcf/input_files_test.cpp
@@ -6,6 +6,7 @@
 
 #include "catch/catch.hpp"
 
+#include "util/stream_utils.hpp"
 #include "vcf/file_structure.hpp"
 #include "vcf/validator.hpp"
 
@@ -13,21 +14,6 @@ namespace ebi
 {
     
     size_t const default_line_buffer_size = 64 * 1024;
-    
-    template <typename Container>
-    std::istream & readline(std::istream & stream, Container & container)
-    {
-        char c;
-
-        container.clear();
-
-        do {
-            stream.get(c);
-            container.push_back(c);
-        } while (!stream.eof() && c != '\n');
-        
-        return stream;
-    }
     
     bool is_valid(std::string path)
     {
@@ -42,7 +28,7 @@ namespace ebi
         std::vector<char> line;
         line.reserve(default_line_buffer_size);
 
-        while (readline(input, line)) { 
+        while (ebi::util::readline(input, line)) { 
            validator.parse(line);
         }
 


### PR DESCRIPTION
- Opening a file should be followed by a test if the file opened
sucessfully.
- our readline() was not checking if the stream was in a bad state,
thus reading on and on even if the file didn't actually open.
- I found out why std::getline was not working for us: it discards
the '\n' when found, and our ragel requires it to be present.