### PR TITLE
EVA-341 Reading sqlite reports

### DIFF
--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -24,6 +24,25 @@ namespace ebi
 {
   namespace vcf
   {
+    enum class ErrorCode {
+        error,
+        meta_section,
+        header_section,
+        body_section,
+        fileformat,
+        chromosome_body,
+        position_body,
+        id_body,
+        reference_allele_body,
+        alternate_alleles_body,
+        quality_body,
+        filter_body,
+        info_body,
+        format_body,
+        samples_body,
+    };
+    
+    
     // parent of vcf errors
     class Error : public std::runtime_error
     {
@@ -36,14 +55,9 @@ namespace ebi
                   message{message} {}
 
 
-        size_t get_line() const
-        {
-          return line;
-        }
-        const std::string &get_raw_message() const
-        {
-          return message;
-        }
+        size_t get_line() const { return line; }
+        const std::string &get_raw_message() const { return message; }
+        virtual ErrorCode get_code() const { return ErrorCode::error; }
 
       private:
         size_t line;
@@ -56,6 +70,7 @@ namespace ebi
       public:
         using Error::Error;
         MetaSectionError(size_t line) : MetaSectionError{line, "Error in meta-data section"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::meta_section; }
     };
 
     class HeaderSectionError : public Error
@@ -63,6 +78,7 @@ namespace ebi
       public:
         using Error::Error;
         HeaderSectionError(size_t line) : HeaderSectionError{line, "Error in header section"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::header_section; }
     };
 
     class BodySectionError : public Error
@@ -70,6 +86,7 @@ namespace ebi
       public:
         using Error::Error;
         BodySectionError(size_t line) : BodySectionError{line, "Error in body section"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::body_section; }
     };
 
     // inheritance siblings about detailed errors
@@ -78,6 +95,7 @@ namespace ebi
       public:
         using MetaSectionError::MetaSectionError;
         FileformatError(size_t line) : FileformatError{line, "Error in file format section"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::fileformat; }
     };
 
     class ChromosomeBodyError : public BodySectionError
@@ -86,6 +104,7 @@ namespace ebi
         using BodySectionError::BodySectionError;
         ChromosomeBodyError(size_t line) : ChromosomeBodyError{line,
             "Chromosome is not a string without colons or whitespaces, optionally wrapped with angle brackets (<>)"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::chromosome_body; }
     };
 
     class PositionBodyError : public BodySectionError
@@ -93,54 +112,63 @@ namespace ebi
       public:
         using BodySectionError::BodySectionError;
         PositionBodyError(size_t line) : PositionBodyError{line, "Position is not a positive number"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::position_body; }
     };
     class IdBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         IdBodyError(size_t line) : IdBodyError{line, "ID is not a single dot or a list of strings without semicolons or whitespaces"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::id_body; }
     };
     class ReferenceAlleleBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         ReferenceAlleleBodyError(size_t line) : ReferenceAlleleBodyError{line, "Reference is not a string of bases"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::reference_allele_body; }
     };
     class AlternateAllelesBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         AlternateAllelesBodyError(size_t line) : AlternateAllelesBodyError{line, "Alternate is not a single dot or a comma-separated list of bases"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::alternate_alleles_body; }
     };
     class QualityBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         QualityBodyError(size_t line) : QualityBodyError{line, "Quality is not a single dot or a positive number"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::quality_body; }
     };
     class FilterBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         FilterBodyError(size_t line) : FilterBodyError{line, "Filter is not a single dot or a semicolon-separated list of strings"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::filter_body; }
     };
     class InfoBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         InfoBodyError(size_t line) : InfoBodyError{line, "Error in info column, in body section"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::info_body; }
     };
     class FormatBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         FormatBodyError(size_t line) : FormatBodyError{line, "Format is not a colon-separated list of alphanumeric strings"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::format_body; }
     };
     class SamplesBodyError : public BodySectionError
     {
       public:
         using BodySectionError::BodySectionError;
         SamplesBodyError(size_t line) : SamplesBodyError{line, "Error in samples columns, in body section"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::samples_body; }
     };
 
   }

--- a/inc/vcf/report_reader.hpp
+++ b/inc/vcf/report_reader.hpp
@@ -33,12 +33,12 @@ namespace ebi
     class ReportReader
     {
       public:
-//        virtual ~ReportReader() {}  // needed if inheriting classes use raw pointers, instead of references or shared_ptrs
+        virtual ~ReportReader() {}  // needed if inheriting classes use raw pointers, instead of references or shared_ptrs
         virtual size_t count_errors() = 0;
-        virtual Error read_error() = 0;
+        virtual void for_each_error(std::function<void(std::shared_ptr<Error>)> user_function) = 0;
         
         virtual size_t count_warnings() = 0;
-        virtual Error read_warning() = 0;
+        virtual void for_each_warning(std::function<void(std::shared_ptr<Error>)> user_function) = 0;
     };
 
   }

