### PR TITLE
EVA-344 fix samples column not matching FORMAT and meta 

### DIFF
--- a/inc/util/stream_utils.hpp
+++ b/inc/util/stream_utils.hpp
@@ -46,7 +46,7 @@ namespace ebi
     }
 
     template <typename Container>
-    std::ostream & writeline(std::ostream & stream, Container & container)
+    std::ostream & writeline(std::ostream & stream, const Container & container)
     {
         for (auto c : container) {
             stream << c;
@@ -61,19 +61,25 @@ namespace ebi
     }
 
     /**
-     * This is a generic method that prints a collection if it has the operations ".size()", ".begin()", ".end()"
+     * This is a generic method that prints a collection if its inner type is printable with "operator<<"
+     *
+     * @param os ostream to write into
+     * @param container must have he operations ".begin()" and ".end()"
      * defined and they provide iterators, and the inner type has an overloaded "operator<<"
+     * @param open_tag will be written before the first element (e.g. "[", if you want something like "[2,4]"), can be an empty string
+     * @param separator_tag will be written between elements (e.g. "," in "[2,4]"), can be empty string
+     * @param close_tag will be written after the last element (e.g. "]" in "[2,4]"), can be emtpy string
+     * @return the ostream passed, in the questionable case you want to do `print_containter(cout, ...) << "more messages"`;
      */
     template <typename T>
     std::ostream &print_container(std::ostream &os, const T &container,
                                   std::string open_tag, std::string separator_tag, std::string close_tag) {
-        size_t size = container.size();
         os << open_tag;
-        if (size > 0) {
-            auto it = container.begin();
+        auto it = container.begin();
+        auto end = container.end();
+        if (it != end) {
             os << *it;
-            it++;
-            for (; it != container.end(); ++it) {
+            for (++it; it != container.end(); ++it) {
                 os << separator_tag << *it;
             }
         }
@@ -82,8 +88,10 @@ namespace ebi
     }
 
     /**
-     * This is a generic method that prints a collection if it has the operations ".size()", ".begin()", ".end()"
+     * This is a generic method that prints a collection if it has the operations ".begin()" and ".end()"
      * defined and they provide iterators, and the inner type has an overloaded "operator<<"
+     *
+     * provides the default open/close/separator tags to print collections like this: [2,4]
      */
     template <typename T>
     std::ostream &print_container(std::ostream &os, const T &container) {
@@ -99,7 +107,7 @@ namespace ebi
     template <typename K, typename V>
     std::ostream &operator<<(std::ostream &os, const std::map<K, V> &container)
     {
-        return print_container<std::map<std::string, std::string>>(os, container);
+        return print_container<std::map<K, V>>(os, container);
     }
   }
 }

--- a/inc/util/stream_utils.hpp
+++ b/inc/util/stream_utils.hpp
@@ -59,24 +59,35 @@ namespace ebi
     {
         return os << "{" << container.first << ", " << container.second << "}";
     }
+
     /**
-     * This is a generic method that prints a collection if it has the operations ".size()", ".begin()", ".end()" 
+     * This is a generic method that prints a collection if it has the operations ".size()", ".begin()", ".end()"
      * defined and they provide iterators, and the inner type has an overloaded "operator<<"
      */
     template <typename T>
-    std::ostream &print_container(std::ostream &os, const T &container) {
+    std::ostream &print_container(std::ostream &os, const T &container,
+                                  std::string open_tag, std::string separator_tag, std::string close_tag) {
         size_t size = container.size();
-        os << "[";
+        os << open_tag;
         if (size > 0) {
             auto it = container.begin();
             os << *it;
             it++;
             for (; it != container.end(); ++it) {
-                os << ", " << *it;
+                os << separator_tag << *it;
             }
         }
-        os << "]";
+        os << close_tag;
         return os;
+    }
+
+    /**
+     * This is a generic method that prints a collection if it has the operations ".size()", ".begin()", ".end()"
+     * defined and they provide iterators, and the inner type has an overloaded "operator<<"
+     */
+    template <typename T>
+    std::ostream &print_container(std::ostream &os, const T &container) {
+        return print_container(os, container, "[", ", ", "]");
     }
     
     // the next functions allow using the previous print_container in a easier syntax

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -3585,6 +3585,18 @@ namespace odb
     field_type_;
 
     static const field_type_ field;
+
+    // field_cardinality
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        long int,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    field_cardinality_type_;
+
+    static const field_cardinality_type_ field_cardinality;
   };
 
   template <typename A>
@@ -3596,6 +3608,11 @@ namespace odb
   const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::field_type_
   query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
   field (A::table_name, "\"field\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::field_cardinality_type_
+  query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
+  field_cardinality (A::table_name, "\"field_cardinality\"", 0);
 
   template <typename A>
   struct pointer_query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >:
@@ -3630,6 +3647,11 @@ namespace odb
       details::buffer field_value;
       std::size_t field_size;
       bool field_null;
+
+      // field_cardinality
+      //
+      long long field_cardinality_value;
+      bool field_cardinality_null;
 
       std::size_t version;
     };
@@ -3683,7 +3705,7 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 2UL;
+    static const std::size_t column_count = 3UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
     static const std::size_t readonly_column_count = 0UL;

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -1156,7 +1156,7 @@ namespace odb
     static const std::size_t column_count = 5UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 1UL;
+    static const std::size_t readonly_column_count = 3UL;
     static const std::size_t managed_optimistic_column_count = 0UL;
     static const std::size_t discriminator_column_count = 1UL;
 

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -792,6 +792,55 @@ namespace odb
     callback (database&, const object_type&, callback_event);
   };
 
+  // SamplesFieldBodyError
+  //
+  template <>
+  struct class_traits< ::ebi::vcf::SamplesFieldBodyError >
+  {
+    static const class_kind kind = class_object;
+  };
+
+  template <>
+  class access::object_traits< ::ebi::vcf::SamplesFieldBodyError >
+  {
+    public:
+    typedef ::ebi::vcf::SamplesFieldBodyError object_type;
+    typedef ::ebi::vcf::SamplesFieldBodyError* pointer_type;
+    typedef odb::pointer_traits<pointer_type> pointer_traits;
+
+    static const bool polymorphic = true;
+
+    typedef ::ebi::vcf::Error root_type;
+    typedef ::ebi::vcf::BodySectionError base_type;
+    typedef object_traits<root_type>::discriminator_type discriminator_type;
+    typedef polymorphic_concrete_info<root_type> info_type;
+
+    static const std::size_t depth = 3UL;
+
+    typedef object_traits< ::ebi::vcf::Error >::id_type id_type;
+
+    static const bool auto_id = false;
+
+    static const bool abstract = false;
+
+    static id_type
+    id (const object_type&);
+
+    typedef
+    no_op_pointer_cache_traits<object_traits<root_type>::pointer_type>
+    pointer_cache_traits;
+
+    typedef
+    no_op_reference_cache_traits<root_type>
+    reference_cache_traits;
+
+    static void
+    callback (database&, object_type&, callback_event);
+
+    static void
+    callback (database&, const object_type&, callback_event);
+  };
+
   // NormalizationError
   //
   template <>
@@ -3573,6 +3622,183 @@ namespace odb
     id_type_;
 
     static const id_type_ id;
+  };
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::id_type_
+  query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
+  id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  struct pointer_query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >
+  {
+  };
+
+  template <>
+  class access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >:
+    public access::object_traits< ::ebi::vcf::SamplesBodyError >
+  {
+    public:
+    typedef polymorphic_entry<object_type, id_sqlite> entry_type;
+    typedef object_traits_impl<root_type, id_sqlite> root_traits;
+    typedef object_traits_impl<base_type, id_sqlite> base_traits;
+
+    typedef root_traits::id_image_type id_image_type;
+
+    static const info_type info;
+
+    struct image_type
+    {
+      base_traits::image_type* base;
+
+      // id_
+      //
+      long long id_value;
+      bool id_null;
+
+      std::size_t version;
+    };
+
+    struct extra_statement_cache_type;
+
+    using object_traits<object_type>::id;
+
+    static bool
+    grow (image_type&,
+          bool*,
+          std::size_t = depth);
+
+    static void
+    bind (sqlite::bind*,
+          const sqlite::bind* id,
+          std::size_t id_size,
+          image_type&,
+          sqlite::statement_kind);
+
+    static void
+    bind (sqlite::bind*, id_image_type&);
+
+    static bool
+    init (image_type&,
+          const object_type&,
+          sqlite::statement_kind);
+
+    static void
+    init (object_type&,
+          const image_type&,
+          database*,
+          std::size_t = depth);
+
+    static void
+    init (id_image_type&, const id_type&);
+
+    static bool
+    check_version (const std::size_t*, const image_type&);
+
+    static void
+    update_version (std::size_t*, const image_type&, sqlite::binding*);
+
+    typedef
+    sqlite::polymorphic_derived_object_statements<object_type>
+    statements_type;
+
+    typedef
+    sqlite::polymorphic_root_object_statements<root_type>
+    root_statements_type;
+
+    typedef sqlite::query_base query_base_type;
+
+    static const std::size_t column_count = 1UL;
+    static const std::size_t id_column_count = 1UL;
+    static const std::size_t inverse_column_count = 0UL;
+    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t managed_optimistic_column_count = 0UL;
+
+    static const std::size_t separate_load_column_count = 0UL;
+    static const std::size_t separate_update_column_count = 0UL;
+
+    static const bool versioned = false;
+
+    static const char persist_statement[];
+    static const char* const find_statements[depth];
+    static const std::size_t find_column_counts[depth];
+    static const char erase_statement[];
+    static const char query_statement[];
+    static const char erase_query_statement[];
+
+    static const char table_name[];
+
+    static void
+    persist (database&, object_type&, bool top = true, bool dyn = true);
+
+    static pointer_type
+    find (database&, const id_type&);
+
+    static bool
+    find (database&, const id_type&, object_type&, bool dyn = true);
+
+    static bool
+    reload (database&, object_type&, bool dyn = true);
+
+    static void
+    update (database&, const object_type&, bool top = true, bool dyn = true);
+
+    static void
+    erase (database&, const id_type&, bool top = true, bool dyn = true);
+
+    static void
+    erase (database&, const object_type&, bool top = true, bool dyn = true);
+
+    static result<object_type>
+    query (database&, const query_base_type&);
+
+    static unsigned long long
+    erase_query (database&, const query_base_type&);
+
+    public:
+    static bool
+    find_ (statements_type&,
+           const id_type*,
+           std::size_t = depth);
+
+    static void
+    load_ (statements_type&,
+           object_type&,
+           bool reload,
+           std::size_t = depth);
+
+    static void
+    load_ (database&, root_type&, std::size_t);
+  };
+
+  template <>
+  class access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_common >:
+    public access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >
+  {
+  };
+
+  // SamplesFieldBodyError
+  //
+  template <typename A>
+  struct query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::BodySectionError, id_sqlite, typename A::base_traits >
+  {
+    // BodySectionError
+    //
+    typedef query_columns< ::ebi::vcf::BodySectionError, id_sqlite, typename A::base_traits > BodySectionError;
+
+    // id
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        long unsigned int,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    id_type_;
+
+    static const id_type_ id;
 
     // field
     //
@@ -3600,29 +3826,29 @@ namespace odb
   };
 
   template <typename A>
