### PR TITLE
bug fix: debugulator: write all the file

### DIFF
--- a/inc/util/stream_utils.hpp
+++ b/inc/util/stream_utils.hpp
@@ -45,6 +45,15 @@ namespace ebi
         return stream;
     }
 
+    template <typename Container>
+    std::ostream & writeline(std::ostream & stream, Container & container)
+    {
+        for (auto c : container) {
+            stream << c;
+        }
+        return stream;
+    }
+
     template <typename F, typename S>
     std::ostream &operator<<(std::ostream &os, const std::pair<F, S> &container)
     {

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -19,6 +19,8 @@
 
 #include <vector>
 #include <iostream>
+
+#include "util/stream_utils.hpp"
 #include "error.hpp"
 
 namespace ebi
@@ -48,50 +50,62 @@ namespace ebi
 
         virtual void visit(Error &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(MetaSectionError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(HeaderSectionError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(BodySectionError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(FileformatError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(ChromosomeBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(PositionBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(IdBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(ReferenceAlleleBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(AlternateAllelesBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(QualityBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(FilterBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(InfoBodyError &error) override
@@ -100,14 +114,17 @@ namespace ebi
         }
         virtual void visit(FormatBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(SamplesBodyError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(NormalizationError &error) override
         {
+            util::writeline(output, *line);
             ignored_errors++;
         }
         virtual void visit(DuplicationError &error) override

--- a/src/vcf/debugulator.cpp
+++ b/src/vcf/debugulator.cpp
@@ -52,9 +52,7 @@ namespace ebi
                   if (current_line == line_index) {
                       break;
                   }
-                  for (auto c : line) {
-                      output << c;
-                  }
+                  util::writeline(output, line);
               }
               fixer.fix(line_index, line, *error);
           });

--- a/src/vcf/debugulator.cpp
+++ b/src/vcf/debugulator.cpp
@@ -59,6 +59,13 @@ namespace ebi
               fixer.fix(line_index, line, *error);
           });
 
+          // advance input from the last error to the end of input
+          while (ebi::util::readline(input, line)) {
+              for (auto c : line) {
+                  output << c;
+              }
+          }
+
           size_t ignored_errors = fixer.get_ignored_errors();
           if (ignored_errors != 0) {
               std::cerr << "There were " << ignored_errors << " errors that couldn't be automatically fixed" << std::endl;


### PR DESCRIPTION
the previous stopped copying the input file at the last error.