--- a/inc/vcf/report_reader.hpp
+++ b/inc/vcf/report_reader.hpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef VCF_VALIDATOR_REPORT_WRITER_HPP
-#define VCF_VALIDATOR_REPORT_WRITER_HPP
+#ifndef VCF_VALIDATOR_REPORT_READER_HPP
+#define VCF_VALIDATOR_REPORT_READER_HPP
 
 #include <iostream>
 #include <string>
@@ -30,28 +30,19 @@ namespace ebi
 {
   namespace vcf
   {
-    class ReportWriter
+    class ReportReader
     {
       public:
-//        virtual ~ReportWriter() {}  // needed if using raw pointers, instead of references or shared_ptrs
-        virtual void write_error(const Error &error) = 0;
-        virtual void write_warning(const Error &error) = 0;
+//        virtual ~ReportReader() {}  // needed if inheriting classes use raw pointers, instead of references or shared_ptrs
+        virtual size_t count_errors() = 0;
+        virtual Error read_error() = 0;
+        
+        virtual size_t count_warnings() = 0;
+        virtual Error read_warning() = 0;
     };
 
-    class StdoutReportWriter : public ReportWriter
-    {
-      public:
-        virtual void write_error(const Error &error) override
-        {
-          std::cout << error.what() << std::endl;
-        }
-        virtual void write_warning(const Error &error) override
-        {
-          std::cout << error.what() << " (warning)" << std::endl;
-        }
-    };
   }
 }
 
 
-#endif //VCF_VALIDATOR_REPORT_WRITER_HPP
+#endif //VCF_VALIDATOR_REPORT_READER_HPP

--- a/inc/vcf/report_writer.hpp
+++ b/inc/vcf/report_writer.hpp
@@ -33,7 +33,7 @@ namespace ebi
     class ReportWriter
     {
       public:
-//        virtual ~ReportWriter() {}  // needed if using raw pointers, instead of references or shared_ptrs
+        virtual ~ReportWriter() {}  // needed if using raw pointers, instead of references or shared_ptrs in children
         virtual void write_error(const Error &error) = 0;
         virtual void write_warning(const Error &error) = 0;
     };

--- a/inc/vcf/sqlite_report.hpp
+++ b/inc/vcf/sqlite_report.hpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VCF_VALIDATOR_SQLITE_REPORT_HPP
+#define VCF_VALIDATOR_SQLITE_REPORT_HPP
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <stdexcept>
+#include <chrono>
+#include <thread>
+#include "sqlite/sqlite3.h"
+#include "vcf/error.hpp"
+#include "report_writer.hpp"
+#include "report_reader.hpp"
+
+namespace ebi
+{
+  namespace vcf
+  {
+    class SqliteReportRW : public ReportWriter, public ReportReader
+    {
+      public:
+        SqliteReportRW(std::string db_name);
+        void close();
+        ~SqliteReportRW();
+        
+        // ReportWriter implementation
+        void write_error(const Error &error) override;
+        void write_warning(const Error &error) override;
+        
+        // ReportReader implementation
+        size_t count_errors() override;
+        Error read_error() override;
+        size_t count_warnings() override;
+        Error read_warning() override;
+        
+      private:
+        void write(const Error &error, std::string table);
+        void start_transaction();
+        void commit_transaction();
+        void rollback_transaction();
+
+        sqlite3* db;
+        std::string db_name;
+        size_t current_transaction_size;
+        const size_t transaction_size;
+        const std::chrono::milliseconds sleep_time;
+    };
+  }
+}
+
+
+#endif //VCF_VALIDATOR_SQLITE_REPORT_HPP

--- a/inc/vcf/sqlite_report.hpp
+++ b/inc/vcf/sqlite_report.hpp
@@ -51,6 +51,7 @@ namespace ebi
         
       private:
         void write(const Error &error, std::string table);
+        size_t count(std::string table);
         void start_transaction();
         void commit_transaction();
         void rollback_transaction();

--- a/inc/vcf/sqlite_report.hpp
+++ b/inc/vcf/sqlite_report.hpp
@@ -49,12 +49,18 @@ namespace ebi
         size_t count_warnings() override;
         Error read_warning() override;
         