-  const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::id_type_
-  query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
+  const typename query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >::id_type_
+  query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
 
   template <typename A>
-  const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::field_type_
-  query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
+  const typename query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >::
   field (A::table_name, "\"field\"", 0);
 
   template <typename A>
-  const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::field_cardinality_type_
-  query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
+  const typename query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >::field_cardinality_type_
+  query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >::
   field_cardinality (A::table_name, "\"field_cardinality\"", 0);
 
   template <typename A>
-  struct pointer_query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >:
-    query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >
+  struct pointer_query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::SamplesFieldBodyError, id_sqlite, A >
   {
   };
 
   template <>
-  class access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >:
-    public access::object_traits< ::ebi::vcf::SamplesBodyError >
+  class access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >:
+    public access::object_traits< ::ebi::vcf::SamplesFieldBodyError >
   {
     public:
     typedef polymorphic_entry<object_type, id_sqlite> entry_type;
@@ -3770,8 +3996,8 @@ namespace odb
   };
 
   template <>
-  class access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_common >:
-    public access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >
+  class access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_common >:
+    public access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >
   {
   };
 
@@ -4168,6 +4394,8 @@ namespace odb
   // FormatBodyError
   //
   // SamplesBodyError
+  //
+  // SamplesFieldBodyError
   //
   // NormalizationError
   //

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -3573,12 +3573,29 @@ namespace odb
     id_type_;
 
     static const id_type_ id;
+
+    // field
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    field_type_;
+
+    static const field_type_ field;
   };
 
   template <typename A>
   const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::id_type_
   query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >::
+  field (A::table_name, "\"field\"", 0);
 
   template <typename A>
   struct pointer_query_columns< ::ebi::vcf::SamplesBodyError, id_sqlite, A >:
@@ -3607,6 +3624,12 @@ namespace odb
       //
       long long id_value;
       bool id_null;
+
+      // field
+      //
+      details::buffer field_value;
+      std::size_t field_size;
+      bool field_null;
 
       std::size_t version;
     };
@@ -3660,7 +3683,7 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 1UL;
+    static const std::size_t column_count = 2UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
     static const std::size_t readonly_column_count = 0UL;
@@ -3674,6 +3697,7 @@ namespace odb
     static const char persist_statement[];
     static const char* const find_statements[depth];
     static const std::size_t find_column_counts[depth];
+    static const char update_statement[];
     static const char erase_statement[];
     static const char query_statement[];
     static const char erase_query_statement[];

--- a/inc/vcf/error-odb.ipp
+++ b/inc/vcf/error-odb.ipp
@@ -451,6 +451,35 @@ namespace odb
     ODB_POTENTIALLY_UNUSED (e);
   }
 
+  // SamplesFieldBodyError
+  //
+
+  inline
+  access::object_traits< ::ebi::vcf::SamplesFieldBodyError >::id_type
+  access::object_traits< ::ebi::vcf::SamplesFieldBodyError >::
+  id (const object_type& o)
+  {
+    return object_traits< ::ebi::vcf::Error >::id (o);
+  }
+
+  inline
+  void access::object_traits< ::ebi::vcf::SamplesFieldBodyError >::
+  callback (database& db, object_type& x, callback_event e)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (x);
+    ODB_POTENTIALLY_UNUSED (e);
+  }
+
+  inline
+  void access::object_traits< ::ebi::vcf::SamplesFieldBodyError >::
+  callback (database& db, const object_type& x, callback_event e)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (x);
+    ODB_POTENTIALLY_UNUSED (e);
+  }
+
   // NormalizationError
   //
 
@@ -1057,6 +1086,45 @@ namespace odb
 
   inline
   void access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::
