### PR TITLE
Clang build re-enabled in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,56 +4,56 @@ language: cpp
 
 matrix:
   include:
-#    # Clang 3.5
-#    - compiler: clang
-#      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5
-#      addons:
-#        apt:
-#          sources:
-#            - boost-latest
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.5
-#          packages:
-#            - clang-3.5
-#            - clang++-3.5
-#            - libboost1.55-dev
-#            - libboost-filesystem1.55-dev
-#            - libboost-program-options1.55-dev
-#            - libboost-regex1.55-dev
-#    
-#    # Clang 3.6
-#    - compiler: clang
-#      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6
-#      addons:
-#        apt:
-#          sources:
-#            - boost-latest
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.6
-#          packages:
-#            - clang-3.6
-#            - clang++-3.6
-#            - libboost1.55-dev
-#            - libboost-filesystem1.55-dev
-#            - libboost-program-options1.55-dev
-#            - libboost-regex1.55-dev
-#    
-#    # Clang 3.7
-#    - compiler: clang
-#      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7
-#      addons:
-#        apt:
-#          sources:
-#            - boost-latest
-#            - ubuntu-toolchain-r-test
-#            - llvm-toolchain-precise-3.7
-#          packages:
-#            - clang-3.7
-#            - clang++-3.7
-#            - libboost1.55-dev
-#            - libboost-filesystem1.55-dev
-#            - libboost-program-options1.55-dev
-#            - libboost-regex1.55-dev
+    # Clang 3.5
+    - compiler: clang
+      env: C_COMPILER=clang-3.5 CXX_COMPILER=clang++-3.5
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
+          packages:
+            - clang-3.5
+            - clang++-3.5
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
+    
+    # Clang 3.6
+    - compiler: clang
+      env: C_COMPILER=clang-3.6 CXX_COMPILER=clang++-3.6
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+            - clang++-3.6
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
+    
+    # Clang 3.7
+    - compiler: clang
+      env: C_COMPILER=clang-3.7 CXX_COMPILER=clang++-3.7
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+            - clang++-3.7
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
     
     # GCC 4.8
     - compiler: gcc


### PR DESCRIPTION
LLVM's APT is back up online, so we can re-enable Clang builds on Travis.