+        void read_errors(std::function<void(std::shared_ptr<Error>)> user_function);
+        void read_warnings(std::function<void(std::shared_ptr<Error>)> user_function);
+        
       private:
         void write(const Error &error, std::string table);
         size_t count(std::string table);
         void start_transaction();
         void commit_transaction();
         void rollback_transaction();
+        
+        void read(std::string table, std::function<void(std::shared_ptr<Error>)> user_function);
+        
 
         sqlite3* db;
         std::string db_name;

--- a/inc/vcf/sqlite_report.hpp
+++ b/inc/vcf/sqlite_report.hpp
@@ -36,8 +36,11 @@ namespace ebi
     {
       public:
         SqliteReportRW(std::string db_name);
+        /** optional, the destructor handles the flushing and closing */
+        void flush();
+        /** optional, the destructor handles the flushing and closing */
         void close();
-        ~SqliteReportRW();
+        ~SqliteReportRW() override;
         
         // ReportWriter implementation
         void write_error(const Error &error) override;
@@ -45,22 +48,19 @@ namespace ebi
         
         // ReportReader implementation
         size_t count_errors() override;
-        Error read_error() override;
         size_t count_warnings() override;
-        Error read_warning() override;
         
-        void read_errors(std::function<void(std::shared_ptr<Error>)> user_function);
-        void read_warnings(std::function<void(std::shared_ptr<Error>)> user_function);
+        void for_each_error(std::function<void(std::shared_ptr<Error>)> user_function);
+        void for_each_warning(std::function<void(std::shared_ptr<Error>)> user_function);
         
       private:
         void write(const Error &error, std::string table);
         size_t count(std::string table);
+        void for_each(std::string table, std::function<void(std::shared_ptr<Error>)> user_function);
+        
         void start_transaction();
         void commit_transaction();
         void rollback_transaction();
-        
-        void read(std::string table, std::function<void(std::shared_ptr<Error>)> user_function);
-        
 
         sqlite3* db;
         std::string db_name;

--- a/inc/vcf/sqlite_report.hpp
+++ b/inc/vcf/sqlite_report.hpp
@@ -50,8 +50,8 @@ namespace ebi
         size_t count_errors() override;
         size_t count_warnings() override;
         
-        void for_each_error(std::function<void(std::shared_ptr<Error>)> user_function);
-        void for_each_warning(std::function<void(std::shared_ptr<Error>)> user_function);
+        void for_each_error(std::function<void(std::shared_ptr<Error>)> user_function) override;
+        void for_each_warning(std::function<void(std::shared_ptr<Error>)> user_function) override;
         
       private:
         void write(const Error &error, sqlite3_stmt *statement);

--- a/inc/vcf/sqlite_report.hpp
+++ b/inc/vcf/sqlite_report.hpp
@@ -54,7 +54,7 @@ namespace ebi
         void for_each_warning(std::function<void(std::shared_ptr<Error>)> user_function);
         
       private:
-        void write(const Error &error, std::string table);
+        void write(const Error &error, sqlite3_stmt *statement);
         size_t count(std::string table);
         void for_each(std::string table, std::function<void(std::shared_ptr<Error>)> user_function);
         
@@ -66,6 +66,8 @@ namespace ebi
         std::string db_name;
         size_t current_transaction_size;
         const size_t transaction_size;
+        sqlite3_stmt *statement_error;
+        sqlite3_stmt *statement_warning;
         const std::chrono::milliseconds sleep_time;
     };
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@
 #include "vcf/validator.hpp"
 #include "vcf/report_writer.hpp"
 #include "util/stream_utils.hpp"
+#include "vcf/sqlite_report.hpp"
 
 namespace
 {
@@ -149,7 +150,7 @@ namespace
                 if (boost::filesystem::exists(db_file)) {
                     throw std::runtime_error{"Report file already exists on " + db_filename + ", please delete it or rename it"};
                 }
-                outputs.emplace_back(new ebi::vcf::SqliteReportWriter(db_filename));
+                outputs.emplace_back(new ebi::vcf::SqliteReportRW(db_filename));
             } else if (out == "stdout") {
                 outputs.emplace_back(new ebi::vcf::StdoutReportWriter());
             } else {

--- a/src/vcf/sqlite_report.cpp
+++ b/src/vcf/sqlite_report.cpp
@@ -169,7 +169,7 @@ namespace ebi
     }
     size_t SqliteReportRW::count_warnings()
     {
-        return 0;
+        return count("warnings");
     }
     Error SqliteReportRW::read_error()
     {
@@ -177,7 +177,29 @@ namespace ebi
     }
     size_t SqliteReportRW::count_errors()
     {
-        return 0;
+        return count("errors");
+    }
+    size_t SqliteReportRW::count(std::string table)
+    {          
+        char *zErrMsg = NULL;
+        size_t count_errors = 0;
+        
+        std::string query{"SELECT count(*) FROM " + table};
+        
+        int rc = sqlite3_exec(db, query.c_str(), [](void* count, int columns, char**values, char**names) {
+            if (values[0] != NULL) {
+                *(size_t*)count = std::stoul(values[0]);
+            }
+            return 0;
+        }, &count_errors, &zErrMsg);
+        
+        if (rc != SQLITE_OK) {
+            std::string error_message = std::string("Can't read database: ") + zErrMsg;
+            sqlite3_free(zErrMsg);
+            throw std::runtime_error(error_message);
+        }
+
+        return count_errors;
     }
   }
 }