+  update_version (std::size_t* v, const image_type& i, sqlite::binding* b)
+  {
+    v[0UL] = i.version;
+    v[1UL] = i.base->version;
+    v[2UL] = i.base->base->version;
+    b[0UL].version++;
+    b[1UL].version++;
+    b[2UL].version++;
+  }
+
+  // SamplesFieldBodyError
+  //
+
+  inline
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  bind (sqlite::bind* b, id_image_type& i)
+  {
+    object_traits_impl< ::ebi::vcf::Error, id_sqlite >::bind (b, i);
+  }
+
+  inline
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  init (id_image_type& i, const id_type& id)
+  {
+    object_traits_impl< ::ebi::vcf::Error, id_sqlite >::init (i, id);
+  }
+
+  inline
+  bool access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  check_version (const std::size_t* v, const image_type& i)
+  {
+    return 
+      v[0UL] != i.version ||
+      v[1UL] != i.base->version ||
+      v[2UL] != i.base->base->version;
+  }
+
+  inline
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
   update_version (std::size_t* v, const image_type& i, sqlite::binding* b)
   {
     v[0UL] = i.version;

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -51,24 +51,24 @@ namespace ebi
 
     enum class Severity { WARNING, ERROR };
 
-    class Error;
-    class MetaSectionError;
-    class HeaderSectionError;
-    class BodySectionError;
-    class FileformatError;
-    class ChromosomeBodyError;
-    class PositionBodyError;
-    class IdBodyError;
-    class ReferenceAlleleBodyError;
-    class AlternateAllelesBodyError;
-    class QualityBodyError;
-    class FilterBodyError;
-    class InfoBodyError;
-    class FormatBodyError;
-    class SamplesBodyError;
-    class SamplesFieldBodyError;
-    class NormalizationError;
-    class DuplicationError;
+    struct Error;
+    struct MetaSectionError;
+    struct HeaderSectionError;
+    struct BodySectionError;
+    struct FileformatError;
+    struct ChromosomeBodyError;
+    struct PositionBodyError;
+    struct IdBodyError;
+    struct ReferenceAlleleBodyError;
+    struct AlternateAllelesBodyError;
+    struct QualityBodyError;
+    struct FilterBodyError;
+    struct InfoBodyError;
+    struct FormatBodyError;
+    struct SamplesBodyError;
+    struct SamplesFieldBodyError;
+    struct NormalizationError;
+    struct DuplicationError;
 
     std::shared_ptr<Error> get_error_instance(ErrorCode code, size_t line, const std::string &message);
 
@@ -106,9 +106,8 @@ namespace ebi
      * - add a new method visit in ErrorVisitor
      */
     #pragma db object polymorphic
-    class Error : public std::runtime_error
+    struct Error : public std::runtime_error
     {
-      public:
         Error() : Error{0} {}
 
         Error(size_t line) : Error{line, "Error, invalid file."} {}
@@ -119,21 +118,17 @@ namespace ebi
                   message{message} {}
 
 
-        size_t get_line() const { return line; }
-        const std::string &get_raw_message() const { return message; }
         virtual ErrorCode get_code() const { return ErrorCode::error; }
         virtual void apply_visitor(ErrorVisitor &visitor) { visitor.visit(*this); }
-        Severity get_severity() { return severity; }
-        void set_severity(Severity severity) { Error::severity = severity; }
         unsigned long get_id() const { return id_; }
+
+        const size_t line;
+        const std::string message;
+        Severity severity;
 
 
       private:
         friend class odb::access;
-
-        size_t line;
-        std::string message;
-        Severity severity;
 
         #pragma db id auto
         unsigned long id_;
@@ -148,9 +143,8 @@ namespace ebi
 
     // inheritance siblings depending on file location
     #pragma db object
-    class MetaSectionError : public Error
+    struct MetaSectionError : public Error
     {
-      public:
         using Error::Error;
         MetaSectionError() : MetaSectionError{0} { }
         MetaSectionError(size_t line) : MetaSectionError{line, "Error in meta-data section"} { }
@@ -159,9 +153,8 @@ namespace ebi
     };
 
     #pragma db object
-    class HeaderSectionError : public Error
+    struct HeaderSectionError : public Error
     {
-      public:
         using Error::Error;
         HeaderSectionError() : HeaderSectionError{0} { }
         HeaderSectionError(size_t line) : HeaderSectionError{line, "Error in header section"} { }
@@ -170,9 +163,8 @@ namespace ebi
     };
 
     #pragma db object
-    class BodySectionError : public Error
+    struct BodySectionError : public Error
     {
-      public:
         using Error::Error;
         BodySectionError() : BodySectionError{0} { }
         BodySectionError(size_t line) : BodySectionError{line, "Error in body section"} { }
@@ -182,9 +174,8 @@ namespace ebi
 
     // inheritance siblings about detailed errors
     #pragma db object
-    class FileformatError : public MetaSectionError
+    struct FileformatError : public MetaSectionError
     {
-      public:
         using MetaSectionError::MetaSectionError;
         FileformatError() : FileformatError{0} {}
         FileformatError(size_t line) : FileformatError{line, "Error in file format section"} { }
@@ -193,9 +184,8 @@ namespace ebi
     };
 
     #pragma db object
-    class ChromosomeBodyError : public BodySectionError
+    struct ChromosomeBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         ChromosomeBodyError() : ChromosomeBodyError{0} {}
         ChromosomeBodyError(size_t line) : ChromosomeBodyError{line,
@@ -205,9 +195,8 @@ namespace ebi
     };
 
     #pragma db object
-    class PositionBodyError : public BodySectionError
+    struct PositionBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         PositionBodyError() : PositionBodyError{0} {}
         PositionBodyError(size_t line) : PositionBodyError{line, "Position is not a positive number"} { }
@@ -215,9 +204,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class IdBodyError : public BodySectionError
+    struct IdBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         IdBodyError() : IdBodyError{0} {}
         IdBodyError(size_t line) : IdBodyError{line, "ID is not a single dot or a list of strings without semicolons or whitespaces"} { }
@@ -225,9 +213,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class ReferenceAlleleBodyError : public BodySectionError
+    struct ReferenceAlleleBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         ReferenceAlleleBodyError() : ReferenceAlleleBodyError{0} {}
         ReferenceAlleleBodyError(size_t line) : ReferenceAlleleBodyError{line, "Reference is not a string of bases"} { }
@@ -235,9 +222,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class AlternateAllelesBodyError : public BodySectionError
+    struct AlternateAllelesBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         AlternateAllelesBodyError() : AlternateAllelesBodyError{0} {}
         AlternateAllelesBodyError(size_t line) : AlternateAllelesBodyError{line, "Alternate is not a single dot or a comma-separated list of bases"} { }
@@ -245,9 +231,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class QualityBodyError : public BodySectionError
+    struct QualityBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         QualityBodyError() : QualityBodyError{0} {}
         QualityBodyError(size_t line) : QualityBodyError{line, "Quality is not a single dot or a positive number"} { }
@@ -255,9 +240,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class FilterBodyError : public BodySectionError
+    struct FilterBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         FilterBodyError() : FilterBodyError{0} {}
         FilterBodyError(size_t line) : FilterBodyError{line, "Filter is not a single dot or a semicolon-separated list of strings"} { }
@@ -265,9 +249,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class InfoBodyError : public BodySectionError
+    struct InfoBodyError : public BodySectionError
     {
-      public:
         InfoBodyError(size_t line = 0,
                       const std::string &message = "Error in info column, in body section",
                       const std::string &field = "")
@@ -275,15 +258,11 @@ namespace ebi
         virtual ErrorCode get_code() const override { return ErrorCode::info_body; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 
-        const std::string &get_field() const {return field;};
-        void set_field(const std::string &field) { this->field = field; };
-      protected:
         std::string field;
     };
     #pragma db object
-    class FormatBodyError : public BodySectionError
+    struct FormatBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         FormatBodyError() : FormatBodyError{0} {}
         FormatBodyError(size_t line) : FormatBodyError{line, "Format is not a colon-separated list of alphanumeric strings"} { }
@@ -291,9 +270,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class SamplesBodyError : public BodySectionError
+    struct SamplesBodyError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         SamplesBodyError() : SamplesBodyError{0} {}
         SamplesBodyError(size_t line) : SamplesBodyError{line, "Error in samples columns, in body section"} { }
@@ -301,7 +279,7 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class SamplesFieldBodyError : public BodySectionError
+    struct SamplesFieldBodyError : public BodySectionError
     {
       private:
         friend class odb::access;
@@ -320,18 +298,12 @@ namespace ebi
         virtual ErrorCode get_code() const override { return ErrorCode::samples_field_body; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 
-        std::string get_field() const { return field; };
-        void set_field(std::string field) { this->field = field; };
-        long get_field_cardinality() const { return field_cardinality; }
-        void set_field_cardinality(long field_cardinality) { this->field_cardinality = field_cardinality; }
-      protected:
         std::string field;
         long field_cardinality;    // [0, inf): valid number of values. -1: unknown amount of values
     };
     #pragma db object
-    class NormalizationError : public BodySectionError
+    struct NormalizationError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         NormalizationError() : NormalizationError{0} {}
         NormalizationError(size_t line) : NormalizationError{line, "Allele normalization could not be performed"} { }
@@ -339,9 +311,8 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
     };
     #pragma db object
-    class DuplicationError : public BodySectionError
+    struct DuplicationError : public BodySectionError
     {
-      public:
         using BodySectionError::BodySectionError;
         DuplicationError() : DuplicationError{0} {}
         DuplicationError(size_t line) : DuplicationError{line, "A duplicated variant was found"} { }

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -293,15 +293,19 @@ namespace ebi
       public:
         SamplesBodyError(size_t line = 0,
                          const std::string &message = "Error in samples columns, in body section",
-                         std::string field = "")
-                : BodySectionError{line, message}, field(field) {}
+                         std::string field = "",
+                         long field_cardinality = -1)
+                : BodySectionError{line, message}, field(field), field_cardinality(field_cardinality) {}
         virtual ErrorCode get_code() const override { return ErrorCode::samples_body; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 
         std::string get_field() const { return field; };
         void set_field(std::string field) { this->field = field; };
+        long get_field_cardinality() const { return field_cardinality; }
+        void set_field_cardinality(long field_cardinality) { this->field_cardinality = field_cardinality; }
       protected:
         std::string field;
+        long field_cardinality;    // [0, inf): valid number of values. -1: unknown amount of values
     };
     #pragma db object
     class NormalizationError : public BodySectionError

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -265,11 +265,10 @@ namespace ebi
     class InfoBodyError : public BodySectionError
     {
       public:
-        using BodySectionError::BodySectionError;
-        InfoBodyError() : InfoBodyError{0} {}
-        InfoBodyError(size_t line) : InfoBodyError{line, "Error in info column, in body section"} { }
-        InfoBodyError(size_t line, const std::string &message, const std::string &field)
-                : InfoBodyError{line, message} {this->field = field;}
+        InfoBodyError(size_t line = 0,
+                      const std::string &message = "Error in info column, in body section",
+                      const std::string &field = "")
+                : BodySectionError{line, message}, field(field) {}
         virtual ErrorCode get_code() const override { return ErrorCode::info_body; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 
@@ -292,11 +291,17 @@ namespace ebi
     class SamplesBodyError : public BodySectionError
     {
       public:
-        using BodySectionError::BodySectionError;
-        SamplesBodyError() : SamplesBodyError{0} {}
-        SamplesBodyError(size_t line) : SamplesBodyError{line, "Error in samples columns, in body section"} { }
+        SamplesBodyError(size_t line = 0,
+                         const std::string &message = "Error in samples columns, in body section",
+                         std::string field = "")
+                : BodySectionError{line, message}, field(field) {}
         virtual ErrorCode get_code() const override { return ErrorCode::samples_body; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
+
+        std::string get_field() const { return field; };
+        void set_field(std::string field) { this->field = field; };
+      protected:
+        std::string field;
     };
     #pragma db object
     class NormalizationError : public BodySectionError

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -309,9 +309,14 @@ namespace ebi
       public:
         SamplesFieldBodyError(size_t line,
                          const std::string &message,
-                         std::string field,
+                         const std::string &field,
                          long field_cardinality = -1)
-                : BodySectionError{line, message}, field(field), field_cardinality(field_cardinality) { }
+                : BodySectionError{line, message}, field(field), field_cardinality(field_cardinality) {
+            if (field.empty()) {
+                throw std::invalid_argument{"SamplesFieldBodyError: field should not be an empty string. Use "
+                                               "SamplesBodyError for unknown errors in the samples columns"};
+            }
+        }
         virtual ErrorCode get_code() const override { return ErrorCode::samples_field_body; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -266,8 +266,23 @@ namespace ebi
         void check_field_type(std::string const & field,
                               std::vector<std::string> const & values,
                               std::string const & type) const;
-        
     };
+
+    /**
+     * returns the expected number of elements, given a string code
+     * @param number one of ["A", "R", "G", ".", number], where
+     *  - "A" is the amount of alleles,
+     *  - "R" the amount of reference (1) plus alleles (A)
+     *  - "G" is `ploidy`-combination with repetition: ((R + ploidy -1) choose ploidy)
+     *  (e.g. with 1 reference, 2 alternate alleles (3 total alleles) and ploidy 2, it's 3 + 2 -1 choose 2, which is 6: 00, 01, 11, 02, 12, 22)
+     *  - "." means unknown number of elements
+     *  - number is a positive number [0, +inf)
+     * @param ploidy is the number of sets of chromosomes, so a given position in a chromosome needs `ploidy` bases to be completely specified
+     * @param cardinality return by reference [0, +inf) for valid numbers. -1 if unknown number. throws std::invalid_argument if it's not a number or std::out_of_range if it's out of range.
+     * @return bool: whether the number was valid or not
+     */
+    bool is_valid_cardinality(const std::string &number, size_t alternate_allele_number, size_t ploidy, long &cardinality);
+
     std::ostream &operator<<(std::ostream &os, const Record &record);
 
   }

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -118,7 +118,7 @@ namespace ebi
             // TODO better log system, if any
             std::cerr << "DEBUG: line " << error.get_line() << ": fixing invalid INFO field " << error.get_field()
                       << std::endl;
-            const int info_column_index = 7;
+            const size_t info_column_index = 7;
             const std::string empty_info_column = ".";
 
             size_t num_removed_subfields = 0;
@@ -175,9 +175,9 @@ namespace ebi
                 std::cerr << "DEBUG: line " << error.get_line() << ": fixing invalid sample field " << error.get_field()
                           << std::endl;
 
-                size_t format_column = 8;
+                const size_t format_column = 8;
 //                size_t first_samples_column = 9;
-                std::string empty_subfield = ".";
+                const std::string empty_subfield = ".";
                 std::string string_line = {line->begin(), line->end()};
 
                 using iter = std::vector<std::string>::iterator;
@@ -267,9 +267,9 @@ namespace ebi
                 column_index_last = columns.size();
             } else {
                 // ensure the requested index is in a valid range
-                column_index_last = std::min(static_cast<size_t>(column_index_last), columns.size() - 1);
+                column_index_last = std::min(static_cast<size_t>(column_index_last), columns.size());
             }
-            column_index = std::min(column_index, columns.size() - 1);  // ensure the requested index is in a valid range
+            column_index = std::min(column_index, columns.size());  // ensure the requested index is in a valid range
 
             size_t i = 0;
             for (; i < column_index; ++i) {
@@ -306,22 +306,22 @@ namespace ebi
 
             std::vector<std::string> columns;
             util::string_split(line, separator.c_str(), columns);
-            size_t column_index_unsigned;
+            size_t column_index_last_unsigned;
             if (column_index_last < 0) {
-                column_index_unsigned = columns.size();
+                column_index_last_unsigned = columns.size();
             } else {
                 // column_index_last is non-negative. ensure the requested index is in a valid range
-                column_index_unsigned = std::min(static_cast<size_t>(column_index_last), columns.size() - 1);
+                column_index_last_unsigned = std::min(static_cast<size_t>(column_index_last), columns.size());
             }
-            column_index = std::min(column_index, columns.size() - 1);  // ensure the requested index is in a valid range
+            column_index = std::min(column_index, columns.size());  // ensure the requested index is in a valid range
 
             for (size_t i = 0; i < column_index; ++i) {
                 output << columns[i] << separator;
             }
 
-            fix_function(columns.begin() + column_index, columns.begin() + column_index_unsigned);
+            fix_function(columns.begin() + column_index, columns.begin() + column_index_last_unsigned);
 
-            for (size_t i = column_index_unsigned; i < columns.size(); ++i) {
+            for (size_t i = column_index_last_unsigned; i < columns.size(); ++i) {
                 output << separator << columns[i];
             }
             return column_index_last - column_index;

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -157,6 +157,11 @@ namespace ebi
             util::writeline(output, *line);
             ignored_errors++;
         }
+        virtual void visit(SamplesBodyError &error) override
+        {
+            util::writeline(output, *line);
+            ignored_errors++;
+        }
 
         /**
          * explanation of the fix:
@@ -174,7 +179,7 @@ namespace ebi
          * field "AC", FORMAT: "GT:AC:AN", sample: "0/0:3,5:4"; becomes 0/0:.,.:4. (index = 1, cardinality = 2)
          * @param error
          */
-        virtual void visit(SamplesBodyError &error) override
+        virtual void visit(SamplesFieldBodyError &error) override
         {
             if (error.get_field().empty()) {
                 util::writeline(output, *line);

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -924,7 +924,7 @@ tr652:
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
 #line 565 "src/vcf/vcf_v41.ragel"
@@ -15780,7 +15780,7 @@ case 658:
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
 #line 565 "src/vcf/vcf_v41.ragel"

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -1117,7 +1117,7 @@ tr773:
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
 #line 565 "src/vcf/vcf_v42.ragel"
@@ -18407,7 +18407,7 @@ case 730:
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
 #line 565 "src/vcf/vcf_v42.ragel"

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -1148,7 +1148,7 @@ tr856:
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
 #line 627 "src/vcf/vcf_v43.ragel"
@@ -20641,7 +20641,7 @@ case 804:
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
 #line 627 "src/vcf/vcf_v43.ragel"

--- a/src/vcf/debugulator.cpp
+++ b/src/vcf/debugulator.cpp
@@ -40,7 +40,7 @@ namespace ebi
           ebi::vcf::Fixer fixer{output};
 
           errorDAO.for_each_error([&](std::shared_ptr<ebi::vcf::Error> error) {
-              size_t line_index = error->get_line();
+              size_t line_index = error->line;
               while (current_line < line_index) {
 
                   // advance input

--- a/src/vcf/error-odb.cpp
+++ b/src/vcf/error-odb.cpp
@@ -157,21 +157,27 @@ namespace odb
 
     // line
     //
-    b[n].type = sqlite::bind::integer;
-    b[n].buffer = &i.line_value;
-    b[n].is_null = &i.line_null;
-    n++;
+    if (sk != statement_update)
+    {
+      b[n].type = sqlite::bind::integer;
+      b[n].buffer = &i.line_value;
+      b[n].is_null = &i.line_null;
+      n++;
+    }
 
     // message
     //
-    b[n].type = sqlite::image_traits<
-      ::std::string,
-      sqlite::id_text>::bind_value;
-    b[n].buffer = i.message_value.data ();
-    b[n].size = &i.message_size;
-    b[n].capacity = i.message_value.capacity ();
-    b[n].is_null = &i.message_null;
-    n++;
+    if (sk != statement_update)
+    {
+      b[n].type = sqlite::image_traits<
+        ::std::string,
+        sqlite::id_text>::bind_value;
+      b[n].buffer = i.message_value.data ();
+      b[n].size = &i.message_size;
+      b[n].capacity = i.message_value.capacity ();
+      b[n].is_null = &i.message_null;
+      n++;
+    }
 
     // severity
     //
@@ -229,6 +235,7 @@ namespace odb
 
     // line
     //
+    if (sk == statement_insert)
     {
       ::size_t const& v =
         o.line;
@@ -245,6 +252,7 @@ namespace odb
 
     // message
     //
+    if (sk == statement_insert)
     {
       ::std::string const& v =
         o.message;
@@ -330,7 +338,8 @@ namespace odb
     //
     {
       ::size_t& v =
-        o.line;
+        const_cast< ::size_t& > (
+        o.line);
 
       sqlite::value_traits<
           ::size_t,
@@ -344,7 +353,8 @@ namespace odb
     //
     {
       ::std::string& v =
-        o.message;
+        const_cast< ::std::string& > (
+        o.message);
 
       sqlite::value_traits<
           ::std::string,
@@ -445,8 +455,6 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::Error, id_sqlite >::update_statement[] =
   "UPDATE \"Error\" "
   "SET "
-  "\"line\"=?, "
-  "\"message\"=?, "
   "\"severity\"=? "
   "WHERE \"id\"=?";
 
@@ -8738,7 +8746,7 @@ namespace odb
     //
     {
       ::std::string const& v =
-        o.get_field ();
+        o.field;
 
       bool is_null (false);
       std::size_t cap (i.field_value.capacity ());
@@ -8774,7 +8782,8 @@ namespace odb
     // field
     //
     {
-      ::std::string v;
+      ::std::string& v =
+        o.field;
 
       sqlite::value_traits<
           ::std::string,
@@ -8783,8 +8792,6 @@ namespace odb
         i.field_value,
         i.field_size,
         i.field_null);
-
-      o.set_field (v);
     }
   }
 

--- a/src/vcf/error-odb.cpp
+++ b/src/vcf/error-odb.cpp
@@ -10098,21 +10098,9 @@ namespace odb
     //
     if (--d != 0)
     {
-      if (base_traits::grow (*i.base, t + 2UL, d))
+      if (base_traits::grow (*i.base, t + 0UL, d))
         i.base->version++;
     }
-
-    // field
-    //
-    if (t[0UL])
-    {
-      i.field_value.capacity (i.field_size);
-      grew = true;
-    }
-
-    // field_cardinality
-    //
-    t[1UL] = false;
 
     return grew;
   }
@@ -10138,24 +10126,6 @@ namespace odb
         std::memcpy (&b[n], id, id_size * sizeof (id[0]));
       n += id_size;
     }
-
-    // field
-    //
-    b[n].type = sqlite::image_traits<
-      ::std::string,
-      sqlite::id_text>::bind_value;
-    b[n].buffer = i.field_value.data ();
-    b[n].size = &i.field_size;
-    b[n].capacity = i.field_value.capacity ();
-    b[n].is_null = &i.field_null;
-    n++;
-
-    // field_cardinality
-    //
-    b[n].type = sqlite::bind::integer;
-    b[n].buffer = &i.field_cardinality_value;
-    b[n].is_null = &i.field_cardinality_null;
-    n++;
 
     // id_
     //
@@ -10185,41 +10155,6 @@ namespace odb
 
     bool grew (false);
 
-    // field
-    //
-    {
-      ::std::string const& v =
-        o.get_field ();
-
-      bool is_null (false);
-      std::size_t cap (i.field_value.capacity ());
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_image (
-        i.field_value,
-        i.field_size,
-        is_null,
-        v);
-      i.field_null = is_null;
-      grew = grew || (cap != i.field_value.capacity ());
-    }
-
-    // field_cardinality
-    //
-    {
-      long int const& v =
-        o.get_field_cardinality ();
-
-      bool is_null (false);
-      sqlite::value_traits<
-          long int,
-          sqlite::id_integer >::set_image (
-        i.field_cardinality_value,
-        is_null,
-        v);
-      i.field_cardinality_null = is_null;
-    }
-
     return grew;
   }
 
@@ -10237,37 +10172,6 @@ namespace odb
     //
     if (--d != 0)
       base_traits::init (o, *i.base, db, d);
-
-    // field
-    //
-    {
-      ::std::string v;
-
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_value (
-        v,
-        i.field_value,
-        i.field_size,
-        i.field_null);
-
-      o.set_field (v);
-    }
-
-    // field_cardinality
-    //
-    {
-      long int v;
-
-      sqlite::value_traits<
-          long int,
-          sqlite::id_integer >::set_value (
-        v,
-        i.field_cardinality_value,
-        i.field_cardinality_null);
-
-      o.set_field_cardinality (v);
-    }
   }
 
   const access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::info_type
@@ -10285,17 +10189,13 @@ namespace odb
 
   const char access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::persist_statement[] =
   "INSERT INTO \"SamplesBodyError\" "
-  "(\"id\", "
-  "\"field\", "
-  "\"field_cardinality\") "
+  "(\"id\") "
   "VALUES "
-  "(?, ?, ?)";
+  "(?)";
 
   const char* const access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::find_statements[] =
   {
     "SELECT "
-    "\"SamplesBodyError\".\"field\", "
-    "\"SamplesBodyError\".\"field_cardinality\", "
     "\"Error\".\"line\", "
     "\"Error\".\"message\", "
     "\"Error\".\"severity\", "
@@ -10305,32 +10205,17 @@ namespace odb
     "LEFT JOIN \"Error\" ON \"Error\".\"id\"=\"SamplesBodyError\".\"id\" "
     "WHERE \"SamplesBodyError\".\"id\"=?",
 
-    "SELECT "
-    "\"SamplesBodyError\".\"field\", "
-    "\"SamplesBodyError\".\"field_cardinality\" "
-    "FROM \"SamplesBodyError\" "
-    "WHERE \"SamplesBodyError\".\"id\"=?",
+    "",
 
-    "SELECT "
-    "\"SamplesBodyError\".\"field\", "
-    "\"SamplesBodyError\".\"field_cardinality\" "
-    "FROM \"SamplesBodyError\" "
-    "WHERE \"SamplesBodyError\".\"id\"=?"
+    ""
   };
 
   const std::size_t access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::find_column_counts[] =
   {
-    7UL,
-    2UL,
-    2UL
+    5UL,
+    0UL,
+    0UL
   };
-
-  const char access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::update_statement[] =
-  "UPDATE \"SamplesBodyError\" "
-  "SET "
-  "\"field\"=?, "
-  "\"field_cardinality\"=? "
-  "WHERE \"id\"=?";
 
   const char access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::erase_statement[] =
   "DELETE FROM \"SamplesBodyError\" "
@@ -10338,8 +10223,6 @@ namespace odb
 
   const char access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::query_statement[] =
   "SELECT\n"
-  "\"SamplesBodyError\".\"field\",\n"
-  "\"SamplesBodyError\".\"field_cardinality\",\n"
   "\"Error\".\"line\",\n"
   "\"Error\".\"message\",\n"
   "\"Error\".\"severity\",\n"
@@ -10438,32 +10321,7 @@ namespace odb
     if (top)
       callback (db, obj, callback_event::pre_update);
 
-    sqlite::transaction& tr (sqlite::transaction::current ());
-    sqlite::connection& conn (tr.connection ());
-    statements_type& sts (
-      conn.statement_cache ().find_object<object_type> ());
-
     base_traits::update (db, obj, false, false);
-
-    image_type& im (sts.image ());
-    if (init (im, obj, statement_update))
-      im.version++;
-
-    const binding& idb (sts.id_image_binding ());
-    binding& imb (sts.update_image_binding ());
-    if (idb.version != sts.update_id_binding_version () ||
-        im.version != sts.update_image_version () ||
-        imb.version == 0)
-    {
-      bind (imb.bind, idb.bind, idb.count, im, statement_update);
-      sts.update_id_binding_version (idb.version);
-      sts.update_image_version (im.version);
-      imb.version++;
-    }
-
-    update_statement& st (sts.update_statement ());
-    if (st.execute () == 0)
-      throw object_not_persistent ();
 
     if (top)
     {
@@ -10796,13 +10654,17 @@ namespace odb
 
     d = depth - d;
 
-    if (!find_ (sts, 0, d))
-      throw object_not_persistent ();
+    if (d > 2UL)
+    {
+      if (!find_ (sts, 0, d))
+        throw object_not_persistent ();
 
-    select_statement& st (sts.find_statement (d));
-    ODB_POTENTIALLY_UNUSED (st);
+      select_statement& st (sts.find_statement (d));
+      ODB_POTENTIALLY_UNUSED (st);
 
-    init (obj, sts.image (), &db, d);
+      init (obj, sts.image (), &db, d);
+    }
+
     load_ (sts, obj, false, d);
   }
 
@@ -10859,6 +10721,817 @@ namespace odb
   }
 
   unsigned long long access::object_traits_impl< ::ebi::vcf::SamplesBodyError, id_sqlite >::
+  erase_query (database&, const query_base_type& q)
+  {
+    using namespace sqlite;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+
+    std::string text (erase_query_statement);
+    if (!q.empty ())
+    {
+      text += ' ';
+      text += q.clause ();
+    }
+
+    q.init_parameters ();
+    delete_statement st (
+      conn,
+      text,
+      q.parameters_binding ());
+
+    return st.execute ();
+  }
+
+  // SamplesFieldBodyError
+  //
+
+  struct access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::extra_statement_cache_type
+  {
+    extra_statement_cache_type (
+      sqlite::connection&,
+      image_type&,
+      id_image_type&,
+      sqlite::binding&,
+      sqlite::binding&)
+    {
+    }
+  };
+
+  bool access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  grow (image_type& i,
+        bool* t,
+        std::size_t d)
+  {
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (t);
+
+    bool grew (false);
+
+    // BodySectionError base
+    //
+    if (--d != 0)
+    {
+      if (base_traits::grow (*i.base, t + 2UL, d))
+        i.base->version++;
+    }
+
+    // field
+    //
+    if (t[0UL])
+    {
+      i.field_value.capacity (i.field_size);
+      grew = true;
+    }
+
+    // field_cardinality
+    //
+    t[1UL] = false;
+
+    return grew;
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  bind (sqlite::bind* b,
+        const sqlite::bind* id,
+        std::size_t id_size,
+        image_type& i,
+        sqlite::statement_kind sk)
+  {
+    ODB_POTENTIALLY_UNUSED (sk);
+
+    using namespace sqlite;
+
+    std::size_t n (0);
+
+    // id_
+    //
+    if (sk == statement_insert)
+    {
+      if (id != 0)
+        std::memcpy (&b[n], id, id_size * sizeof (id[0]));
+      n += id_size;
+    }
+
+    // field
+    //
+    b[n].type = sqlite::image_traits<
+      ::std::string,
+      sqlite::id_text>::bind_value;
+    b[n].buffer = i.field_value.data ();
+    b[n].size = &i.field_size;
+    b[n].capacity = i.field_value.capacity ();
+    b[n].is_null = &i.field_null;
+    n++;
+
+    // field_cardinality
+    //
+    b[n].type = sqlite::bind::integer;
+    b[n].buffer = &i.field_cardinality_value;
+    b[n].is_null = &i.field_cardinality_null;
+    n++;
+
+    // id_
+    //
+    if (sk == statement_update)
+    {
+      if (id != 0)
+        std::memcpy (&b[n], id, id_size * sizeof (id[0]));
+      n += id_size;
+    }
+
+    // BodySectionError base
+    //
+    if (sk == statement_select)
+      base_traits::bind (b + n, id, id_size, *i.base, sk);
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  init (image_type& i,
+        const object_type& o,
+        sqlite::statement_kind sk)
+  {
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (o);
+    ODB_POTENTIALLY_UNUSED (sk);
+
+    using namespace sqlite;
+
+    bool grew (false);
+
+    // field
+    //
+    {
+      ::std::string const& v =
+        o.field;
+
+      bool is_null (false);
+      std::size_t cap (i.field_value.capacity ());
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_image (
+        i.field_value,
+        i.field_size,
+        is_null,
+        v);
+      i.field_null = is_null;
+      grew = grew || (cap != i.field_value.capacity ());
+    }
+
+    // field_cardinality
+    //
+    {
+      long int const& v =
+        o.field_cardinality;
+
+      bool is_null (false);
+      sqlite::value_traits<
+          long int,
+          sqlite::id_integer >::set_image (
+        i.field_cardinality_value,
+        is_null,
+        v);
+      i.field_cardinality_null = is_null;
+    }
+
+    return grew;
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  init (object_type& o,
+        const image_type& i,
+        database* db,
+        std::size_t d)
+  {
+    ODB_POTENTIALLY_UNUSED (o);
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (db);
+
+    // BodySectionError base
+    //
+    if (--d != 0)
+      base_traits::init (o, *i.base, db, d);
+
+    // field
+    //
+    {
+      ::std::string& v =
+        o.field;
+
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_value (
+        v,
+        i.field_value,
+        i.field_size,
+        i.field_null);
+    }
+
+    // field_cardinality
+    //
+    {
+      long int& v =
+        o.field_cardinality;
+
+      sqlite::value_traits<
+          long int,
+          sqlite::id_integer >::set_value (
+        v,
+        i.field_cardinality_value,
+        i.field_cardinality_null);
+    }
+  }
+
+  const access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::info_type
+  access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::info (
+    typeid (::ebi::vcf::SamplesFieldBodyError),
+    &object_traits_impl< ::ebi::vcf::BodySectionError, id_sqlite >::info,
+    0,
+    "ebi::vcf::SamplesFieldBodyError",
+    &odb::create_impl< ::ebi::vcf::SamplesFieldBodyError >,
+    &odb::dispatch_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >,
+    &statements_type::delayed_loader);
+
+  static const access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::entry_type
+  polymorphic_entry_for_ebi_vcf_SamplesFieldBodyError;
+
+  const char access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::persist_statement[] =
+  "INSERT INTO \"SamplesFieldBodyError\" "
+  "(\"id\", "
+  "\"field\", "
+  "\"field_cardinality\") "
+  "VALUES "
+  "(?, ?, ?)";
+
+  const char* const access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::find_statements[] =
+  {
+    "SELECT "
+    "\"SamplesFieldBodyError\".\"field\", "
+    "\"SamplesFieldBodyError\".\"field_cardinality\", "
+    "\"Error\".\"line\", "
+    "\"Error\".\"message\", "
+    "\"Error\".\"severity\", "
+    "\"Error\".\"id\", "
+    "\"Error\".\"typeid\" "
+    "FROM \"SamplesFieldBodyError\" "
+    "LEFT JOIN \"Error\" ON \"Error\".\"id\"=\"SamplesFieldBodyError\".\"id\" "
+    "WHERE \"SamplesFieldBodyError\".\"id\"=?",
+
+    "SELECT "
+    "\"SamplesFieldBodyError\".\"field\", "
+    "\"SamplesFieldBodyError\".\"field_cardinality\" "
+    "FROM \"SamplesFieldBodyError\" "
+    "WHERE \"SamplesFieldBodyError\".\"id\"=?",
+
+    "SELECT "
+    "\"SamplesFieldBodyError\".\"field\", "
+    "\"SamplesFieldBodyError\".\"field_cardinality\" "
+    "FROM \"SamplesFieldBodyError\" "
+    "WHERE \"SamplesFieldBodyError\".\"id\"=?"
+  };
+
+  const std::size_t access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::find_column_counts[] =
+  {
+    7UL,
+    2UL,
+    2UL
+  };
+
+  const char access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::update_statement[] =
+  "UPDATE \"SamplesFieldBodyError\" "
+  "SET "
+  "\"field\"=?, "
+  "\"field_cardinality\"=? "
+  "WHERE \"id\"=?";
+
+  const char access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::erase_statement[] =
+  "DELETE FROM \"SamplesFieldBodyError\" "
+  "WHERE \"id\"=?";
+
+  const char access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::query_statement[] =
+  "SELECT\n"
+  "\"SamplesFieldBodyError\".\"field\",\n"
+  "\"SamplesFieldBodyError\".\"field_cardinality\",\n"
+  "\"Error\".\"line\",\n"
+  "\"Error\".\"message\",\n"
+  "\"Error\".\"severity\",\n"
+  "\"Error\".\"id\",\n"
+  "\"Error\".\"typeid\"\n"
+  "FROM \"SamplesFieldBodyError\"\n"
+  "LEFT JOIN \"BodySectionError\" ON \"BodySectionError\".\"id\"=\"SamplesFieldBodyError\".\"id\"\n"
+  "LEFT JOIN \"Error\" ON \"Error\".\"id\"=\"SamplesFieldBodyError\".\"id\"";
+
+  const char access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::erase_query_statement[] =
+  "DELETE FROM \"SamplesFieldBodyError\"";
+
+  const char access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::table_name[] =
+  "\"SamplesFieldBodyError\"";
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  persist (database& db, object_type& obj, bool top, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    using namespace sqlite;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        pi.dispatch (info_type::call_persist, db, &obj, 0);
+        return;
+      }
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    if (top)
+      callback (db,
+                static_cast<const object_type&> (obj),
+                callback_event::pre_persist);
+
+    base_traits::persist (db, obj, false, false);
+
+    image_type& im (sts.image ());
+    binding& imb (sts.insert_image_binding ());
+    const binding& idb (sts.id_image_binding ());
+
+    if (init (im, obj, statement_insert))
+      im.version++;
+
+    if (idb.version != sts.insert_id_binding_version () ||
+        im.version != sts.insert_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, idb.bind, idb.count, im, statement_insert);
+      sts.insert_id_binding_version (idb.version);
+      sts.insert_image_version (im.version);
+      imb.version++;
+    }
+
+    insert_statement& st (sts.persist_statement ());
+    if (!st.execute ())
+      throw object_already_persistent ();
+
+    if (top)
+      callback (db,
+                static_cast<const object_type&> (obj),
+                callback_event::post_persist);
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  update (database& db, const object_type& obj, bool top, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    using namespace sqlite;
+    using sqlite::update_statement;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        pi.dispatch (info_type::call_update, db, &obj, 0);
+        return;
+      }
+    }
+
+    if (top)
+      callback (db, obj, callback_event::pre_update);
+
+    sqlite::transaction& tr (sqlite::transaction::current ());
+    sqlite::connection& conn (tr.connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    base_traits::update (db, obj, false, false);
+
+    image_type& im (sts.image ());
+    if (init (im, obj, statement_update))
+      im.version++;
+
+    const binding& idb (sts.id_image_binding ());
+    binding& imb (sts.update_image_binding ());
+    if (idb.version != sts.update_id_binding_version () ||
+        im.version != sts.update_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, idb.bind, idb.count, im, statement_update);
+      sts.update_id_binding_version (idb.version);
+      sts.update_image_version (im.version);
+      imb.version++;
+    }
+
+    update_statement& st (sts.update_statement ());
+    if (st.execute () == 0)
+      throw object_not_persistent ();
+
+    if (top)
+    {
+      callback (db, obj, callback_event::post_update);
+      pointer_cache_traits::update (db, obj);
+    }
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  erase (database& db, const id_type& id, bool top, bool dyn)
+  {
+    using namespace sqlite;
+
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    if (dyn)
+    {
+      discriminator_type d;
+      root_traits::discriminator_ (sts.root_statements (), id, &d);
+
+      if (d != info.discriminator)
+      {
+        const info_type& pi (root_traits::map->find (d));
+
+        if (!pi.derived (info))
+          throw object_not_persistent ();
+
+        pi.dispatch (info_type::call_erase, db, 0, &id);
+        return;
+      }
+    }
+
+    if (top)
+    {
+      id_image_type& i (sts.id_image ());
+      init (i, id);
+
+      binding& idb (sts.id_image_binding ());
+      if (i.version != sts.id_image_version () || idb.version == 0)
+      {
+        bind (idb.bind, i);
+        sts.id_image_version (i.version);
+        idb.version++;
+      }
+    }
+
+    if (sts.erase_statement ().execute () != 1)
+      throw object_not_persistent ();
+
+    base_traits::erase (db, id, false, false);
+
+    if (top)
+      pointer_cache_traits::erase (db, id);
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  erase (database& db, const object_type& obj, bool top, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        pi.dispatch (info_type::call_erase, db, &obj, 0);
+        return;
+      }
+    }
+
+    callback (db, obj, callback_event::pre_erase);
+    erase (db, id (obj), true, false);
+    callback (db, obj, callback_event::post_erase);
+  }
+
+  access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::pointer_type
+  access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  find (database& db, const id_type& id)
+  {
+    using namespace sqlite;
+
+    {
+      root_traits::pointer_type rp (pointer_cache_traits::find (db, id));
+
+      if (!root_traits::pointer_traits::null_ptr (rp))
+        return
+          root_traits::pointer_traits::dynamic_pointer_cast<object_type> (rp);
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+    root_statements_type& rsts (sts.root_statements ());
+
+    statements_type::auto_lock l (rsts);
+    root_traits::discriminator_type d;
+
+    if (l.locked ())
+    {
+      if (!find_ (sts, &id))
+        return pointer_type ();
+      d = root_traits::discriminator (rsts.image ());
+    }
+    else
+      root_traits::discriminator_ (rsts, id, &d);
+
+    const info_type& pi (
+      d == info.discriminator ? info : root_traits::map->find (d));
+
+    root_traits::pointer_type rp (pi.create ());
+    pointer_type p (
+      root_traits::pointer_traits::static_pointer_cast<object_type> (rp));
+    pointer_traits::guard pg (p);
+
+    pointer_cache_traits::insert_guard ig (
+      pointer_cache_traits::insert (db, id, rp));
+
+    object_type& obj (pointer_traits::get_ref (p));
+
+    if (l.locked ())
+    {
+      select_statement& st (sts.find_statement (depth));
+      ODB_POTENTIALLY_UNUSED (st);
+
+      callback_event ce (callback_event::pre_load);
+      pi.dispatch (info_type::call_callback, db, &obj, &ce);
+      init (obj, sts.image (), &db);
+      load_ (sts, obj, false);
+
+      if (&pi != &info)
+      {
+        std::size_t d (depth);
+        pi.dispatch (info_type::call_load, db, &obj, &d);
+      }
+
+      rsts.load_delayed (0);
+      l.unlock ();
+      ce = callback_event::post_load;
+      pi.dispatch (info_type::call_callback, db, &obj, &ce);
+      pointer_cache_traits::load (ig.position ());
+    }
+    else
+      rsts.delay_load (id, obj, ig.position (), pi.delayed_loader);
+
+    ig.release ();
+    pg.release ();
+    return p;
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  find (database& db, const id_type& id, object_type& obj, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (dyn);
+
+    using namespace sqlite;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        return pi.dispatch (info_type::call_find, db, &obj, &id);
+      }
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+    root_statements_type& rsts (sts.root_statements ());
+
+    statements_type::auto_lock l (rsts);
+
+    if (!find_ (sts, &id))
+      return false;
+
+    select_statement& st (sts.find_statement (depth));
+    ODB_POTENTIALLY_UNUSED (st);
+
+    reference_cache_traits::position_type pos (
+      reference_cache_traits::insert (db, id, obj));
+    reference_cache_traits::insert_guard ig (pos);
+
+    callback (db, obj, callback_event::pre_load);
+    init (obj, sts.image (), &db);
+    load_ (sts, obj, false);
+    rsts.load_delayed (0);
+    l.unlock ();
+    callback (db, obj, callback_event::post_load);
+    reference_cache_traits::load (pos);
+    ig.release ();
+    return true;
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  reload (database& db, object_type& obj, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (dyn);
+
+    using namespace sqlite;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        return pi.dispatch (info_type::call_reload, db, &obj, 0);
+      }
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+    root_statements_type& rsts (sts.root_statements ());
+
+    statements_type::auto_lock l (rsts);
+
+    const id_type& id  (
+      obj.id_);
+
+    if (!find_ (sts, &id))
+      return false;
+
+    select_statement& st (sts.find_statement (depth));
+    ODB_POTENTIALLY_UNUSED (st);
+
+    callback (db, obj, callback_event::pre_load);
+    init (obj, sts.image (), &db);
+    load_ (sts, obj, true);
+    rsts.load_delayed (0);
+    l.unlock ();
+    callback (db, obj, callback_event::post_load);
+    return true;
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  find_ (statements_type& sts,
+         const id_type* id,
+         std::size_t d)
+  {
+    using namespace sqlite;
+
+    if (d == depth)
+    {
+      id_image_type& i (sts.id_image ());
+      init (i, *id);
+
+      binding& idb (sts.id_image_binding ());
+      if (i.version != sts.id_image_version () || idb.version == 0)
+      {
+        bind (idb.bind, i);
+        sts.id_image_version (i.version);
+        idb.version++;
+      }
+    }
+
+    image_type& im (sts.image ());
+    binding& imb (sts.select_image_binding (d));
+
+    if (imb.version == 0 ||
+        check_version (sts.select_image_versions (), im))
+    {
+      bind (imb.bind, 0, 0, im, statement_select);
+      update_version (sts.select_image_versions (),
+                      im,
+                      sts.select_image_bindings ());
+    }
+
+    select_statement& st (sts.find_statement (d));
+
+    st.execute ();
+    auto_result ar (st);
+    select_statement::result r (st.fetch ());
+
+    if (r == select_statement::truncated)
+    {
+      if (grow (im, sts.select_image_truncated (), d))
+        im.version++;
+
+      if (check_version (sts.select_image_versions (), im))
+      {
+        bind (imb.bind, 0, 0, im, statement_select);
+        update_version (sts.select_image_versions (),
+                        im,
+                        sts.select_image_bindings ());
+        st.refetch ();
+      }
+    }
+
+    return r != select_statement::no_data;
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  load_ (statements_type& sts,
+         object_type& obj,
+         bool reload,
+         std::size_t d)
+  {
+    ODB_POTENTIALLY_UNUSED (reload);
+
+    if (--d != 0)
+      base_traits::load_ (sts.base_statements (), obj, reload, d);
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  load_ (database& db, root_type& r, std::size_t d)
+  {
+    using namespace sqlite;
+
+    object_type& obj (static_cast<object_type&> (r));
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    d = depth - d;
+
+    if (!find_ (sts, 0, d))
+      throw object_not_persistent ();
+
+    select_statement& st (sts.find_statement (d));
+    ODB_POTENTIALLY_UNUSED (st);
+
+    init (obj, sts.image (), &db, d);
+    load_ (sts, obj, false, d);
+  }
+
+  result< access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::object_type >
+  access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
+  query (database&, const query_base_type& q)
+  {
+    using namespace sqlite;
+    using odb::details::shared;
+    using odb::details::shared_ptr;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    image_type& im (sts.image ());
+    binding& imb (sts.select_image_binding (depth));
+
+    if (imb.version == 0 ||
+        check_version (sts.select_image_versions (), im))
+    {
+      bind (imb.bind, 0, 0, im, statement_select);
+      update_version (sts.select_image_versions (),
+                      im,
+                      sts.select_image_bindings ());
+    }
+
+    std::string text (query_statement);
+    if (!q.empty ())
+    {
+      text += "\n";
+      text += q.clause ();
+    }
+
+    q.init_parameters ();
+    shared_ptr<select_statement> st (
+      new (shared) select_statement (
+        conn,
+        text,
+        true,
+        true,
+        q.parameters_binding (),
+        imb));
+
+    st->execute ();
+
+    shared_ptr< odb::polymorphic_object_result_impl<object_type> > r (
+      new (shared) sqlite::polymorphic_object_result_impl<object_type> (
+        q, st, sts, 0));
+
+    return result<object_type> (r);
+  }
+
+  unsigned long long access::object_traits_impl< ::ebi::vcf::SamplesFieldBodyError, id_sqlite >::
   erase_query (database&, const query_base_type& q)
   {
     using namespace sqlite;
@@ -12254,6 +12927,7 @@ namespace odb
         {
           db.execute ("DROP TABLE IF EXISTS \"DuplicationError\"");
           db.execute ("DROP TABLE IF EXISTS \"NormalizationError\"");
+          db.execute ("DROP TABLE IF EXISTS \"SamplesFieldBodyError\"");
           db.execute ("DROP TABLE IF EXISTS \"SamplesBodyError\"");
           db.execute ("DROP TABLE IF EXISTS \"FormatBodyError\"");
           db.execute ("DROP TABLE IF EXISTS \"InfoBodyError\"");
@@ -12365,6 +13039,12 @@ namespace odb
                       "    REFERENCES \"BodySectionError\" (\"id\")\n"
                       "    ON DELETE CASCADE)");
           db.execute ("CREATE TABLE \"SamplesBodyError\" (\n"
+                      "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
+                      "  CONSTRAINT \"id_fk\"\n"
+                      "    FOREIGN KEY (\"id\")\n"
+                      "    REFERENCES \"BodySectionError\" (\"id\")\n"
+                      "    ON DELETE CASCADE)");
+          db.execute ("CREATE TABLE \"SamplesFieldBodyError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
                       "  \"field\" TEXT NOT NULL,\n"
                       "  \"field_cardinality\" INTEGER NOT NULL,\n"

--- a/src/vcf/error.cpp
+++ b/src/vcf/error.cpp
@@ -55,6 +55,8 @@ namespace ebi
             return std::shared_ptr<Error>(new FormatBodyError{line, message});
         case ErrorCode::samples_body:
             return std::shared_ptr<Error>(new SamplesBodyError{line, message});
+        case ErrorCode::samples_field_body:
+            return std::shared_ptr<Error>(new SamplesFieldBodyError{line, message, ""});
         case ErrorCode::normalization:
             return std::shared_ptr<Error>(new NormalizationError{line, message});
         case ErrorCode::duplication:

--- a/src/vcf/odb_report.cpp
+++ b/src/vcf/odb_report.cpp
@@ -78,12 +78,12 @@ namespace ebi
     // ReportWriter implementation
     void OdbReportRW::write_error(Error &error)
     {
-        error.set_severity(Severity::ERROR);
+        error.severity = Severity::ERROR;
         write(error);
     }
     void OdbReportRW::write_warning(Error &error)
     {
-        error.set_severity(Severity::WARNING);
+        error.severity = Severity::WARNING;
         write(error);
     }
 

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -300,10 +300,14 @@ namespace ebi
                     check_field_cardinality(subfield, values, key_values["Number"], alleles.size());
                     check_field_type(subfield, values, key_values["Type"]);
                 } catch (Error *ex) {
+                    long cardinality;
+                    bool valid = is_valid_cardinality(key_values["Number"], alternate_alleles.size(), alleles.size(), cardinality);
+                    long number = valid ? cardinality : -1;
                     throw new SamplesBodyError{line,
                                                "Sample #" + std::to_string(i+1) + ", "
                                                        + key_values["ID"] + "=" + ex->get_raw_message(),
-                                               key_values["ID"]};
+                                               key_values["ID"],
+                                               number};
                 }
             }
         }
@@ -331,56 +335,65 @@ namespace ebi
         }
     }
 
+    bool is_valid_cardinality(const std::string &number, size_t alternate_allele_number, size_t ploidy, long &cardinality)
+    {
+        bool valid = true;
+
+        if (number == "A") {
+            // ...the number of alternate alleles
+            cardinality = alternate_allele_number;
+        } else if (number == "R") {
+            // ...the number of alternate alleles + reference
+            cardinality = alternate_allele_number + 1;
+        } else if (number == "G") {
+            // ...the number of possible genotypes
+            // The binomial coefficient is calculated considering the ploidy of the sample
+            cardinality = boost::math::binomial_coefficient<float>(alternate_allele_number + ploidy, ploidy);
+        } else if (number == ".") {
+            // ...it is unspecified
+            cardinality = -1;
+        } else {
+            // ...specified as a number in range [0, +MAX_LONG)
+            try {
+                cardinality = stoi(number);
+                if (cardinality < 0) {
+                    valid = false;
+                }
+            } catch (...) {
+                valid = false;
+            }
+        }
+        return valid;
+    }
+
     void Record::check_field_cardinality(std::string const & field,
                                          std::vector<std::string> const & values,
                                          std::string const & number, 
                                          size_t ploidy) const
     {
-        // To check the field cardinality...
-        size_t expected = -1;
-        
-        if (number == "A") {
-            // ...check against the number of alternate alleles
-            expected = alternate_alleles.size();
-        } else if (number == "R") {
-            // ...check against the number of alternate alleles + 1
-            expected = alternate_alleles.size() + 1;
-        } else if (number == "G") {
-            // ...check against the number of possible genotypes
-            // The binomial coefficient is calculated considering the ploidy of the sample
-            expected = boost::math::binomial_coefficient<float>(alternate_alleles.size() + ploidy, ploidy);
-        } else if (number == ".") {
-            // ...do nothing, it is unspecified
-        } else {
-            try {
-                // ...check against the specified number
-                expected = std::stoi(number);
-            } catch (...) {
-                // this is handled below as expected == -1
-            }
-        } 
+        long expected;
+        if(not is_valid_cardinality(number, alternate_alleles.size(), ploidy, expected)) {
+            throw new Error{line, field + " meta specification Number=" + number + " is not one of [A, R, G, ., <non-negative number>]"};
+        }
 
-        if (number != ".") { // Forget about the unspecified number
-            bool number_matches = true;
-            if (expected > 0) {
-                // The number of values must match the expected
-                number_matches = ( values.size() == expected );
-            } else if (expected == 0) {
-                // There will be one empty value that needs to be specifically checked
-                number_matches = values.size() == 0 || 
-                                (values.size() == 1 && (values[0] == "0" || values[0] == "1"));
-            } else {
-                // Negative values are not allowed
-                throw new Error{line, field + " meta specification Number=" + number + " is negative"};
-            }
-            
-            if (!number_matches) {
-                throw new Error{line, field + " does not match the meta specification Number=" + number + 
-                        ", expected " + std::to_string(expected) + " values"};                
-            }
+        bool number_matches = true;
+        if (expected > 0) {
+            // The number of values must match the expected
+            number_matches = ( values.size() == expected );
+        } else if (expected == 0) {
+            // There will be one empty value that needs to be specifically checked
+            number_matches = values.size() == 0 ||
+                    (values.size() == 1 && (values[0] == "0" || values[0] == "1"));
+        } else {
+            // if number=".", then `expected` was set to -1, and it should always match, letting `number_matches` as true
+        }
+
+        if (!number_matches) {
+            throw new Error{line, field + " does not match the meta specification Number=" + number +
+                    ", expected " + std::to_string(expected) + " values"};
         }
     }
-    
+
     void Record::check_field_type(std::string const & field,
                                   std::vector<std::string> const & values,
                                   std::string const & type) const

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -206,7 +206,7 @@ namespace ebi
                         check_field_type(field.second, values, key_values["Type"]);
                     } catch (Error *ex) {
                         throw new InfoBodyError{line,
-                                                "Info " + key_values["ID"] + "=" + ex->get_raw_message(),
+                                                "Info " + key_values["ID"] + "=" + ex->message,
                                                 key_values["ID"]};
                     }
                     
@@ -305,7 +305,7 @@ namespace ebi
                     long number = valid ? cardinality : -1;
                     throw new SamplesFieldBodyError{line,
                                                "Sample #" + std::to_string(i+1) + ", "
-                                                       + key_values["ID"] + "=" + ex->get_raw_message(),
+                                                       + key_values["ID"] + "=" + ex->message,
                                                key_values["ID"],
                                                number};
                 }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -303,7 +303,7 @@ namespace ebi
                     long cardinality;
                     bool valid = is_valid_cardinality(key_values["Number"], alternate_alleles.size(), alleles.size(), cardinality);
                     long number = valid ? cardinality : -1;
-                    throw new SamplesBodyError{line,
+                    throw new SamplesFieldBodyError{line,
                                                "Sample #" + std::to_string(i+1) + ", "
                                                        + key_values["ID"] + "=" + ex->get_raw_message(),
                                                key_values["ID"],
@@ -320,13 +320,13 @@ namespace ebi
 
             // Discard non-integer numbers
             if (std::find_if_not(allele.begin(), allele.end(), isdigit) != allele.end()) {
-                throw new SamplesBodyError{line, "Allele index " + allele + " is not an integer number", "GT"};
+                throw new SamplesFieldBodyError{line, "Allele index " + allele + " is not an integer number", "GT"};
             }
             
             // After guaranteeing the number is an integer, check it is in range
             size_t num_allele = std::stoi(allele);
             if (num_allele > alternate_alleles.size()) {
-                throw new SamplesBodyError{line,
+                throw new SamplesFieldBodyError{line,
                                            "Allele index " + std::to_string(num_allele)
                                                    + " is greater than the maximum allowed "
                                                    + std::to_string(alternate_alleles.size()),

--- a/src/vcf/sqlite_report.cpp
+++ b/src/vcf/sqlite_report.cpp
@@ -127,7 +127,7 @@ namespace ebi
             start_transaction();
         }
         
-        rc = sqlite3_bind_int64(statement, 1, error.get_line());
+        rc = sqlite3_bind_int64(statement, 1, error.line);
         if (rc != SQLITE_OK) {
             rollback_transaction();
             throw std::runtime_error{std::string{"Can't write, failed sqlite3_bind_int64 with code: "} + std::to_string(rc)};
@@ -137,7 +137,7 @@ namespace ebi
             rollback_transaction();
             throw std::runtime_error{std::string{"Can't write, failed sqlite3_bind_int64 with code: "} + std::to_string(rc)};
         }
-        rc = sqlite3_bind_text(statement, 3, error.get_raw_message().c_str(), -1, SQLITE_TRANSIENT);
+        rc = sqlite3_bind_text(statement, 3, error.message.c_str(), -1, SQLITE_TRANSIENT);
         if (rc != SQLITE_OK) {
             rollback_transaction();
             throw std::runtime_error{std::string{"Can't write, failed sqlite3_bind_text with code: "} + std::to_string(rc)};

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -84,7 +84,8 @@ namespace ebi
                             state.n_lines,
                             "Sample #" + std::to_string(i) + " has " + std::to_string(alleles.size())
                                     + " allele(s), but " + std::to_string(ploidy) + " were found in others",
-                            "GT"};
+                            "GT",
+                            static_cast<long>(ploidy)};
                 }
             } else {
                 ploidy = alleles.size();

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -83,7 +83,8 @@ namespace ebi
                     throw new SamplesBodyError{
                             state.n_lines,
                             "Sample #" + std::to_string(i) + " has " + std::to_string(alleles.size())
-                                    + " allele(s), but " + std::to_string(ploidy) + " were found in others"};
+                                    + " allele(s), but " + std::to_string(ploidy) + " were found in others",
+                            "GT"};
                 }
             } else {
                 ploidy = alleles.size();

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -80,7 +80,7 @@ namespace ebi
 
             if (ploidy > 0) {
                 if (alleles.size() != ploidy) {
-                    throw new SamplesBodyError{
+                    throw new SamplesFieldBodyError{
                             state.n_lines,
                             "Sample #" + std::to_string(i) + " has " + std::to_string(alleles.size())
                                     + " allele(s), but " + std::to_string(ploidy) + " were found in others",

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -572,7 +572,7 @@
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str(), "GT"});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         fhold; fgoto body_section_skip;
     }
 

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -572,7 +572,7 @@
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str(), "GT"});
         fhold; fgoto body_section_skip;
     }
 

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -572,7 +572,7 @@
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str(), "GT"});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         fhold; fgoto body_section_skip;
     }
 

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -572,7 +572,7 @@
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str(), "GT"});
         fhold; fgoto body_section_skip;
     }
 

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -634,7 +634,7 @@
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
+        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str(), "GT"});
         fhold; fgoto body_section_skip;
     }
 

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -634,7 +634,7 @@
     action sample_gt_error {
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
-        ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str(), "GT"});
+        ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         fhold; fgoto body_section_skip;
     }
 

--- a/test/vcf/debugulator_integration_test.cpp
+++ b/test/vcf/debugulator_integration_test.cpp
@@ -155,7 +155,8 @@ namespace ebi
 
       for (size_t i = 1; i <= 3; ++i) {
           // syntax error, AC must be a positive integer
-          path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_info_038.vcf");
+          path = boost::filesystem::path(
+                  "test/input_files/v4." + std::to_string(i) + "/failed/failed_body_info_038.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
               first_validation = validate(file, path, BEFORE_TAG, version);
@@ -169,7 +170,8 @@ namespace ebi
           }
 
           // semantic error, the number of values doesn't match the description in the meta section
-          path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_info_034.vcf");
+          path = boost::filesystem::path(
+                  "test/input_files/v4." + std::to_string(i) + "/failed/failed_body_info_034.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
               first_validation = validate(file, path, BEFORE_TAG, version);
@@ -180,6 +182,48 @@ namespace ebi
               INFO(debug_message);
               REQUIRE(second_validation);
               REQUIRE(lines == 5);
+          }
+
+          version = static_cast<ebi::vcf::Version>(i);
+      }
+  }
+
+  TEST_CASE("Fixing a VCF with wrong SAMPLE fields", "[debugulator]")
+  {
+      boost::filesystem::path path;
+      ebi::vcf::Version version = ebi::vcf::Version::v41;
+      bool first_validation, second_validation;
+      std::string debug_message;
+      std::unique_ptr<std::stringstream> fixed_vcf;
+      long lines;
+
+      for (size_t i = 1; i <= 3; ++i) {
+          // syntax error, AC must be a positive integer
+          path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_sample_002.vcf");
+          SECTION(path.string()) {
+              std::ifstream file{path.c_str()};
+              first_validation = validate(file, path, BEFORE_TAG, version);
+              REQUIRE_FALSE(first_validation);
+              std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              debug_message = handle_test_results(path, second_validation, *fixed_vcf);
+              INFO(debug_message);
+              REQUIRE(second_validation);
+              REQUIRE(lines == 4);
+          }
+
+          // semantic error, the number of values doesn't match the description in the meta section
+          path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_sample_005.vcf");
+          SECTION(path.string()) {
+              std::ifstream file{path.c_str()};
+              first_validation = validate(file, path, BEFORE_TAG, version);
+              REQUIRE_FALSE(first_validation);
+              std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              debug_message = handle_test_results(path, second_validation, *fixed_vcf);
+              INFO(debug_message);
+              REQUIRE(second_validation);
+              REQUIRE(lines == 4);
           }
 
           version = static_cast<ebi::vcf::Version>(i);

--- a/test/vcf/debugulator_integration_test.cpp
+++ b/test/vcf/debugulator_integration_test.cpp
@@ -223,7 +223,21 @@ namespace ebi
               debug_message = handle_test_results(path, second_validation, *fixed_vcf);
               INFO(debug_message);
               REQUIRE(second_validation);
-              REQUIRE(lines == 4);
+              REQUIRE(lines == 5);
+          }
+
+          // semantic error, the number of values doesn't match the description in the meta section
+          path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_sample_006.vcf");
+          SECTION(path.string()) {
+              std::ifstream file{path.c_str()};
+              first_validation = validate(file, path, BEFORE_TAG, version);
+              REQUIRE_FALSE(first_validation);
+              std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              debug_message = handle_test_results(path, second_validation, *fixed_vcf);
+              INFO(debug_message);
+              REQUIRE(second_validation);
+              REQUIRE(lines == 5);
           }
 
           version = static_cast<ebi::vcf::Version>(i);

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -81,6 +81,41 @@ namespace ebi
           INFO(output.str());
           CHECK(info_fields[0] == ".");
       }