--- a/src/vcf/sqlite_report.cpp
+++ b/src/vcf/sqlite_report.cpp
@@ -26,7 +26,7 @@ namespace ebi
         int rc = sqlite3_open(db_name.c_str(), &db);
         if (rc != SQLITE_OK) {
             sqlite3_close(db);
-            throw std::runtime_error(std::string{"Can't open database: "} + sqlite3_errmsg(db));
+            throw std::runtime_error{std::string{"Can't open database: "} + sqlite3_errmsg(db)};
         }
 
         char *zErrMsg = NULL;

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -167,7 +167,7 @@ namespace ebi
       SECTION("write and read errors")
       {
           size_t line = 8;
-          std::string message{"testing erros"};
+          std::string message{"testing errors"};
           ebi::vcf::Error test_error{line, message};
           errorDAO.write_error(test_error);
           errorDAO.flush();

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -27,6 +27,7 @@
 #include "vcf/validator.hpp"
 #include "vcf/error.hpp"
 #include "vcf/report_writer.hpp"
+#include "vcf/sqlite_report.hpp"
 
 
 namespace ebi
@@ -83,7 +84,7 @@ namespace ebi
   {
       std::string db_name = "test/input_files/sqlite_test.errors.db";
       sqlite3* db;
-      ebi::vcf::SqliteReportWriter output{db_name};
+      ebi::vcf::SqliteReportRW output{db_name};
 
       int rc = sqlite3_open(db_name.c_str(), &db);
       if(rc != SQLITE_OK) {
@@ -154,7 +155,7 @@ namespace ebi
       SECTION(path.string())
       {
           {
-              std::shared_ptr<ebi::vcf::ReportWriter> output{std::make_shared<ebi::vcf::SqliteReportWriter>(db_name)};
+              std::shared_ptr<ebi::vcf::ReportWriter> output{std::make_shared<ebi::vcf::SqliteReportRW>(db_name)};
               CHECK_FALSE(is_valid(path.string(), *output));
           }
           int rc = sqlite3_open(db_name.c_str(), &db);

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -198,6 +198,29 @@ namespace ebi
           CHECK(errors_read == 1);
       }
       
+      SECTION("write and read error codes")
+      {
+          size_t line = 8;
+          std::string message{"testing erros"};
+          ebi::vcf::Error generic_error{line, message};
+          ebi::vcf::MetaSectionError meta_section_error{line, message};
+          ebi::vcf::SamplesBodyError samples_body_error{line, message};
+          errorDAO.write_error(generic_error);
+          errorDAO.write_error(meta_section_error);
+          errorDAO.write_error(samples_body_error);
+          errorDAO.flush();
+          
+          std::vector<std::shared_ptr<ebi::vcf::Error>> errors;
+          errorDAO.for_each_error([&](std::shared_ptr<ebi::vcf::Error> error) {
+              errors.push_back(error);
+          });
+          
+          CHECK(errors.size());
+          CHECK(errors[0]->get_code() == ebi::vcf::ErrorCode::error);
+          CHECK(errors[1]->get_code() == ebi::vcf::ErrorCode::meta_section);
+          CHECK(errors[2]->get_code() == ebi::vcf::ErrorCode::samples_body);
+      }
+      
       boost::filesystem::path db_file{db_name};
       boost::filesystem::remove(db_file);
       CHECK_FALSE(boost::filesystem::exists(db_file));


### PR DESCRIPTION
improvements over #24:
- added a ReportReader interface.
- SqliteReportRW (renamed from SqliteReportWriter) now implements both ReportReader and ReportWriter.
- added error codes to Error hierachy to instatiate the correct class while reading from DB.
- added more tests for SqliteReporRW.
- The report reader/writer add a virtual destructor, which fixes a bug in the current develop branch, which doesn't flush the writing