+
+      SECTION("Fix SAMPLE invalid field")
+      {
+          size_t line_number = 8;
+          std::string message{"requested to remove a wrong file"};
+          ebi::vcf::SamplesBodyError test_error{line_number, message, "AC"};
+
+          std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C\tGT:GS:GL\t1/C:0.000:-0.18,-0.48,-2.49";
+          std::vector<char> line{string_line.begin(), string_line.end()};
+
+          std::stringstream output;
+          vcf::Fixer{output}.fix(line_number, line, test_error);
+
+          CHECK(output.str() == string_line);
+      }
+
+      SECTION("Fix SAMPLE without samples")
+      {
+          size_t line_number = 8;
+          std::string message{"requested to remove a wrong file"};
+          ebi::vcf::SamplesBodyError test_error{line_number, message, "AC"};
+
+          std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C";
+
+          std::vector<char> line{string_line.begin(), string_line.end()};
+
+          std::stringstream output;
+          vcf::Fixer{output}.fix(line_number, line, test_error);
+          std::cout << string_line << std::endl;
+          std::cout << output.str() << std::endl;
+          INFO(string_line);
+          INFO(output.str());
+
+          CHECK(output.str() == string_line);
+      }
   }
 
   TEST_CASE("Empty report", "[debugulator]")

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -67,7 +67,7 @@ namespace ebi
       {
           size_t line_number = 8;
           std::string message{"the genotype in the sample column has an illegal value"};
-          ebi::vcf::SamplesBodyError test_error{line_number, message, "GT"};
+          ebi::vcf::SamplesFieldBodyError test_error{line_number, message, "GT"};
 
           std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C\tGT:GS:GL\t1/C:0.000:-0.18,-0.48,-2.49";
           std::vector<char> line{string_line.begin(), string_line.end()};
@@ -86,7 +86,7 @@ namespace ebi
       {
           size_t line_number = 8;
           std::string message{"requested to remove a wrong file"};
-          ebi::vcf::SamplesBodyError test_error{line_number, message, "AC"};
+          ebi::vcf::SamplesFieldBodyError test_error{line_number, message, "AC"};
 
           std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C\tGT:GS:GL\t1/C:0.000:-0.18,-0.48,-2.49";
           std::vector<char> line{string_line.begin(), string_line.end()};
@@ -101,7 +101,7 @@ namespace ebi
       {
           size_t line_number = 8;
           std::string message{"requested to remove a wrong file"};
-          ebi::vcf::SamplesBodyError test_error{line_number, message, "AC"};
+          ebi::vcf::SamplesFieldBodyError test_error{line_number, message, "AC"};
 
           std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C";
 
@@ -109,10 +109,6 @@ namespace ebi
 
           std::stringstream output;
           vcf::Fixer{output}.fix(line_number, line, test_error);
-          std::cout << string_line << std::endl;
-          std::cout << output.str() << std::endl;
-          INFO(string_line);
-          INFO(output.str());
 
           CHECK(output.str() == string_line);
       }

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -97,7 +97,7 @@ namespace ebi
           CHECK(columns[7] == ".");
       }
 
-      SECTION("Fix SAMPLE field")
+      SECTION("Fix SAMPLE field GT")
       {
           size_t line_number = 8;
           std::string message{"the genotype in the sample column has an illegal value"};
@@ -109,28 +109,47 @@ namespace ebi
           std::stringstream output;
           vcf::Fixer{output}.fix(line_number, line, test_error);
 
-          std::vector<std::string> columns, info_fields;
+          std::vector<std::string> columns, sample_fields;
           util::string_split(output.str(), "\t", columns);
-          util::string_split(columns[9], ":", info_fields);
+          util::string_split(columns[9], ":", sample_fields);
           INFO(output.str());
-          CHECK(info_fields[0] == ".");
+          CHECK(sample_fields[0] == ".");
+          CHECK(columns[8] == "GT:GS:GL");
       }
-
-      SECTION("Fix SAMPLE invalid field")
+      SECTION("Fix SAMPLE field AC")
       {
           size_t line_number = 8;
-          std::string message{"requested to remove a wrong file"};
+          std::string message{"the genotype in the sample column has an illegal value"};
           ebi::vcf::SamplesFieldBodyError test_error{line_number, message, "AC"};
 
-          std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C\tGT:GS:GL\t1/C:0.000:-0.18,-0.48,-2.49";
+          std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C\tGT:AC:GL\t1/1:0.000:-0.18,-0.48,-2.49";
           std::vector<char> line{string_line.begin(), string_line.end()};
 
           std::stringstream output;
           vcf::Fixer{output}.fix(line_number, line, test_error);
 
+          std::vector<std::string> columns, sample_fields;
+          util::string_split(output.str(), "\t", columns);
+          util::string_split(columns[9], ":", sample_fields);
+          INFO(output.str());
+          CHECK(sample_fields.size() == 2);
+          CHECK(columns[8] == "GT:GL");
+      }
+      SECTION("Fix SAMPLE field that doesn't exist")
+      {
+          size_t line_number = 8;
+          std::string message{"requested to remove a wrong field"};
+          ebi::vcf::SamplesFieldBodyError test_error{line_number, message, "AC"};
+
+          std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C\tGT:GS:GL\t1/1:0.000:-0.18,-0.48,-2.49";
+          std::vector<char> line{string_line.begin(), string_line.end()};
+
+          std::stringstream output;
+          vcf::Fixer{output}.fix(line_number, line, test_error);
+
+          INFO("the line should be left identical, because we told it to remove a wrong field")
           CHECK(output.str() == string_line);
       }
-
       SECTION("Fix SAMPLE without samples")
       {
           size_t line_number = 8;

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -60,7 +60,41 @@ namespace ebi
           std::vector<std::string> columns, info_fields;
           util::string_split(output.str(), "\t", columns);
           util::string_split(columns[7], ";", info_fields);
+          INFO(columns[7]);
           CHECK(info_fields.size() == 2);
+      }
+      SECTION("Fix first INFO field")
+      {
+          size_t line_number = 8;
+          std::string message{"error message mock: There's an invalid info field"};
+          ebi::vcf::InfoBodyError test_error{line_number, message, "wrong_field"};
+
+          std::string string_line = "chr\tpos\tid\tref\talt\tqual\tfilter\twrong_field=x;AC=1\tformat\tsamples";
+          std::vector<char> line{string_line.begin(), string_line.end()};
+
+          std::stringstream output;
+          vcf::Fixer{output}.fix(line_number, line, test_error);
+
+          std::vector<std::string> columns, info_fields;
+          util::string_split(output.str(), "\t", columns);
+          util::string_split(columns[7], ";", info_fields);
+          CHECK(info_fields.size() == 1);
+      }
+      SECTION("Fix unique INFO field")
+      {
+          size_t line_number = 8;
+          std::string message{"error message mock: There's an invalid info field"};
+          ebi::vcf::InfoBodyError test_error{line_number, message, "wrong_field"};
+
+          std::string string_line = "chr\tpos\tid\tref\talt\tqual\tfilter\twrong_field=x\tformat\tsamples";
+          std::vector<char> line{string_line.begin(), string_line.end()};
+
+          std::stringstream output;
+          vcf::Fixer{output}.fix(line_number, line, test_error);
+
+          std::vector<std::string> columns, info_fields;
+          util::string_split(output.str(), "\t", columns);
+          CHECK(columns[7] == ".");
       }
 
       SECTION("Fix SAMPLE field")

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -62,6 +62,25 @@ namespace ebi
           util::string_split(columns[7], ";", info_fields);
           CHECK(info_fields.size() == 2);
       }
+
+      SECTION("Fix SAMPLE field")
+      {
+          size_t line_number = 8;
+          std::string message{"the genotype in the sample column has an illegal value"};
+          ebi::vcf::SamplesBodyError test_error{line_number, message, "GT"};
+
+          std::string string_line = "1\t55388\trs182711216\tC\tT\t100\tPASS\tTHETA=0.0102;AA=C\tGT:GS:GL\t1/C:0.000:-0.18,-0.48,-2.49";
+          std::vector<char> line{string_line.begin(), string_line.end()};
+
+          std::stringstream output;
+          vcf::Fixer{output}.fix(line_number, line, test_error);
+
+          std::vector<std::string> columns, info_fields;
+          util::string_split(output.str(), "\t", columns);
+          util::string_split(columns[9], ":", info_fields);
+          INFO(output.str());
+          CHECK(info_fields[0] == ".");
+      }
   }
 
   TEST_CASE("Empty report", "[debugulator]")

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -175,8 +175,8 @@ namespace ebi
           
           size_t errors_read = 0;
           errorDAO.for_each_error([&](std::shared_ptr<ebi::vcf::Error> error) {
-              CHECK(error->get_line() == line);
-              CHECK(error->get_raw_message() == message);
+              CHECK(error->line == line);
+              CHECK(error->message == message);
               errors_read++;
           });
           CHECK(errors_read == 1);
@@ -192,8 +192,8 @@ namespace ebi
           
           size_t errors_read = 0;
           errorDAO.for_each_warning([&](std::shared_ptr<ebi::vcf::Error> error) {
-              CHECK(error->get_line() == line);
-              CHECK(error->get_raw_message() == message);
+              CHECK(error->line == line);
+              CHECK(error->message == message);
               errors_read++;
           });
           CHECK(errors_read == 1);
@@ -259,8 +259,8 @@ namespace ebi
           ebi::vcf::SqliteReportRW errorsDAO{db_name};
 
           errorsDAO.for_each_error([&errors_read](std::shared_ptr<ebi::vcf::Error> error) {
-              CHECK(error->get_line() == 1);
-              CHECK(error->get_raw_message() == "The fileformat declaration is not 'fileformat=VCFv4.1'");
+              CHECK(error->line == 1);
+              CHECK(error->message == "The fileformat declaration is not 'fileformat=VCFv4.1'");
               errors_read++;
           });
 
@@ -318,8 +318,8 @@ namespace ebi
 
           size_t errors_read = 0;
           errorDAO.for_each_error([&](std::shared_ptr<ebi::vcf::Error> error) {
-              CHECK(error->get_line() == line);
-              CHECK(error->get_raw_message() == message);
+              CHECK(error->line == line);
+              CHECK(error->message == message);
               errors_read++;
           });
           CHECK(errors_read == 1);
@@ -335,8 +335,8 @@ namespace ebi
 
           size_t errors_read = 0;
           errorDAO.for_each_warning([&](std::shared_ptr<ebi::vcf::Error> error) {
-              CHECK(error->get_line() == line);
-              CHECK(error->get_raw_message() == message);
+              CHECK(error->line == line);
+              CHECK(error->message == message);
               errors_read++;
           });
           CHECK(errors_read == 1);


### PR DESCRIPTION
When the meta section has description about FORMAT fields, such as the Type (String, Integer, etc) or the Number (A, R, G, ., number) we can check that every sample value matches.

For any invalid field we find, we replace with "unknown value", commonly as a `.`.

For values whose number is more than 1, the `.` is repeated with commas (`,`) in between, except for the GT field, which is split by `/`. 

Added unit and integration tests.