### PR TITLE
EVA-407 removed some useless shared_ptrs from PasingState and Parsers

### DIFF
--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -138,9 +138,8 @@ namespace ebi
         std::vector<std::string> format;
 
         std::vector<std::string> samples;
-        
+
         std::shared_ptr<Source> source;
-        
 
         Record(size_t line,
                 std::string const & chromosome,
@@ -153,7 +152,7 @@ namespace ebi
                 std::map<std::string, std::string> const & info,
                 std::vector<std::string> const & format,
                 std::vector<std::string> const & samples,
-                std::shared_ptr<Source> const & source);
+                std::shared_ptr<Source> source);
         
         bool operator==(Record const &) const;
 

--- a/inc/vcf/parse_policy.hpp
+++ b/inc/vcf/parse_policy.hpp
@@ -73,15 +73,15 @@ namespace ebi
         void handle_token_end(ParsingState const & state, std::string token);
         void handle_newline(ParsingState const & state);
         
-        void handle_fileformat(ParsingState const & state);
+        void handle_fileformat(ParsingState & state);
         
         void handle_meta_typeid(ParsingState const & state);
         void handle_meta_typeid(ParsingState const & state, std::string type_id);
-        void handle_meta_line(ParsingState const & state);
+        void handle_meta_line(ParsingState & state);
         
         
         void handle_sample_name(ParsingState const & state);
-        void handle_header_line(ParsingState const & state);
+        void handle_header_line(ParsingState & state);
         
         void handle_column_end(ParsingState const & state, size_t n_columns);
         void handle_body_line(ParsingState & state);

--- a/inc/vcf/parsing_state.hpp
+++ b/inc/vcf/parsing_state.hpp
@@ -41,22 +41,21 @@ namespace ebi
         bool m_is_valid;
         
         std::shared_ptr<Source> source;
-        std::shared_ptr<std::vector<Record>> records;
-        std::shared_ptr<std::vector<std::unique_ptr<Error>>> errors;
-        std::shared_ptr<std::vector<std::unique_ptr<Error>>> warnings;
+        std::unique_ptr<Record> record;
+        std::vector<std::unique_ptr<Error>> errors;
+        std::vector<std::unique_ptr<Error>> warnings;
 
         std::multimap<std::string, std::string> defined_metadata;
         std::multimap<std::string, std::string> undefined_metadata;
         
-        ParsingState(std::shared_ptr<Source> source,
-                     std::shared_ptr<std::vector<Record>> records);
+        ParsingState(std::shared_ptr<Source> source);
         
-        void set_version(Version version) const;
+        void set_version(Version version);
         
-        void add_meta(MetaEntry const & meta) const;
-        
-        void add_record(Record const & record);
-        void clear_records() const;
+        void add_meta(MetaEntry const & meta);
+
+        void set_record(std::unique_ptr<Record> record);
+        void unset_record();
 
         void add_error(std::unique_ptr<Error> error);
         void clear_errors();
@@ -66,13 +65,13 @@ namespace ebi
         
         std::vector<std::string> const & samples() const;
         
-        void set_samples(std::vector<std::string> & samples) const;
+        void set_samples(std::vector<std::string> & samples);
         
-        bool is_well_defined_meta(std::string const & meta_type, std::string const & id);
+        bool is_well_defined_meta(std::string const & meta_type, std::string const & id) const;
         
         void add_well_defined_meta(std::string const & meta_type, std::string const & id);
         
-        bool is_bad_defined_meta(std::string const & meta_type, std::string const & id);
+        bool is_bad_defined_meta(std::string const & meta_type, std::string const & id) const;
         
         void add_bad_defined_meta(std::string const & meta_type, std::string const & id);
     };

--- a/inc/vcf/validator.hpp
+++ b/inc/vcf/validator.hpp
@@ -75,8 +75,8 @@ namespace ebi
         virtual void end() = 0;
 
         virtual bool is_valid() const = 0;
-        virtual const std::shared_ptr<std::vector<std::unique_ptr<Error>>> errors() const = 0;
-        virtual const std::shared_ptr<std::vector<std::unique_ptr<Error>>> warnings() const = 0;
+        virtual const std::vector<std::unique_ptr<Error>> & errors() const = 0;
+        virtual const std::vector<std::unique_ptr<Error>> & warnings() const = 0;
     };
     
     class ParserImpl
@@ -84,8 +84,7 @@ namespace ebi
       public ParsingState
     {
       public:
-        ParserImpl(std::shared_ptr<Source> const & source,
-                   std::shared_ptr<std::vector<Record>> const & records);
+        ParserImpl(std::shared_ptr<Source> source);
         
         void parse(std::string const & text) override;
         void parse(std::vector<char> const & text) override;
@@ -93,8 +92,8 @@ namespace ebi
         void end() override;
 
         bool is_valid() const override;
-        const std::shared_ptr<std::vector<std::unique_ptr<Error>>> errors() const override;
-        const std::shared_ptr<std::vector<std::unique_ptr<Error>>> warnings() const override;
+        const std::vector<std::unique_ptr<Error>> & errors() const override;
+        const std::vector<std::unique_ptr<Error>> & warnings() const override;
 
        
       protected:
@@ -118,8 +117,7 @@ namespace ebi
         using ErrorPolicy = typename Configuration::ErrorPolicy;
         using OptionalPolicy = typename Configuration::OptionalPolicy;
 
-        ParserImpl_v41(std::shared_ptr<Source> const & source,
-               std::shared_ptr<std::vector<Record>> const & records);
+        ParserImpl_v41(std::shared_ptr<Source> source);
 
       private:
         void parse_buffer(char const * p, char const * pe, char const * eof);
@@ -137,8 +135,7 @@ namespace ebi
         using ErrorPolicy = typename Configuration::ErrorPolicy;
         using OptionalPolicy = typename Configuration::OptionalPolicy;
 
-        ParserImpl_v42(std::shared_ptr<Source> const & source,
-               std::shared_ptr<std::vector<Record>> const & records);
+        ParserImpl_v42(std::shared_ptr<Source> source);
 
       private:
         void parse_buffer(char const * p, char const * pe, char const * eof);
@@ -156,8 +153,7 @@ namespace ebi
         using ErrorPolicy = typename Configuration::ErrorPolicy;
         using OptionalPolicy = typename Configuration::OptionalPolicy;
 
-        ParserImpl_v43(std::shared_ptr<Source> const & source,
-               std::shared_ptr<std::vector<Record>> const & records);
+        ParserImpl_v43(std::shared_ptr<Source> source);
 
       private:
         void parse_buffer(char const * p, char const * pe, char const * eof);

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 821 "src/vcf/vcf_v41.ragel"
+#line 819 "src/vcf/vcf_v41.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v41_en_meta_section_skip = 652;
 static const int vcf_v41_en_body_section_skip = 653;
 
 
-#line 827 "src/vcf/vcf_v41.ragel"
+#line 825 "src/vcf/vcf_v41.ragel"
 
 }
 
@@ -49,18 +49,16 @@ namespace ebi
   {
     
     template <typename Configuration>
-    ParserImpl_v41<Configuration>::ParserImpl_v41(std::shared_ptr<Source> const & source,
-                                                  std::shared_ptr<std::vector<Record>> const & records
-    )
-    : ParserImpl{source, records}
+    ParserImpl_v41<Configuration>::ParserImpl_v41(std::shared_ptr<Source> source)
+    : ParserImpl{source}
     {
       
-#line 59 "inc/vcf/validator_detail_v41.hpp"
+#line 57 "inc/vcf/validator_detail_v41.hpp"
 	{
 	cs = vcf_v41_start;
 	}
 
-#line 843 "src/vcf/vcf_v41.ragel"
+#line 839 "src/vcf/vcf_v41.ragel"
 
     }
 
@@ -68,7 +66,7 @@ namespace ebi
     void ParserImpl_v41<Configuration>::parse_buffer(char const * p, char const * pe, char const * eof)
     {
       
-#line 72 "inc/vcf/validator_detail_v41.hpp"
+#line 70 "inc/vcf/validator_detail_v41.hpp"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -86,7 +84,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 227 "src/vcf/vcf_v41.ragel"
+#line 225 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
@@ -109,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 338 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -143,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 338 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -172,47 +170,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -231,7 +229,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -243,13 +241,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st652;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -261,12 +259,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -278,12 +276,12 @@ tr152:
     }
 	goto st0;
 tr162:
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -295,7 +293,7 @@ tr162:
     }
 	goto st0;
 tr165:
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -307,12 +305,12 @@ tr165:
     }
 	goto st0;
 tr175:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -324,12 +322,12 @@ tr175:
     }
 	goto st0;
 tr194:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -341,7 +339,7 @@ tr194:
     }
 	goto st0;
 tr204:
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -353,12 +351,12 @@ tr204:
     }
 	goto st0;
 tr214:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -370,12 +368,12 @@ tr214:
     }
 	goto st0;
 tr227:
-#line 269 "src/vcf/vcf_v41.ragel"
+#line 267 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -387,12 +385,12 @@ tr227:
     }
 	goto st0;
 tr236:
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -404,12 +402,12 @@ tr236:
     }
 	goto st0;
 tr253:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -421,7 +419,7 @@ tr253:
     }
 	goto st0;
 tr264:
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -433,12 +431,12 @@ tr264:
     }
 	goto st0;
 tr273:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -450,12 +448,12 @@ tr273:
     }
 	goto st0;
 tr286:
-#line 285 "src/vcf/vcf_v41.ragel"
+#line 283 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -467,12 +465,12 @@ tr286:
     }
 	goto st0;
 tr295:
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -484,12 +482,12 @@ tr295:
     }
 	goto st0;
 tr312:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -501,7 +499,7 @@ tr312:
     }
 	goto st0;
 tr323:
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -513,12 +511,12 @@ tr323:
     }
 	goto st0;
 tr333:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -530,7 +528,7 @@ tr333:
     }
 	goto st0;
 tr345:
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -542,12 +540,12 @@ tr345:
     }
 	goto st0;
 tr356:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -559,17 +557,17 @@ tr356:
     }
 	goto st0;
 tr361:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 311 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -581,12 +579,12 @@ tr361:
     }
 	goto st0;
 tr363:
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 311 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -598,17 +596,17 @@ tr363:
     }
 	goto st0;
 tr373:
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 311 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -620,12 +618,12 @@ tr373:
     }
 	goto st0;
 tr376:
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -637,17 +635,17 @@ tr376:
     }
 	goto st0;
 tr386:
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -659,12 +657,12 @@ tr386:
     }
 	goto st0;
 tr389:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -676,7 +674,7 @@ tr389:
     }
 	goto st0;
 tr412:
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -688,12 +686,12 @@ tr412:
     }
 	goto st0;
 tr421:
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -705,7 +703,7 @@ tr421:
     }
 	goto st0;
 tr442:
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -717,12 +715,12 @@ tr442:
     }
 	goto st0;
 tr453:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -734,7 +732,7 @@ tr453:
     }
 	goto st0;
 tr491:
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -746,12 +744,12 @@ tr491:
     }
 	goto st0;
 tr503:
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -763,7 +761,7 @@ tr503:
     }
 	goto st0;
 tr526:
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 338 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -807,7 +805,7 @@ tr566:
     }
 	goto st0;
 tr581:
-#line 357 "src/vcf/vcf_v41.ragel"
+#line 355 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
@@ -819,7 +817,7 @@ tr581:
     }
 	goto st0;
 tr584:
-#line 363 "src/vcf/vcf_v41.ragel"
+#line 361 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st653;}
@@ -831,7 +829,7 @@ tr584:
     }
 	goto st0;
 tr588:
-#line 369 "src/vcf/vcf_v41.ragel"
+#line 367 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st653;}
@@ -843,7 +841,7 @@ tr588:
     }
 	goto st0;
 tr593:
-#line 375 "src/vcf/vcf_v41.ragel"
+#line 373 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st653;}
@@ -855,7 +853,7 @@ tr593:
     }
 	goto st0;
 tr597:
-#line 381 "src/vcf/vcf_v41.ragel"
+#line 379 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st653;}
@@ -867,7 +865,7 @@ tr597:
     }
 	goto st0;
 tr606:
-#line 387 "src/vcf/vcf_v41.ragel"
+#line 385 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st653;}
@@ -879,7 +877,7 @@ tr606:
     }
 	goto st0;
 tr617:
-#line 393 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st653;}
@@ -891,12 +889,12 @@ tr617:
     }
 	goto st0;
 tr625:
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -908,7 +906,7 @@ tr625:
     }
 	goto st0;
 tr647:
-#line 559 "src/vcf/vcf_v41.ragel"
+#line 557 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st653;}
@@ -920,14 +918,14 @@ tr647:
     }
 	goto st0;
 tr652:
-#line 572 "src/vcf/vcf_v41.ragel"
+#line 570 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 563 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -941,7 +939,7 @@ tr652:
     }
 	goto st0;
 tr656:
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 563 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -962,12 +960,12 @@ tr663:
     }
 	goto st0;
 tr672:
-#line 409 "src/vcf/vcf_v41.ragel"
+#line 407 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -979,7 +977,7 @@ tr672:
     }
 	goto st0;
 tr674:
-#line 550 "src/vcf/vcf_v41.ragel"
+#line 548 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -987,12 +985,12 @@ tr674:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1004,7 +1002,7 @@ tr674:
     }
 	goto st0;
 tr676:
-#line 550 "src/vcf/vcf_v41.ragel"
+#line 548 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1012,7 +1010,7 @@ tr676:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1024,7 +1022,7 @@ tr676:
     }
 	goto st0;
 tr683:
-#line 414 "src/vcf/vcf_v41.ragel"
+#line 412 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1032,7 +1030,7 @@ tr683:
                 "AA"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1044,7 +1042,7 @@ tr683:
     }
 	goto st0;
 tr686:
-#line 422 "src/vcf/vcf_v41.ragel"
+#line 420 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1052,7 +1050,7 @@ tr686:
                 "AC"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1064,7 +1062,7 @@ tr686:
     }
 	goto st0;
 tr689:
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 428 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1072,7 +1070,7 @@ tr689:
                 "AF"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1084,7 +1082,7 @@ tr689:
     }
 	goto st0;
 tr703:
-#line 438 "src/vcf/vcf_v41.ragel"
+#line 436 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1092,7 +1090,7 @@ tr703:
                 "AN"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1104,7 +1102,7 @@ tr703:
     }
 	goto st0;
 tr707:
-#line 446 "src/vcf/vcf_v41.ragel"
+#line 444 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1112,7 +1110,7 @@ tr707:
                 "BQ"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1124,7 +1122,7 @@ tr707:
     }
 	goto st0;
 tr725:
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 452 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1132,7 +1130,7 @@ tr725:
                 "CIGAR"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1144,7 +1142,7 @@ tr725:
     }
 	goto st0;
 tr730:
-#line 462 "src/vcf/vcf_v41.ragel"
+#line 460 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1152,12 +1150,12 @@ tr730:
                 "DB"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1169,7 +1167,7 @@ tr730:
     }
 	goto st0;
 tr732:
-#line 462 "src/vcf/vcf_v41.ragel"
+#line 460 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1177,7 +1175,7 @@ tr732:
                 "DB"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1189,7 +1187,7 @@ tr732:
     }
 	goto st0;
 tr735:
-#line 470 "src/vcf/vcf_v41.ragel"
+#line 468 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1197,7 +1195,7 @@ tr735:
                 "DP"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1209,7 +1207,7 @@ tr735:
     }
 	goto st0;
 tr740:
-#line 478 "src/vcf/vcf_v41.ragel"
+#line 476 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1217,7 +1215,7 @@ tr740:
                 "END"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1229,7 +1227,7 @@ tr740:
     }
 	goto st0;
 tr744:
-#line 486 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1237,12 +1235,12 @@ tr744:
                 "H2"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1254,7 +1252,7 @@ tr744:
     }
 	goto st0;
 tr746:
-#line 486 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1262,7 +1260,7 @@ tr746:
                 "H2"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1274,7 +1272,7 @@ tr746:
     }
 	goto st0;
 tr748:
-#line 494 "src/vcf/vcf_v41.ragel"
+#line 492 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1282,12 +1280,12 @@ tr748:
                 "H3"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1299,7 +1297,7 @@ tr748:
     }
 	goto st0;
 tr750:
-#line 494 "src/vcf/vcf_v41.ragel"
+#line 492 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1307,7 +1305,7 @@ tr750:
                 "H3"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1319,7 +1317,7 @@ tr750:
     }
 	goto st0;
 tr756:
-#line 510 "src/vcf/vcf_v41.ragel"
+#line 508 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1327,7 +1325,7 @@ tr756:
                 "MQ0"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1339,7 +1337,7 @@ tr756:
     }
 	goto st0;
 tr758:
-#line 502 "src/vcf/vcf_v41.ragel"
+#line 500 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1347,7 +1345,7 @@ tr758:
                 "MQ"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1359,7 +1357,7 @@ tr758:
     }
 	goto st0;
 tr773:
-#line 518 "src/vcf/vcf_v41.ragel"
+#line 516 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1367,7 +1365,7 @@ tr773:
                 "NS"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1379,7 +1377,7 @@ tr773:
     }
 	goto st0;
 tr778:
-#line 526 "src/vcf/vcf_v41.ragel"
+#line 524 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1387,7 +1385,7 @@ tr778:
                 "SB"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1399,7 +1397,7 @@ tr778:
     }
 	goto st0;
 tr796:
-#line 534 "src/vcf/vcf_v41.ragel"
+#line 532 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1407,12 +1405,12 @@ tr796:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1424,7 +1422,7 @@ tr796:
     }
 	goto st0;
 tr798:
-#line 534 "src/vcf/vcf_v41.ragel"
+#line 532 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1432,7 +1430,7 @@ tr798:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1444,7 +1442,7 @@ tr798:
     }
 	goto st0;
 tr808:
-#line 542 "src/vcf/vcf_v41.ragel"
+#line 540 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1452,12 +1450,12 @@ tr808:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1469,7 +1467,7 @@ tr808:
     }
 	goto st0;
 tr810:
-#line 542 "src/vcf/vcf_v41.ragel"
+#line 540 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1477,7 +1475,7 @@ tr810:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1502,7 +1500,7 @@ tr859:
         
         p--; {goto st653;}
     }
-#line 357 "src/vcf/vcf_v41.ragel"
+#line 355 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
@@ -1513,7 +1511,7 @@ tr859:
         p--; {goto st653;}
     }
 	goto st0;
-#line 1517 "inc/vcf/validator_detail_v41.hpp"
+#line 1515 "inc/vcf/validator_detail_v41.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1622,7 +1620,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1626 "inc/vcf/validator_detail_v41.hpp"
+#line 1624 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1636,7 +1634,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1640 "inc/vcf/validator_detail_v41.hpp"
+#line 1638 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1650,7 +1648,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1654 "inc/vcf/validator_detail_v41.hpp"
+#line 1652 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1664,7 +1662,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1668 "inc/vcf/validator_detail_v41.hpp"
+#line 1666 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1678,7 +1676,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1682 "inc/vcf/validator_detail_v41.hpp"
+#line 1680 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1692,7 +1690,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1696 "inc/vcf/validator_detail_v41.hpp"
+#line 1694 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 49 )
 		goto tr21;
 	goto tr14;
@@ -1706,7 +1704,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1710 "inc/vcf/validator_detail_v41.hpp"
+#line 1708 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -1737,7 +1735,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1741 "inc/vcf/validator_detail_v41.hpp"
+#line 1739 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1790,7 +1788,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1794 "inc/vcf/validator_detail_v41.hpp"
+#line 1792 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1806,7 +1804,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1810 "inc/vcf/validator_detail_v41.hpp"
+#line 1808 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -1834,7 +1832,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 1838 "inc/vcf/validator_detail_v41.hpp"
+#line 1836 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -1890,7 +1888,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 1894 "inc/vcf/validator_detail_v41.hpp"
+#line 1892 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -1942,7 +1940,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 1946 "inc/vcf/validator_detail_v41.hpp"
+#line 1944 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -1977,7 +1975,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 1981 "inc/vcf/validator_detail_v41.hpp"
+#line 1979 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2005,7 +2003,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2009 "inc/vcf/validator_detail_v41.hpp"
+#line 2007 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2031,7 +2029,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2035 "inc/vcf/validator_detail_v41.hpp"
+#line 2033 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2053,7 +2051,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2057 "inc/vcf/validator_detail_v41.hpp"
+#line 2055 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2114,7 +2112,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2118 "inc/vcf/validator_detail_v41.hpp"
+#line 2116 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2142,7 +2140,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2146 "inc/vcf/validator_detail_v41.hpp"
+#line 2144 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
@@ -2166,7 +2164,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2170 "inc/vcf/validator_detail_v41.hpp"
+#line 2168 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2188,7 +2186,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2192 "inc/vcf/validator_detail_v41.hpp"
+#line 2190 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2207,7 +2205,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2211 "inc/vcf/validator_detail_v41.hpp"
+#line 2209 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2227,7 +2225,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2231 "inc/vcf/validator_detail_v41.hpp"
+#line 2229 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2262,7 +2260,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2266 "inc/vcf/validator_detail_v41.hpp"
+#line 2264 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2289,7 +2287,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2293 "inc/vcf/validator_detail_v41.hpp"
+#line 2291 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2321,7 +2319,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2325 "inc/vcf/validator_detail_v41.hpp"
+#line 2323 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2342,7 +2340,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2346 "inc/vcf/validator_detail_v41.hpp"
+#line 2344 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2367,7 +2365,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2371 "inc/vcf/validator_detail_v41.hpp"
+#line 2369 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2402,7 +2400,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2406 "inc/vcf/validator_detail_v41.hpp"
+#line 2404 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2429,7 +2427,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2433 "inc/vcf/validator_detail_v41.hpp"
+#line 2431 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2472,7 +2470,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2476 "inc/vcf/validator_detail_v41.hpp"
+#line 2474 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2500,7 +2498,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2504 "inc/vcf/validator_detail_v41.hpp"
+#line 2502 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2526,7 +2524,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2530 "inc/vcf/validator_detail_v41.hpp"
+#line 2528 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2548,7 +2546,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2552 "inc/vcf/validator_detail_v41.hpp"
+#line 2550 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2588,7 +2586,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2592 "inc/vcf/validator_detail_v41.hpp"
+#line 2590 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2639,7 +2637,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2643 "inc/vcf/validator_detail_v41.hpp"
+#line 2641 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2690,7 +2688,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2694 "inc/vcf/validator_detail_v41.hpp"
+#line 2692 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2733,7 +2731,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2737 "inc/vcf/validator_detail_v41.hpp"
+#line 2735 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2763,7 +2761,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2767 "inc/vcf/validator_detail_v41.hpp"
+#line 2765 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2803,7 +2801,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2807 "inc/vcf/validator_detail_v41.hpp"
+#line 2805 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2833,7 +2831,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 2837 "inc/vcf/validator_detail_v41.hpp"
+#line 2835 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -2853,7 +2851,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 2857 "inc/vcf/validator_detail_v41.hpp"
+#line 2855 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -2894,7 +2892,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 2898 "inc/vcf/validator_detail_v41.hpp"
+#line 2896 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -2922,7 +2920,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 2926 "inc/vcf/validator_detail_v41.hpp"
+#line 2924 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -2944,7 +2942,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 2948 "inc/vcf/validator_detail_v41.hpp"
+#line 2946 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -2974,7 +2972,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 2978 "inc/vcf/validator_detail_v41.hpp"
+#line 2976 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3025,7 +3023,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3029 "inc/vcf/validator_detail_v41.hpp"
+#line 3027 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3076,7 +3074,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3080 "inc/vcf/validator_detail_v41.hpp"
+#line 3078 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3119,7 +3117,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3123 "inc/vcf/validator_detail_v41.hpp"
+#line 3121 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3149,7 +3147,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3153 "inc/vcf/validator_detail_v41.hpp"
+#line 3151 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3179,7 +3177,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3183 "inc/vcf/validator_detail_v41.hpp"
+#line 3181 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3209,7 +3207,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3213 "inc/vcf/validator_detail_v41.hpp"
+#line 3211 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3233,7 +3231,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3237 "inc/vcf/validator_detail_v41.hpp"
+#line 3235 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3251,7 +3249,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3255 "inc/vcf/validator_detail_v41.hpp"
+#line 3253 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3278,7 +3276,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3282 "inc/vcf/validator_detail_v41.hpp"
+#line 3280 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3350,7 +3348,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3354 "inc/vcf/validator_detail_v41.hpp"
+#line 3352 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3404,7 +3402,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3408 "inc/vcf/validator_detail_v41.hpp"
+#line 3406 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3425,7 +3423,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3429 "inc/vcf/validator_detail_v41.hpp"
+#line 3427 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3523,7 +3521,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3527 "inc/vcf/validator_detail_v41.hpp"
+#line 3525 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3551,7 +3549,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3555 "inc/vcf/validator_detail_v41.hpp"
+#line 3553 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3579,7 +3577,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3583 "inc/vcf/validator_detail_v41.hpp"
+#line 3581 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st100;
 	goto tr152;
@@ -3612,7 +3610,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3616 "inc/vcf/validator_detail_v41.hpp"
+#line 3614 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr160;
 		case 92: goto tr158;
@@ -3634,7 +3632,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3638 "inc/vcf/validator_detail_v41.hpp"
+#line 3636 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 62: goto tr161;
@@ -3653,7 +3651,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3657 "inc/vcf/validator_detail_v41.hpp"
+#line 3655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3677,7 +3675,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3681 "inc/vcf/validator_detail_v41.hpp"
+#line 3679 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr163;
@@ -3696,7 +3694,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3700 "inc/vcf/validator_detail_v41.hpp"
+#line 3698 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr166;
@@ -3714,7 +3712,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3718 "inc/vcf/validator_detail_v41.hpp"
+#line 3716 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr167;
@@ -3732,7 +3730,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3736 "inc/vcf/validator_detail_v41.hpp"
+#line 3734 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr168;
@@ -3750,7 +3748,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3754 "inc/vcf/validator_detail_v41.hpp"
+#line 3752 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st109;
@@ -3777,7 +3775,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 3781 "inc/vcf/validator_detail_v41.hpp"
+#line 3779 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st111;
 	goto tr165;
@@ -3834,7 +3832,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 3838 "inc/vcf/validator_detail_v41.hpp"
+#line 3836 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st115;
 	if ( (*p) < 48 ) {
@@ -3873,7 +3871,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 3877 "inc/vcf/validator_detail_v41.hpp"
+#line 3875 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr180;
 		case 95: goto tr179;
@@ -3900,7 +3898,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 3904 "inc/vcf/validator_detail_v41.hpp"
+#line 3902 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st118;
 	goto tr165;
@@ -3998,7 +3996,7 @@ st130:
 	if ( ++p == pe )
 		goto _test_eof130;
 case 130:
-#line 4002 "inc/vcf/validator_detail_v41.hpp"
+#line 4000 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr196;
 		case 92: goto tr197;
@@ -4026,7 +4024,7 @@ st131:
 	if ( ++p == pe )
 		goto _test_eof131;
 case 131:
-#line 4030 "inc/vcf/validator_detail_v41.hpp"
+#line 4028 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 92: goto tr200;
@@ -4054,7 +4052,7 @@ st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 4058 "inc/vcf/validator_detail_v41.hpp"
+#line 4056 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st133;
 	goto tr194;
@@ -4087,7 +4085,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4091 "inc/vcf/validator_detail_v41.hpp"
+#line 4089 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr202;
 		case 92: goto tr200;
@@ -4109,7 +4107,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4113 "inc/vcf/validator_detail_v41.hpp"
+#line 4111 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 62: goto tr203;
@@ -4128,7 +4126,7 @@ st136:
 	if ( ++p == pe )
 		goto _test_eof136;
 case 136:
-#line 4132 "inc/vcf/validator_detail_v41.hpp"
+#line 4130 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4148,7 +4146,7 @@ st137:
 	if ( ++p == pe )
 		goto _test_eof137;
 case 137:
-#line 4152 "inc/vcf/validator_detail_v41.hpp"
+#line 4150 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr205;
@@ -4166,7 +4164,7 @@ st138:
 	if ( ++p == pe )
 		goto _test_eof138;
 case 138:
-#line 4170 "inc/vcf/validator_detail_v41.hpp"
+#line 4168 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr206;
@@ -4184,7 +4182,7 @@ st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 4188 "inc/vcf/validator_detail_v41.hpp"
+#line 4186 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr207;
@@ -4202,7 +4200,7 @@ st140:
 	if ( ++p == pe )
 		goto _test_eof140;
 case 140:
-#line 4206 "inc/vcf/validator_detail_v41.hpp"
+#line 4204 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st141;
@@ -4229,7 +4227,7 @@ st142:
 	if ( ++p == pe )
 		goto _test_eof142;
 case 142:
-#line 4233 "inc/vcf/validator_detail_v41.hpp"
+#line 4231 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st143;
 	goto tr204;
@@ -4286,7 +4284,7 @@ st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 4290 "inc/vcf/validator_detail_v41.hpp"
+#line 4288 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st147;
 	if ( (*p) < 48 ) {
@@ -4325,7 +4323,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4329 "inc/vcf/validator_detail_v41.hpp"
+#line 4327 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr219;
 		case 95: goto tr218;
@@ -4352,7 +4350,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4356 "inc/vcf/validator_detail_v41.hpp"
+#line 4354 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st150;
 	goto tr204;
@@ -4428,7 +4426,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4432 "inc/vcf/validator_detail_v41.hpp"
+#line 4430 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	goto tr227;
@@ -4442,7 +4440,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 4446 "inc/vcf/validator_detail_v41.hpp"
+#line 4444 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st159;
 	goto tr204;
@@ -4508,7 +4506,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 4512 "inc/vcf/validator_detail_v41.hpp"
+#line 4510 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr238;
 	if ( (*p) > 90 ) {
@@ -4527,7 +4525,7 @@ st165:
 	if ( ++p == pe )
 		goto _test_eof165;
 case 165:
-#line 4531 "inc/vcf/validator_detail_v41.hpp"
+#line 4529 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st166;
 	goto tr204;
@@ -4625,7 +4623,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 4629 "inc/vcf/validator_detail_v41.hpp"
+#line 4627 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr255;
 		case 92: goto tr256;
@@ -4653,7 +4651,7 @@ st179:
 	if ( ++p == pe )
 		goto _test_eof179;
 case 179:
-#line 4657 "inc/vcf/validator_detail_v41.hpp"
+#line 4655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 92: goto tr259;
@@ -4681,7 +4679,7 @@ st180:
 	if ( ++p == pe )
 		goto _test_eof180;
 case 180:
-#line 4685 "inc/vcf/validator_detail_v41.hpp"
+#line 4683 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st181;
 	goto tr253;
@@ -4714,7 +4712,7 @@ st182:
 	if ( ++p == pe )
 		goto _test_eof182;
 case 182:
-#line 4718 "inc/vcf/validator_detail_v41.hpp"
+#line 4716 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr261;
 		case 92: goto tr259;
@@ -4736,7 +4734,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 4740 "inc/vcf/validator_detail_v41.hpp"
+#line 4738 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 62: goto tr262;
@@ -4755,7 +4753,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 4759 "inc/vcf/validator_detail_v41.hpp"
+#line 4757 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4789,7 +4787,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 4793 "inc/vcf/validator_detail_v41.hpp"
+#line 4791 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -4809,7 +4807,7 @@ st186:
 	if ( ++p == pe )
 		goto _test_eof186;
 case 186:
-#line 4813 "inc/vcf/validator_detail_v41.hpp"
+#line 4811 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr265;
@@ -4827,7 +4825,7 @@ st187:
 	if ( ++p == pe )
 		goto _test_eof187;
 case 187:
-#line 4831 "inc/vcf/validator_detail_v41.hpp"
+#line 4829 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr266;
@@ -4845,7 +4843,7 @@ st188:
 	if ( ++p == pe )
 		goto _test_eof188;
 case 188:
-#line 4849 "inc/vcf/validator_detail_v41.hpp"
+#line 4847 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st189;
@@ -4872,7 +4870,7 @@ st190:
 	if ( ++p == pe )
 		goto _test_eof190;
 case 190:
-#line 4876 "inc/vcf/validator_detail_v41.hpp"
+#line 4874 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st191;
 	goto tr264;
@@ -4929,7 +4927,7 @@ st195:
 	if ( ++p == pe )
 		goto _test_eof195;
 case 195:
-#line 4933 "inc/vcf/validator_detail_v41.hpp"
+#line 4931 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st195;
 	if ( (*p) < 48 ) {
@@ -4968,7 +4966,7 @@ st196:
 	if ( ++p == pe )
 		goto _test_eof196;
 case 196:
-#line 4972 "inc/vcf/validator_detail_v41.hpp"
+#line 4970 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr278;
 		case 95: goto tr277;
@@ -4995,7 +4993,7 @@ st197:
 	if ( ++p == pe )
 		goto _test_eof197;
 case 197:
-#line 4999 "inc/vcf/validator_detail_v41.hpp"
+#line 4997 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st198;
 	goto tr264;
@@ -5071,7 +5069,7 @@ st205:
 	if ( ++p == pe )
 		goto _test_eof205;
 case 205:
-#line 5075 "inc/vcf/validator_detail_v41.hpp"
+#line 5073 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	goto tr286;
@@ -5085,7 +5083,7 @@ st206:
 	if ( ++p == pe )
 		goto _test_eof206;
 case 206:
-#line 5089 "inc/vcf/validator_detail_v41.hpp"
+#line 5087 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st207;
 	goto tr264;
@@ -5151,7 +5149,7 @@ st212:
 	if ( ++p == pe )
 		goto _test_eof212;
 case 212:
-#line 5155 "inc/vcf/validator_detail_v41.hpp"
+#line 5153 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr297;
 	if ( (*p) > 90 ) {
@@ -5170,7 +5168,7 @@ st213:
 	if ( ++p == pe )
 		goto _test_eof213;
 case 213:
-#line 5174 "inc/vcf/validator_detail_v41.hpp"
+#line 5172 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st214;
 	goto tr264;
@@ -5268,7 +5266,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 5272 "inc/vcf/validator_detail_v41.hpp"
+#line 5270 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr314;
 		case 92: goto tr315;
@@ -5296,7 +5294,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 5300 "inc/vcf/validator_detail_v41.hpp"
+#line 5298 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -5324,7 +5322,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 5328 "inc/vcf/validator_detail_v41.hpp"
+#line 5326 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st229;
 	goto tr312;
@@ -5357,7 +5355,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 5361 "inc/vcf/validator_detail_v41.hpp"
+#line 5359 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr318;
@@ -5379,7 +5377,7 @@ st231:
 	if ( ++p == pe )
 		goto _test_eof231;
 case 231:
-#line 5383 "inc/vcf/validator_detail_v41.hpp"
+#line 5381 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 62: goto tr321;
@@ -5398,7 +5396,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 5402 "inc/vcf/validator_detail_v41.hpp"
+#line 5400 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5432,7 +5430,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 5436 "inc/vcf/validator_detail_v41.hpp"
+#line 5434 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -5452,7 +5450,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 5456 "inc/vcf/validator_detail_v41.hpp"
+#line 5454 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr324;
@@ -5470,7 +5468,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 5474 "inc/vcf/validator_detail_v41.hpp"
+#line 5472 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr325;
@@ -5488,7 +5486,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 5492 "inc/vcf/validator_detail_v41.hpp"
+#line 5490 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr326;
@@ -5506,7 +5504,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 5510 "inc/vcf/validator_detail_v41.hpp"
+#line 5508 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr327;
@@ -5524,7 +5522,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 5528 "inc/vcf/validator_detail_v41.hpp"
+#line 5526 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr328;
@@ -5542,7 +5540,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 5546 "inc/vcf/validator_detail_v41.hpp"
+#line 5544 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr329;
@@ -5560,7 +5558,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 5564 "inc/vcf/validator_detail_v41.hpp"
+#line 5562 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st241;
@@ -5587,7 +5585,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 5591 "inc/vcf/validator_detail_v41.hpp"
+#line 5589 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st243;
 	goto tr323;
@@ -5601,7 +5599,7 @@ st243:
 	if ( ++p == pe )
 		goto _test_eof243;
 case 243:
-#line 5605 "inc/vcf/validator_detail_v41.hpp"
+#line 5603 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr334;
 	if ( (*p) < 48 ) {
@@ -5626,7 +5624,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 5630 "inc/vcf/validator_detail_v41.hpp"
+#line 5628 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st244;
 	if ( (*p) < 48 ) {
@@ -5661,7 +5659,7 @@ st245:
 	if ( ++p == pe )
 		goto _test_eof245;
 case 245:
-#line 5665 "inc/vcf/validator_detail_v41.hpp"
+#line 5663 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr338;
 		case 95: goto tr337;
@@ -5688,7 +5686,7 @@ st246:
 	if ( ++p == pe )
 		goto _test_eof246;
 case 246:
-#line 5692 "inc/vcf/validator_detail_v41.hpp"
+#line 5690 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr339;
 	if ( (*p) < 48 ) {
@@ -5713,7 +5711,7 @@ st247:
 	if ( ++p == pe )
 		goto _test_eof247;
 case 247:
-#line 5717 "inc/vcf/validator_detail_v41.hpp"
+#line 5715 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st247;
 	if ( (*p) < 48 ) {
@@ -5748,7 +5746,7 @@ st248:
 	if ( ++p == pe )
 		goto _test_eof248;
 case 248:
-#line 5752 "inc/vcf/validator_detail_v41.hpp"
+#line 5750 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr343;
 		case 62: goto tr344;
@@ -5776,7 +5774,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 5780 "inc/vcf/validator_detail_v41.hpp"
+#line 5778 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5796,7 +5794,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 5800 "inc/vcf/validator_detail_v41.hpp"
+#line 5798 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr346;
@@ -5814,7 +5812,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 5818 "inc/vcf/validator_detail_v41.hpp"
+#line 5816 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr347;
@@ -5832,7 +5830,7 @@ st252:
 	if ( ++p == pe )
 		goto _test_eof252;
 case 252:
-#line 5836 "inc/vcf/validator_detail_v41.hpp"
+#line 5834 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr348;
@@ -5850,7 +5848,7 @@ st253:
 	if ( ++p == pe )
 		goto _test_eof253;
 case 253:
-#line 5854 "inc/vcf/validator_detail_v41.hpp"
+#line 5852 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr349;
@@ -5868,7 +5866,7 @@ st254:
 	if ( ++p == pe )
 		goto _test_eof254;
 case 254:
-#line 5872 "inc/vcf/validator_detail_v41.hpp"
+#line 5870 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st255;
@@ -5895,7 +5893,7 @@ st256:
 	if ( ++p == pe )
 		goto _test_eof256;
 case 256:
-#line 5899 "inc/vcf/validator_detail_v41.hpp"
+#line 5897 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st257;
 	goto tr345;
@@ -5952,7 +5950,7 @@ st261:
 	if ( ++p == pe )
 		goto _test_eof261;
 case 261:
-#line 5956 "inc/vcf/validator_detail_v41.hpp"
+#line 5954 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st261;
 	if ( (*p) < 48 ) {
@@ -5991,7 +5989,7 @@ st262:
 	if ( ++p == pe )
 		goto _test_eof262;
 case 262:
-#line 5995 "inc/vcf/validator_detail_v41.hpp"
+#line 5993 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr362;
 		case 95: goto tr360;
@@ -6018,7 +6016,7 @@ st263:
 	if ( ++p == pe )
 		goto _test_eof263;
 case 263:
-#line 6022 "inc/vcf/validator_detail_v41.hpp"
+#line 6020 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 71 )
 		goto st264;
 	goto tr363;
@@ -6111,7 +6109,7 @@ st272:
 	if ( ++p == pe )
 		goto _test_eof272;
 case 272:
-#line 6115 "inc/vcf/validator_detail_v41.hpp"
+#line 6113 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr375;
 	if ( (*p) < 35 ) {
@@ -6133,7 +6131,7 @@ st273:
 	if ( ++p == pe )
 		goto _test_eof273;
 case 273:
-#line 6137 "inc/vcf/validator_detail_v41.hpp"
+#line 6135 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 77 )
 		goto st274;
 	goto tr376;
@@ -6226,7 +6224,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 6230 "inc/vcf/validator_detail_v41.hpp"
+#line 6228 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) < 35 ) {
@@ -6248,7 +6246,7 @@ st283:
 	if ( ++p == pe )
 		goto _test_eof283;
 case 283:
-#line 6252 "inc/vcf/validator_detail_v41.hpp"
+#line 6250 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st284;
 	goto tr389;
@@ -6346,7 +6344,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 6350 "inc/vcf/validator_detail_v41.hpp"
+#line 6348 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 92: goto tr405;
@@ -6374,7 +6372,7 @@ st297:
 	if ( ++p == pe )
 		goto _test_eof297;
 case 297:
-#line 6378 "inc/vcf/validator_detail_v41.hpp"
+#line 6376 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 92: goto tr408;
@@ -6402,7 +6400,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 6406 "inc/vcf/validator_detail_v41.hpp"
+#line 6404 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st299;
 	goto tr389;
@@ -6435,7 +6433,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 6439 "inc/vcf/validator_detail_v41.hpp"
+#line 6437 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr410;
 		case 92: goto tr408;
@@ -6457,7 +6455,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 6461 "inc/vcf/validator_detail_v41.hpp"
+#line 6459 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 62: goto tr411;
@@ -6476,7 +6474,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 6480 "inc/vcf/validator_detail_v41.hpp"
+#line 6478 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6500,7 +6498,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 6504 "inc/vcf/validator_detail_v41.hpp"
+#line 6502 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr413;
@@ -6518,7 +6516,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 6522 "inc/vcf/validator_detail_v41.hpp"
+#line 6520 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr414;
@@ -6536,7 +6534,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 6540 "inc/vcf/validator_detail_v41.hpp"
+#line 6538 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr415;
@@ -6554,7 +6552,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 6558 "inc/vcf/validator_detail_v41.hpp"
+#line 6556 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr416;
@@ -6572,7 +6570,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 6576 "inc/vcf/validator_detail_v41.hpp"
+#line 6574 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr417;
@@ -6590,7 +6588,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 6594 "inc/vcf/validator_detail_v41.hpp"
+#line 6592 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr418;
@@ -6608,7 +6606,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 6612 "inc/vcf/validator_detail_v41.hpp"
+#line 6610 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st310;
@@ -6635,7 +6633,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 6639 "inc/vcf/validator_detail_v41.hpp"
+#line 6637 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr422;
@@ -6652,7 +6650,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 6656 "inc/vcf/validator_detail_v41.hpp"
+#line 6654 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6678,7 +6676,7 @@ st313:
 	if ( ++p == pe )
 		goto _test_eof313;
 case 313:
-#line 6682 "inc/vcf/validator_detail_v41.hpp"
+#line 6680 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6801,7 +6799,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 6805 "inc/vcf/validator_detail_v41.hpp"
+#line 6803 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr438;
@@ -6869,7 +6867,7 @@ st330:
 	if ( ++p == pe )
 		goto _test_eof330;
 case 330:
-#line 6873 "inc/vcf/validator_detail_v41.hpp"
+#line 6871 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr443;
@@ -6887,7 +6885,7 @@ st331:
 	if ( ++p == pe )
 		goto _test_eof331;
 case 331:
-#line 6891 "inc/vcf/validator_detail_v41.hpp"
+#line 6889 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr444;
@@ -6905,7 +6903,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 6909 "inc/vcf/validator_detail_v41.hpp"
+#line 6907 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr445;
@@ -6923,7 +6921,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 6927 "inc/vcf/validator_detail_v41.hpp"
+#line 6925 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr446;
@@ -6941,7 +6939,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 6945 "inc/vcf/validator_detail_v41.hpp"
+#line 6943 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st335;
@@ -6968,7 +6966,7 @@ st336:
 	if ( ++p == pe )
 		goto _test_eof336;
 case 336:
-#line 6972 "inc/vcf/validator_detail_v41.hpp"
+#line 6970 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st337;
 	goto tr442;
@@ -7030,7 +7028,7 @@ st341:
 	if ( ++p == pe )
 		goto _test_eof341;
 case 341:
-#line 7034 "inc/vcf/validator_detail_v41.hpp"
+#line 7032 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 59: goto tr455;
@@ -7052,7 +7050,7 @@ st342:
 	if ( ++p == pe )
 		goto _test_eof342;
 case 342:
-#line 7056 "inc/vcf/validator_detail_v41.hpp"
+#line 7054 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr458;
 	if ( (*p) < 48 ) {
@@ -7077,7 +7075,7 @@ st343:
 	if ( ++p == pe )
 		goto _test_eof343;
 case 343:
-#line 7081 "inc/vcf/validator_detail_v41.hpp"
+#line 7079 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st343;
 	if ( (*p) < 48 ) {
@@ -7112,7 +7110,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 7116 "inc/vcf/validator_detail_v41.hpp"
+#line 7114 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr462;
 		case 95: goto tr461;
@@ -7139,7 +7137,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 7143 "inc/vcf/validator_detail_v41.hpp"
+#line 7141 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st348;
 	if ( (*p) < 45 ) {
@@ -7171,7 +7169,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 7175 "inc/vcf/validator_detail_v41.hpp"
+#line 7173 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 62: goto tr457;
@@ -7192,7 +7190,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 7196 "inc/vcf/validator_detail_v41.hpp"
+#line 7194 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7229,7 +7227,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 7233 "inc/vcf/validator_detail_v41.hpp"
+#line 7231 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 92: goto tr471;
@@ -7257,7 +7255,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 7261 "inc/vcf/validator_detail_v41.hpp"
+#line 7259 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st342;
 		case 62: goto st347;
@@ -7283,7 +7281,7 @@ st351:
 	if ( ++p == pe )
 		goto _test_eof351;
 case 351:
-#line 7287 "inc/vcf/validator_detail_v41.hpp"
+#line 7285 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 92: goto tr471;
@@ -7305,7 +7303,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 7309 "inc/vcf/validator_detail_v41.hpp"
+#line 7307 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr475;
@@ -7345,7 +7343,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 7349 "inc/vcf/validator_detail_v41.hpp"
+#line 7347 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7396,7 +7394,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 7400 "inc/vcf/validator_detail_v41.hpp"
+#line 7398 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7447,7 +7445,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 7451 "inc/vcf/validator_detail_v41.hpp"
+#line 7449 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7490,7 +7488,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 7494 "inc/vcf/validator_detail_v41.hpp"
+#line 7492 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr483;
 		case 44: goto tr469;
@@ -7520,7 +7518,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 7524 "inc/vcf/validator_detail_v41.hpp"
+#line 7522 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr486;
@@ -7560,7 +7558,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 7564 "inc/vcf/validator_detail_v41.hpp"
+#line 7562 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7590,7 +7588,7 @@ st359:
 	if ( ++p == pe )
 		goto _test_eof359;
 case 359:
-#line 7594 "inc/vcf/validator_detail_v41.hpp"
+#line 7592 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 44: goto tr486;
@@ -7610,7 +7608,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 7614 "inc/vcf/validator_detail_v41.hpp"
+#line 7612 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr467;
 		case 44: goto tr489;
@@ -7634,7 +7632,7 @@ st361:
 	if ( ++p == pe )
 		goto _test_eof361;
 case 361:
-#line 7638 "inc/vcf/validator_detail_v41.hpp"
+#line 7636 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr492;
@@ -7652,7 +7650,7 @@ st362:
 	if ( ++p == pe )
 		goto _test_eof362;
 case 362:
-#line 7656 "inc/vcf/validator_detail_v41.hpp"
+#line 7654 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr493;
@@ -7670,7 +7668,7 @@ st363:
 	if ( ++p == pe )
 		goto _test_eof363;
 case 363:
-#line 7674 "inc/vcf/validator_detail_v41.hpp"
+#line 7672 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr494;
@@ -7688,7 +7686,7 @@ st364:
 	if ( ++p == pe )
 		goto _test_eof364;
 case 364:
-#line 7692 "inc/vcf/validator_detail_v41.hpp"
+#line 7690 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr495;
@@ -7706,7 +7704,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 7710 "inc/vcf/validator_detail_v41.hpp"
+#line 7708 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr496;
@@ -7724,7 +7722,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 7728 "inc/vcf/validator_detail_v41.hpp"
+#line 7726 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr497;
@@ -7742,7 +7740,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 7746 "inc/vcf/validator_detail_v41.hpp"
+#line 7744 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr498;
@@ -7760,7 +7758,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 7764 "inc/vcf/validator_detail_v41.hpp"
+#line 7762 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr499;
@@ -7778,7 +7776,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 7782 "inc/vcf/validator_detail_v41.hpp"
+#line 7780 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st370;
@@ -7805,7 +7803,7 @@ st371:
 	if ( ++p == pe )
 		goto _test_eof371;
 case 371:
-#line 7809 "inc/vcf/validator_detail_v41.hpp"
+#line 7807 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st372;
 	goto tr491;
@@ -7829,7 +7827,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 7833 "inc/vcf/validator_detail_v41.hpp"
+#line 7831 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7855,7 +7853,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 7859 "inc/vcf/validator_detail_v41.hpp"
+#line 7857 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7966,7 +7964,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 7970 "inc/vcf/validator_detail_v41.hpp"
+#line 7968 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr520;
@@ -7987,7 +7985,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 7991 "inc/vcf/validator_detail_v41.hpp"
+#line 7989 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr522;
@@ -8022,7 +8020,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 8026 "inc/vcf/validator_detail_v41.hpp"
+#line 8024 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr520;
@@ -8122,7 +8120,7 @@ st398:
 	if ( ++p == pe )
 		goto _test_eof398;
 case 398:
-#line 8126 "inc/vcf/validator_detail_v41.hpp"
+#line 8124 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 80 )
 		goto st399;
 	goto tr526;
@@ -8157,7 +8155,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 8161 "inc/vcf/validator_detail_v41.hpp"
+#line 8159 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st403;
 	goto tr526;
@@ -8185,7 +8183,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 8189 "inc/vcf/validator_detail_v41.hpp"
+#line 8187 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 82 )
 		goto st406;
 	goto tr526;
@@ -8220,7 +8218,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 8224 "inc/vcf/validator_detail_v41.hpp"
+#line 8222 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 65 )
 		goto st410;
 	goto tr526;
@@ -8255,7 +8253,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 8259 "inc/vcf/validator_detail_v41.hpp"
+#line 8257 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 81 )
 		goto st414;
 	goto tr526;
@@ -8297,7 +8295,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 8301 "inc/vcf/validator_detail_v41.hpp"
+#line 8299 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st419;
 	goto tr526;
@@ -8353,7 +8351,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 8357 "inc/vcf/validator_detail_v41.hpp"
+#line 8355 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st426;
 	goto tr526;
@@ -8398,7 +8396,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 8402 "inc/vcf/validator_detail_v41.hpp"
+#line 8400 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st431;
 	goto tr566;
@@ -8464,7 +8462,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 8468 "inc/vcf/validator_detail_v41.hpp"
+#line 8466 "inc/vcf/validator_detail_v41.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr574;
 	goto tr566;
@@ -8488,7 +8486,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 8492 "inc/vcf/validator_detail_v41.hpp"
+#line 8490 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr575;
 		case 10: goto tr576;
@@ -8537,7 +8535,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 8541 "inc/vcf/validator_detail_v41.hpp"
+#line 8539 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr860;
 		case 13: goto tr861;
@@ -8588,7 +8586,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 8592 "inc/vcf/validator_detail_v41.hpp"
+#line 8590 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr864;
 		case 13: goto tr865;
@@ -8630,7 +8628,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 8634 "inc/vcf/validator_detail_v41.hpp"
+#line 8632 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st655;
 	goto st0;
@@ -8672,7 +8670,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 8676 "inc/vcf/validator_detail_v41.hpp"
+#line 8674 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr582;
 		case 59: goto tr583;
@@ -8715,7 +8713,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 8719 "inc/vcf/validator_detail_v41.hpp"
+#line 8717 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr585;
 	goto tr584;
@@ -8739,7 +8737,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 8743 "inc/vcf/validator_detail_v41.hpp"
+#line 8741 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr586;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8769,7 +8767,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 8773 "inc/vcf/validator_detail_v41.hpp"
+#line 8771 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr589;
@@ -8796,7 +8794,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 8800 "inc/vcf/validator_detail_v41.hpp"
+#line 8798 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr590;
 		case 59: goto tr592;
@@ -8822,7 +8820,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 8826 "inc/vcf/validator_detail_v41.hpp"
+#line 8824 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr594;
 		case 67: goto tr594;
@@ -8856,7 +8854,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 8860 "inc/vcf/validator_detail_v41.hpp"
+#line 8858 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr595;
 		case 65: goto tr596;
@@ -8889,7 +8887,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 8893 "inc/vcf/validator_detail_v41.hpp"
+#line 8891 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr599;
@@ -8928,7 +8926,7 @@ st448:
 	if ( ++p == pe )
 		goto _test_eof448;
 case 448:
-#line 8932 "inc/vcf/validator_detail_v41.hpp"
+#line 8930 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -8952,7 +8950,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 8956 "inc/vcf/validator_detail_v41.hpp"
+#line 8954 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr607;
 		case 45: goto tr607;
@@ -8977,7 +8975,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 8981 "inc/vcf/validator_detail_v41.hpp"
+#line 8979 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr613;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9003,7 +9001,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 9007 "inc/vcf/validator_detail_v41.hpp"
+#line 9005 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 46: goto tr615;
@@ -9031,7 +9029,7 @@ st452:
 	if ( ++p == pe )
 		goto _test_eof452;
 case 452:
-#line 9035 "inc/vcf/validator_detail_v41.hpp"
+#line 9033 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr619;
 		case 58: goto tr618;
@@ -9067,7 +9065,7 @@ st453:
 	if ( ++p == pe )
 		goto _test_eof453;
 case 453:
-#line 9071 "inc/vcf/validator_detail_v41.hpp"
+#line 9069 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto st453;
 	if ( (*p) < 65 ) {
@@ -9111,7 +9109,7 @@ st454:
 	if ( ++p == pe )
 		goto _test_eof454;
 case 454:
-#line 9115 "inc/vcf/validator_detail_v41.hpp"
+#line 9113 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 59: goto tr624;
@@ -9137,7 +9135,7 @@ st455:
 	if ( ++p == pe )
 		goto _test_eof455;
 case 455:
-#line 9141 "inc/vcf/validator_detail_v41.hpp"
+#line 9139 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr627;
 		case 49: goto tr629;
@@ -9195,7 +9193,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 9199 "inc/vcf/validator_detail_v41.hpp"
+#line 9197 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr640;
 		case 60: goto tr640;
@@ -9241,7 +9239,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 9245 "inc/vcf/validator_detail_v41.hpp"
+#line 9243 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9276,7 +9274,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 9280 "inc/vcf/validator_detail_v41.hpp"
+#line 9278 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr648;
@@ -9306,7 +9304,7 @@ st459:
 	if ( ++p == pe )
 		goto _test_eof459;
 case 459:
-#line 9310 "inc/vcf/validator_detail_v41.hpp"
+#line 9308 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 58: goto tr651;
@@ -9338,7 +9336,7 @@ st460:
 	if ( ++p == pe )
 		goto _test_eof460;
 case 460:
-#line 9342 "inc/vcf/validator_detail_v41.hpp"
+#line 9340 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr654;
 	if ( (*p) < 48 ) {
@@ -9370,7 +9368,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 9374 "inc/vcf/validator_detail_v41.hpp"
+#line 9372 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9395,16 +9393,14 @@ tr643:
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
                     ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -9429,7 +9425,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 9433 "inc/vcf/validator_detail_v41.hpp"
+#line 9429 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr864;
 		case 13: goto tr865;
@@ -9458,7 +9454,7 @@ st462:
 	if ( ++p == pe )
 		goto _test_eof462;
 case 462:
-#line 9462 "inc/vcf/validator_detail_v41.hpp"
+#line 9458 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr659;
@@ -9488,7 +9484,7 @@ st463:
 	if ( ++p == pe )
 		goto _test_eof463;
 case 463:
-#line 9492 "inc/vcf/validator_detail_v41.hpp"
+#line 9488 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr660;
 		case 62: goto tr661;
@@ -9512,7 +9508,7 @@ st464:
 	if ( ++p == pe )
 		goto _test_eof464;
 case 464:
-#line 9516 "inc/vcf/validator_detail_v41.hpp"
+#line 9512 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr662;
 	goto tr581;
@@ -9531,16 +9527,14 @@ tr644:
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
                     ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -9565,7 +9559,7 @@ st465:
 	if ( ++p == pe )
 		goto _test_eof465;
 case 465:
-#line 9569 "inc/vcf/validator_detail_v41.hpp"
+#line 9563 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st656;
 	goto tr663;
@@ -9579,7 +9573,7 @@ st466:
 	if ( ++p == pe )
 		goto _test_eof466;
 case 466:
-#line 9583 "inc/vcf/validator_detail_v41.hpp"
+#line 9577 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr657;
@@ -9606,7 +9600,7 @@ st467:
 	if ( ++p == pe )
 		goto _test_eof467;
 case 467:
-#line 9610 "inc/vcf/validator_detail_v41.hpp"
+#line 9604 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9628,7 +9622,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 9632 "inc/vcf/validator_detail_v41.hpp"
+#line 9626 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9665,7 +9659,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 9669 "inc/vcf/validator_detail_v41.hpp"
+#line 9663 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9693,7 +9687,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 9697 "inc/vcf/validator_detail_v41.hpp"
+#line 9691 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 49: goto tr629;
 		case 58: goto tr626;
@@ -9744,7 +9738,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 9748 "inc/vcf/validator_detail_v41.hpp"
+#line 9742 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9766,7 +9760,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 9770 "inc/vcf/validator_detail_v41.hpp"
+#line 9764 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9788,7 +9782,7 @@ st473:
 	if ( ++p == pe )
 		goto _test_eof473;
 case 473:
-#line 9792 "inc/vcf/validator_detail_v41.hpp"
+#line 9786 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9810,7 +9804,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 9814 "inc/vcf/validator_detail_v41.hpp"
+#line 9808 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9832,7 +9826,7 @@ st475:
 	if ( ++p == pe )
 		goto _test_eof475;
 case 475:
-#line 9836 "inc/vcf/validator_detail_v41.hpp"
+#line 9830 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr673;
@@ -9849,7 +9843,7 @@ st476:
 	if ( ++p == pe )
 		goto _test_eof476;
 case 476:
-#line 9853 "inc/vcf/validator_detail_v41.hpp"
+#line 9847 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9869,7 +9863,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 9873 "inc/vcf/validator_detail_v41.hpp"
+#line 9867 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9890,7 +9884,7 @@ st478:
 	if ( ++p == pe )
 		goto _test_eof478;
 case 478:
-#line 9894 "inc/vcf/validator_detail_v41.hpp"
+#line 9888 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr677;
 	goto tr676;
@@ -9904,7 +9898,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 9908 "inc/vcf/validator_detail_v41.hpp"
+#line 9902 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9926,7 +9920,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 9930 "inc/vcf/validator_detail_v41.hpp"
+#line 9924 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9951,7 +9945,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 9955 "inc/vcf/validator_detail_v41.hpp"
+#line 9949 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr682;
 	if ( (*p) > 58 ) {
@@ -9970,7 +9964,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 9974 "inc/vcf/validator_detail_v41.hpp"
+#line 9968 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr684;
 	if ( (*p) < 45 ) {
@@ -9992,7 +9986,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 9996 "inc/vcf/validator_detail_v41.hpp"
+#line 9990 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10018,7 +10012,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10022 "inc/vcf/validator_detail_v41.hpp"
+#line 10016 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr685;
 	if ( (*p) > 58 ) {
@@ -10037,7 +10031,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10041 "inc/vcf/validator_detail_v41.hpp"
+#line 10035 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr687;
 	goto tr686;
@@ -10051,7 +10045,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 10055 "inc/vcf/validator_detail_v41.hpp"
+#line 10049 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10072,7 +10066,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 10076 "inc/vcf/validator_detail_v41.hpp"
+#line 10070 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr688;
 	if ( (*p) > 58 ) {
@@ -10091,7 +10085,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 10095 "inc/vcf/validator_detail_v41.hpp"
+#line 10089 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr690;
 		case 45: goto tr690;
@@ -10111,7 +10105,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 10115 "inc/vcf/validator_detail_v41.hpp"
+#line 10109 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr692;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10127,7 +10121,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10131 "inc/vcf/validator_detail_v41.hpp"
+#line 10125 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10151,7 +10145,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 10155 "inc/vcf/validator_detail_v41.hpp"
+#line 10149 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr696;
 	goto tr689;
@@ -10165,7 +10159,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 10169 "inc/vcf/validator_detail_v41.hpp"
+#line 10163 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10188,7 +10182,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 10192 "inc/vcf/validator_detail_v41.hpp"
+#line 10186 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr697;
 		case 45: goto tr697;
@@ -10206,7 +10200,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 10210 "inc/vcf/validator_detail_v41.hpp"
+#line 10204 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr698;
 	goto tr689;
@@ -10220,7 +10214,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10224 "inc/vcf/validator_detail_v41.hpp"
+#line 10218 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10241,7 +10235,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10245 "inc/vcf/validator_detail_v41.hpp"
+#line 10239 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr699;
 	goto tr689;
@@ -10255,7 +10249,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10259 "inc/vcf/validator_detail_v41.hpp"
+#line 10253 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr700;
 	goto tr689;
@@ -10269,7 +10263,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10273 "inc/vcf/validator_detail_v41.hpp"
+#line 10267 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10288,7 +10282,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10292 "inc/vcf/validator_detail_v41.hpp"
+#line 10286 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr701;
 	goto tr689;
@@ -10302,7 +10296,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10306 "inc/vcf/validator_detail_v41.hpp"
+#line 10300 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr700;
 	goto tr689;
@@ -10316,7 +10310,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 10320 "inc/vcf/validator_detail_v41.hpp"
+#line 10314 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr702;
 	if ( (*p) > 58 ) {
@@ -10335,7 +10329,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10339 "inc/vcf/validator_detail_v41.hpp"
+#line 10333 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr704;
 	goto tr703;
@@ -10349,7 +10343,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 10353 "inc/vcf/validator_detail_v41.hpp"
+#line 10347 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10373,7 +10367,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 10377 "inc/vcf/validator_detail_v41.hpp"
+#line 10371 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10395,7 +10389,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 10399 "inc/vcf/validator_detail_v41.hpp"
+#line 10393 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr706;
 	if ( (*p) > 58 ) {
@@ -10414,7 +10408,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 10418 "inc/vcf/validator_detail_v41.hpp"
+#line 10412 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr708;
 		case 45: goto tr708;
@@ -10434,7 +10428,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 10438 "inc/vcf/validator_detail_v41.hpp"
+#line 10432 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr710;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10450,7 +10444,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 10454 "inc/vcf/validator_detail_v41.hpp"
+#line 10448 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10473,7 +10467,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10477 "inc/vcf/validator_detail_v41.hpp"
+#line 10471 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr714;
 	goto tr707;
@@ -10487,7 +10481,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10491 "inc/vcf/validator_detail_v41.hpp"
+#line 10485 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10509,7 +10503,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 10513 "inc/vcf/validator_detail_v41.hpp"
+#line 10507 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr715;
 		case 45: goto tr715;
@@ -10527,7 +10521,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 10531 "inc/vcf/validator_detail_v41.hpp"
+#line 10525 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr716;
 	goto tr707;
@@ -10541,7 +10535,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 10545 "inc/vcf/validator_detail_v41.hpp"
+#line 10539 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10561,7 +10555,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 10565 "inc/vcf/validator_detail_v41.hpp"
+#line 10559 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr717;
 	goto tr707;
@@ -10575,7 +10569,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 10579 "inc/vcf/validator_detail_v41.hpp"
+#line 10573 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr718;
 	goto tr707;
@@ -10589,7 +10583,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 10593 "inc/vcf/validator_detail_v41.hpp"
+#line 10587 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10607,7 +10601,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 10611 "inc/vcf/validator_detail_v41.hpp"
+#line 10605 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr719;
 	goto tr707;
@@ -10621,7 +10615,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 10625 "inc/vcf/validator_detail_v41.hpp"
+#line 10619 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr718;
 	goto tr707;
@@ -10639,7 +10633,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 10643 "inc/vcf/validator_detail_v41.hpp"
+#line 10637 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10661,7 +10655,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 10665 "inc/vcf/validator_detail_v41.hpp"
+#line 10659 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10683,7 +10677,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 10687 "inc/vcf/validator_detail_v41.hpp"
+#line 10681 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10705,7 +10699,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 10709 "inc/vcf/validator_detail_v41.hpp"
+#line 10703 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10727,7 +10721,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 10731 "inc/vcf/validator_detail_v41.hpp"
+#line 10725 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr724;
 	if ( (*p) > 58 ) {
@@ -10746,7 +10740,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 10750 "inc/vcf/validator_detail_v41.hpp"
+#line 10744 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr726;
 	goto tr725;
@@ -10760,7 +10754,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 10764 "inc/vcf/validator_detail_v41.hpp"
+#line 10758 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 68: goto tr727;
 		case 80: goto tr727;
@@ -10786,7 +10780,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 10790 "inc/vcf/validator_detail_v41.hpp"
+#line 10784 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10810,7 +10804,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 10814 "inc/vcf/validator_detail_v41.hpp"
+#line 10808 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10833,7 +10827,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 10837 "inc/vcf/validator_detail_v41.hpp"
+#line 10831 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10854,7 +10848,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 10858 "inc/vcf/validator_detail_v41.hpp"
+#line 10852 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr733;
 	goto tr732;
@@ -10868,7 +10862,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 10872 "inc/vcf/validator_detail_v41.hpp"
+#line 10866 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10886,7 +10880,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 10890 "inc/vcf/validator_detail_v41.hpp"
+#line 10884 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr734;
 	if ( (*p) > 58 ) {
@@ -10905,7 +10899,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 10909 "inc/vcf/validator_detail_v41.hpp"
+#line 10903 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr736;
 	goto tr735;
@@ -10919,7 +10913,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 10923 "inc/vcf/validator_detail_v41.hpp"
+#line 10917 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10943,7 +10937,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 10947 "inc/vcf/validator_detail_v41.hpp"
+#line 10941 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10965,7 +10959,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 10969 "inc/vcf/validator_detail_v41.hpp"
+#line 10963 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10987,7 +10981,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 10991 "inc/vcf/validator_detail_v41.hpp"
+#line 10985 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr739;
 	if ( (*p) > 58 ) {
@@ -11006,7 +11000,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 11010 "inc/vcf/validator_detail_v41.hpp"
+#line 11004 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr741;
 	goto tr740;
@@ -11020,7 +11014,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 11024 "inc/vcf/validator_detail_v41.hpp"
+#line 11018 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11044,7 +11038,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 11048 "inc/vcf/validator_detail_v41.hpp"
+#line 11042 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11067,7 +11061,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 11071 "inc/vcf/validator_detail_v41.hpp"
+#line 11065 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11088,7 +11082,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 11092 "inc/vcf/validator_detail_v41.hpp"
+#line 11086 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr747;
 	goto tr746;
@@ -11102,7 +11096,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 11106 "inc/vcf/validator_detail_v41.hpp"
+#line 11100 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11120,7 +11114,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 11124 "inc/vcf/validator_detail_v41.hpp"
+#line 11118 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11141,7 +11135,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 11145 "inc/vcf/validator_detail_v41.hpp"
+#line 11139 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr751;
 	goto tr750;
@@ -11155,7 +11149,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 11159 "inc/vcf/validator_detail_v41.hpp"
+#line 11153 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11177,7 +11171,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 11181 "inc/vcf/validator_detail_v41.hpp"
+#line 11175 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11199,7 +11193,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 11203 "inc/vcf/validator_detail_v41.hpp"
+#line 11197 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 48: goto tr753;
 		case 61: goto tr754;
@@ -11220,7 +11214,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 11224 "inc/vcf/validator_detail_v41.hpp"
+#line 11218 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr755;
 	if ( (*p) > 58 ) {
@@ -11239,7 +11233,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 11243 "inc/vcf/validator_detail_v41.hpp"
+#line 11237 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr757;
 	goto tr756;
@@ -11253,7 +11247,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 11257 "inc/vcf/validator_detail_v41.hpp"
+#line 11251 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11273,7 +11267,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 11277 "inc/vcf/validator_detail_v41.hpp"
+#line 11271 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr759;
 		case 45: goto tr759;
@@ -11293,7 +11287,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 11297 "inc/vcf/validator_detail_v41.hpp"
+#line 11291 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr761;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11309,7 +11303,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 11313 "inc/vcf/validator_detail_v41.hpp"
+#line 11307 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11332,7 +11326,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 11336 "inc/vcf/validator_detail_v41.hpp"
+#line 11330 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr765;
 	goto tr758;
@@ -11346,7 +11340,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 11350 "inc/vcf/validator_detail_v41.hpp"
+#line 11344 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11368,7 +11362,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 11372 "inc/vcf/validator_detail_v41.hpp"
+#line 11366 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr766;
 		case 45: goto tr766;
@@ -11386,7 +11380,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 11390 "inc/vcf/validator_detail_v41.hpp"
+#line 11384 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr767;
 	goto tr758;
@@ -11400,7 +11394,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 11404 "inc/vcf/validator_detail_v41.hpp"
+#line 11398 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11420,7 +11414,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 11424 "inc/vcf/validator_detail_v41.hpp"
+#line 11418 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr768;
 	goto tr758;
@@ -11434,7 +11428,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 11438 "inc/vcf/validator_detail_v41.hpp"
+#line 11432 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr769;
 	goto tr758;
@@ -11448,7 +11442,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 11452 "inc/vcf/validator_detail_v41.hpp"
+#line 11446 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11466,7 +11460,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 11470 "inc/vcf/validator_detail_v41.hpp"
+#line 11464 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr770;
 	goto tr758;
@@ -11480,7 +11474,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 11484 "inc/vcf/validator_detail_v41.hpp"
+#line 11478 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr769;
 	goto tr758;
@@ -11498,7 +11492,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 11502 "inc/vcf/validator_detail_v41.hpp"
+#line 11496 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11520,7 +11514,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 11524 "inc/vcf/validator_detail_v41.hpp"
+#line 11518 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr772;
 	if ( (*p) > 58 ) {
@@ -11539,7 +11533,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 11543 "inc/vcf/validator_detail_v41.hpp"
+#line 11537 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr774;
 	goto tr773;
@@ -11553,7 +11547,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 11557 "inc/vcf/validator_detail_v41.hpp"
+#line 11551 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11577,7 +11571,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 11581 "inc/vcf/validator_detail_v41.hpp"
+#line 11575 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11600,7 +11594,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 11604 "inc/vcf/validator_detail_v41.hpp"
+#line 11598 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr777;
 	if ( (*p) > 58 ) {
@@ -11619,7 +11613,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 11623 "inc/vcf/validator_detail_v41.hpp"
+#line 11617 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr779;
 		case 45: goto tr779;
@@ -11639,7 +11633,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 11643 "inc/vcf/validator_detail_v41.hpp"
+#line 11637 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr781;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11655,7 +11649,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 11659 "inc/vcf/validator_detail_v41.hpp"
+#line 11653 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11678,7 +11672,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 11682 "inc/vcf/validator_detail_v41.hpp"
+#line 11676 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr785;
 	goto tr778;
@@ -11692,7 +11686,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 11696 "inc/vcf/validator_detail_v41.hpp"
+#line 11690 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11714,7 +11708,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 11718 "inc/vcf/validator_detail_v41.hpp"
+#line 11712 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr786;
 		case 45: goto tr786;
@@ -11732,7 +11726,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 11736 "inc/vcf/validator_detail_v41.hpp"
+#line 11730 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr787;
 	goto tr778;
@@ -11746,7 +11740,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 11750 "inc/vcf/validator_detail_v41.hpp"
+#line 11744 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11766,7 +11760,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 11770 "inc/vcf/validator_detail_v41.hpp"
+#line 11764 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr788;
 	goto tr778;
@@ -11780,7 +11774,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 11784 "inc/vcf/validator_detail_v41.hpp"
+#line 11778 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr789;
 	goto tr778;
@@ -11794,7 +11788,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 11798 "inc/vcf/validator_detail_v41.hpp"
+#line 11792 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11812,7 +11806,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 11816 "inc/vcf/validator_detail_v41.hpp"
+#line 11810 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr790;
 	goto tr778;
@@ -11826,7 +11820,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 11830 "inc/vcf/validator_detail_v41.hpp"
+#line 11824 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr789;
 	goto tr778;
@@ -11840,7 +11834,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 11844 "inc/vcf/validator_detail_v41.hpp"
+#line 11838 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11862,7 +11856,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 11866 "inc/vcf/validator_detail_v41.hpp"
+#line 11860 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11884,7 +11878,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 11888 "inc/vcf/validator_detail_v41.hpp"
+#line 11882 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11906,7 +11900,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 11910 "inc/vcf/validator_detail_v41.hpp"
+#line 11904 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11928,7 +11922,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 11932 "inc/vcf/validator_detail_v41.hpp"
+#line 11926 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11950,7 +11944,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 11954 "inc/vcf/validator_detail_v41.hpp"
+#line 11948 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11971,7 +11965,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 11975 "inc/vcf/validator_detail_v41.hpp"
+#line 11969 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr799;
 	goto tr798;
@@ -11985,7 +11979,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 11989 "inc/vcf/validator_detail_v41.hpp"
+#line 11983 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12007,7 +12001,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12011 "inc/vcf/validator_detail_v41.hpp"
+#line 12005 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12029,7 +12023,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12033 "inc/vcf/validator_detail_v41.hpp"
+#line 12027 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12051,7 +12045,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12055 "inc/vcf/validator_detail_v41.hpp"
+#line 12049 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12073,7 +12067,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 12077 "inc/vcf/validator_detail_v41.hpp"
+#line 12071 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12095,7 +12089,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 12099 "inc/vcf/validator_detail_v41.hpp"
+#line 12093 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12117,7 +12111,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 12121 "inc/vcf/validator_detail_v41.hpp"
+#line 12115 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12139,7 +12133,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 12143 "inc/vcf/validator_detail_v41.hpp"
+#line 12137 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12161,7 +12155,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 12165 "inc/vcf/validator_detail_v41.hpp"
+#line 12159 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12183,7 +12177,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 12187 "inc/vcf/validator_detail_v41.hpp"
+#line 12181 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12204,7 +12198,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 12208 "inc/vcf/validator_detail_v41.hpp"
+#line 12202 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr811;
 	goto tr810;
@@ -12218,7 +12212,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 12222 "inc/vcf/validator_detail_v41.hpp"
+#line 12216 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12240,7 +12234,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 12244 "inc/vcf/validator_detail_v41.hpp"
+#line 12238 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12279,7 +12273,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 12283 "inc/vcf/validator_detail_v41.hpp"
+#line 12277 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr618;
 	if ( (*p) < 65 ) {
@@ -12317,7 +12311,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 12321 "inc/vcf/validator_detail_v41.hpp"
+#line 12315 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 58: goto st453;
@@ -12353,7 +12347,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 12357 "inc/vcf/validator_detail_v41.hpp"
+#line 12351 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr812;
 	goto tr606;
@@ -12367,7 +12361,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 12371 "inc/vcf/validator_detail_v41.hpp"
+#line 12365 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 69: goto tr616;
@@ -12386,7 +12380,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 12390 "inc/vcf/validator_detail_v41.hpp"
+#line 12384 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr813;
 		case 45: goto tr813;
@@ -12404,7 +12398,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 12408 "inc/vcf/validator_detail_v41.hpp"
+#line 12402 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr814;
 	goto tr606;
@@ -12418,7 +12412,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 12422 "inc/vcf/validator_detail_v41.hpp"
+#line 12416 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12444,7 +12438,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 12448 "inc/vcf/validator_detail_v41.hpp"
+#line 12442 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr815;
 	goto tr606;
@@ -12458,7 +12452,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 12462 "inc/vcf/validator_detail_v41.hpp"
+#line 12456 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr816;
 	goto tr606;
@@ -12482,7 +12476,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 12486 "inc/vcf/validator_detail_v41.hpp"
+#line 12480 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	goto tr606;
@@ -12500,7 +12494,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 12504 "inc/vcf/validator_detail_v41.hpp"
+#line 12498 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr817;
 	goto tr606;
@@ -12514,7 +12508,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 12518 "inc/vcf/validator_detail_v41.hpp"
+#line 12512 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr816;
 	goto tr606;
@@ -12528,7 +12522,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 12532 "inc/vcf/validator_detail_v41.hpp"
+#line 12526 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr818;
@@ -12567,7 +12561,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 12571 "inc/vcf/validator_detail_v41.hpp"
+#line 12565 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr819;
 		case 67: goto tr819;
@@ -12591,7 +12585,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 12595 "inc/vcf/validator_detail_v41.hpp"
+#line 12589 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12627,7 +12621,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 12631 "inc/vcf/validator_detail_v41.hpp"
+#line 12625 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr820;
 	if ( (*p) < 63 ) {
@@ -12667,7 +12661,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 12671 "inc/vcf/validator_detail_v41.hpp"
+#line 12665 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto tr822;
 	if ( (*p) < 45 ) {
@@ -12699,7 +12693,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 12703 "inc/vcf/validator_detail_v41.hpp"
+#line 12697 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12728,7 +12722,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 12732 "inc/vcf/validator_detail_v41.hpp"
+#line 12726 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr827;
 	if ( (*p) < 65 ) {
@@ -12750,7 +12744,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 12754 "inc/vcf/validator_detail_v41.hpp"
+#line 12748 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr828;
 		case 61: goto tr826;
@@ -12774,7 +12768,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 12778 "inc/vcf/validator_detail_v41.hpp"
+#line 12772 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr829;
 	goto tr597;
@@ -12788,7 +12782,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 12792 "inc/vcf/validator_detail_v41.hpp"
+#line 12786 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12804,7 +12798,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 12808 "inc/vcf/validator_detail_v41.hpp"
+#line 12802 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr830;
@@ -12824,7 +12818,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 12828 "inc/vcf/validator_detail_v41.hpp"
+#line 12822 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr830;
 		case 62: goto tr831;
@@ -12848,7 +12842,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 12852 "inc/vcf/validator_detail_v41.hpp"
+#line 12846 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr828;
 	goto tr597;
@@ -12862,7 +12856,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 12866 "inc/vcf/validator_detail_v41.hpp"
+#line 12860 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr833;
 	if ( (*p) < 65 ) {
@@ -12884,7 +12878,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 12888 "inc/vcf/validator_detail_v41.hpp"
+#line 12882 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr834;
 		case 61: goto tr832;
@@ -12908,7 +12902,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 12912 "inc/vcf/validator_detail_v41.hpp"
+#line 12906 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr597;
@@ -12922,7 +12916,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 12926 "inc/vcf/validator_detail_v41.hpp"
+#line 12920 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12938,7 +12932,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 12942 "inc/vcf/validator_detail_v41.hpp"
+#line 12936 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr836;
@@ -12958,7 +12952,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 12962 "inc/vcf/validator_detail_v41.hpp"
+#line 12956 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr836;
 		case 62: goto tr837;
@@ -12982,7 +12976,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 12986 "inc/vcf/validator_detail_v41.hpp"
+#line 12980 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr834;
 	goto tr597;
@@ -13000,7 +12994,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 13004 "inc/vcf/validator_detail_v41.hpp"
+#line 12998 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr839;
 	if ( (*p) < 65 ) {
@@ -13022,7 +13016,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13026 "inc/vcf/validator_detail_v41.hpp"
+#line 13020 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr840;
 		case 61: goto tr838;
@@ -13046,7 +13040,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 13050 "inc/vcf/validator_detail_v41.hpp"
+#line 13044 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr841;
 	goto tr597;
@@ -13060,7 +13054,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 13064 "inc/vcf/validator_detail_v41.hpp"
+#line 13058 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr842;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13076,7 +13070,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 13080 "inc/vcf/validator_detail_v41.hpp"
+#line 13074 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr843;
@@ -13096,7 +13090,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 13100 "inc/vcf/validator_detail_v41.hpp"
+#line 13094 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr843;
 		case 62: goto tr844;
@@ -13120,7 +13114,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 13124 "inc/vcf/validator_detail_v41.hpp"
+#line 13118 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr840;
 	goto tr597;
@@ -13138,7 +13132,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 13142 "inc/vcf/validator_detail_v41.hpp"
+#line 13136 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr846;
 	if ( (*p) < 65 ) {
@@ -13160,7 +13154,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 13164 "inc/vcf/validator_detail_v41.hpp"
+#line 13158 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr847;
 		case 61: goto tr845;
@@ -13184,7 +13178,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 13188 "inc/vcf/validator_detail_v41.hpp"
+#line 13182 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr848;
 	goto tr597;
@@ -13198,7 +13192,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 13202 "inc/vcf/validator_detail_v41.hpp"
+#line 13196 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr842;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13214,7 +13208,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 13218 "inc/vcf/validator_detail_v41.hpp"
+#line 13212 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr849;
@@ -13234,7 +13228,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 13238 "inc/vcf/validator_detail_v41.hpp"
+#line 13232 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr849;
 		case 62: goto tr850;
@@ -13258,7 +13252,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 13262 "inc/vcf/validator_detail_v41.hpp"
+#line 13256 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr847;
 	goto tr597;
@@ -13276,7 +13270,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 13280 "inc/vcf/validator_detail_v41.hpp"
+#line 13274 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 65: goto tr819;
@@ -13331,7 +13325,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 13335 "inc/vcf/validator_detail_v41.hpp"
+#line 13329 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st654;
 	goto tr566;
@@ -13360,7 +13354,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 13364 "inc/vcf/validator_detail_v41.hpp"
+#line 13358 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -13380,7 +13374,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 13384 "inc/vcf/validator_detail_v41.hpp"
+#line 13378 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr854;
 		case 13: goto tr855;
@@ -13397,14 +13391,14 @@ tr854:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 819 "src/vcf/vcf_v41.ragel"
+#line 817 "src/vcf/vcf_v41.ragel"
 	{ {goto st28;} }
 	goto st657;
 st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 13408 "inc/vcf/validator_detail_v41.hpp"
+#line 13402 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 tr858:
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -13422,7 +13416,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 13426 "inc/vcf/validator_detail_v41.hpp"
+#line 13420 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr857;
 		case 13: goto tr858;
@@ -13439,14 +13433,14 @@ tr857:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 820 "src/vcf/vcf_v41.ragel"
+#line 818 "src/vcf/vcf_v41.ragel"
 	{ {goto st656;} }
 	goto st658;
 st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 13450 "inc/vcf/validator_detail_v41.hpp"
+#line 13444 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -14234,7 +14228,7 @@ case 658:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 227 "src/vcf/vcf_v41.ragel"
+#line 225 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
@@ -14267,7 +14261,7 @@ case 658:
 	case 95: 
 	case 96: 
 	case 100: 
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -14286,7 +14280,7 @@ case 658:
 	case 308: 
 	case 309: 
 	case 310: 
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -14326,7 +14320,7 @@ case 658:
 	case 358: 
 	case 359: 
 	case 360: 
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -14360,7 +14354,7 @@ case 658:
 	case 128: 
 	case 129: 
 	case 133: 
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -14406,7 +14400,7 @@ case 658:
 	case 176: 
 	case 177: 
 	case 181: 
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14451,7 +14445,7 @@ case 658:
 	case 224: 
 	case 225: 
 	case 229: 
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -14472,7 +14466,7 @@ case 658:
 	case 241: 
 	case 242: 
 	case 249: 
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -14494,7 +14488,7 @@ case 658:
 	case 369: 
 	case 370: 
 	case 371: 
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -14516,7 +14510,7 @@ case 658:
 	case 258: 
 	case 259: 
 	case 299: 
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -14564,7 +14558,7 @@ case 658:
 	case 427: 
 	case 428: 
 	case 429: 
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 338 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14596,7 +14590,7 @@ case 658:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 357 "src/vcf/vcf_v41.ragel"
+#line 355 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
@@ -14609,7 +14603,7 @@ case 658:
 	break;
 	case 441: 
 	case 442: 
-#line 363 "src/vcf/vcf_v41.ragel"
+#line 361 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st653;}
@@ -14622,7 +14616,7 @@ case 658:
 	break;
 	case 443: 
 	case 444: 
-#line 369 "src/vcf/vcf_v41.ragel"
+#line 367 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st653;}
@@ -14635,7 +14629,7 @@ case 658:
 	break;
 	case 445: 
 	case 446: 
-#line 375 "src/vcf/vcf_v41.ragel"
+#line 373 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st653;}
@@ -14683,7 +14677,7 @@ case 658:
 	case 647: 
 	case 648: 
 	case 649: 
-#line 381 "src/vcf/vcf_v41.ragel"
+#line 379 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st653;}
@@ -14707,7 +14701,7 @@ case 658:
 	case 612: 
 	case 613: 
 	case 614: 
-#line 387 "src/vcf/vcf_v41.ragel"
+#line 385 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st653;}
@@ -14723,7 +14717,7 @@ case 658:
 	case 454: 
 	case 603: 
 	case 604: 
-#line 393 "src/vcf/vcf_v41.ragel"
+#line 391 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st653;}
@@ -14736,7 +14730,7 @@ case 658:
 	break;
 	case 458: 
 	case 459: 
-#line 559 "src/vcf/vcf_v41.ragel"
+#line 557 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st653;}
@@ -14749,7 +14743,7 @@ case 658:
 	break;
 	case 461: 
 	case 466: 
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 563 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -14769,7 +14763,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 338 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14800,13 +14794,13 @@ case 658:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 237 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st652;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -14818,12 +14812,12 @@ case 658:
     }
 	break;
 	case 104: 
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14837,12 +14831,12 @@ case 658:
 	case 156: 
 	case 157: 
 	case 185: 
-#line 269 "src/vcf/vcf_v41.ragel"
+#line 267 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14856,12 +14850,12 @@ case 658:
 	case 204: 
 	case 205: 
 	case 233: 
-#line 285 "src/vcf/vcf_v41.ragel"
+#line 283 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -14874,12 +14868,12 @@ case 658:
 	break;
 	case 163: 
 	case 164: 
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14892,12 +14886,12 @@ case 658:
 	break;
 	case 211: 
 	case 212: 
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 288 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -14917,12 +14911,12 @@ case 658:
 	case 269: 
 	case 270: 
 	case 271: 
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 311 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -14942,12 +14936,12 @@ case 658:
 	case 279: 
 	case 280: 
 	case 281: 
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -14960,12 +14954,12 @@ case 658:
 	break;
 	case 340: 
 	case 341: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -14979,12 +14973,12 @@ case 658:
 	case 114: 
 	case 115: 
 	case 116: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -14998,12 +14992,12 @@ case 658:
 	case 146: 
 	case 147: 
 	case 148: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -15017,12 +15011,12 @@ case 658:
 	case 194: 
 	case 195: 
 	case 196: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -15039,12 +15033,12 @@ case 658:
 	case 246: 
 	case 247: 
 	case 248: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -15057,12 +15051,12 @@ case 658:
 	break;
 	case 260: 
 	case 261: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15079,12 +15073,12 @@ case 658:
 	case 101: 
 	case 102: 
 	case 103: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -15101,12 +15095,12 @@ case 658:
 	case 134: 
 	case 135: 
 	case 136: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -15123,12 +15117,12 @@ case 658:
 	case 182: 
 	case 183: 
 	case 184: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -15145,12 +15139,12 @@ case 658:
 	case 230: 
 	case 231: 
 	case 232: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -15180,12 +15174,12 @@ case 658:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15215,12 +15209,12 @@ case 658:
 	case 327: 
 	case 328: 
 	case 329: 
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -15252,12 +15246,12 @@ case 658:
 	case 390: 
 	case 391: 
 	case 392: 
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 332 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -15315,12 +15309,12 @@ case 658:
 	case 597: 
 	case 598: 
 	case 602: 
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15333,12 +15327,12 @@ case 658:
 	break;
 	case 475: 
 	case 476: 
-#line 409 "src/vcf/vcf_v41.ragel"
+#line 407 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15351,7 +15345,7 @@ case 658:
 	break;
 	case 482: 
 	case 483: 
-#line 414 "src/vcf/vcf_v41.ragel"
+#line 412 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15359,7 +15353,7 @@ case 658:
                 "AA"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15372,7 +15366,7 @@ case 658:
 	break;
 	case 485: 
 	case 486: 
-#line 422 "src/vcf/vcf_v41.ragel"
+#line 420 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15380,7 +15374,7 @@ case 658:
                 "AC"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15404,7 +15398,7 @@ case 658:
 	case 498: 
 	case 499: 
 	case 500: 
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 428 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15412,7 +15406,7 @@ case 658:
                 "AF"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15425,7 +15419,7 @@ case 658:
 	break;
 	case 502: 
 	case 503: 
-#line 438 "src/vcf/vcf_v41.ragel"
+#line 436 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15433,7 +15427,7 @@ case 658:
                 "AN"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15457,7 +15451,7 @@ case 658:
 	case 516: 
 	case 517: 
 	case 518: 
-#line 446 "src/vcf/vcf_v41.ragel"
+#line 444 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15465,7 +15459,7 @@ case 658:
                 "BQ"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15479,7 +15473,7 @@ case 658:
 	case 524: 
 	case 525: 
 	case 526: 
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 452 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15487,7 +15481,7 @@ case 658:
                 "CIGAR"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15500,7 +15494,7 @@ case 658:
 	break;
 	case 529: 
 	case 530: 
-#line 462 "src/vcf/vcf_v41.ragel"
+#line 460 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15508,7 +15502,7 @@ case 658:
                 "DB"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15521,7 +15515,7 @@ case 658:
 	break;
 	case 532: 
 	case 533: 
-#line 470 "src/vcf/vcf_v41.ragel"
+#line 468 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15529,7 +15523,7 @@ case 658:
                 "DP"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15542,7 +15536,7 @@ case 658:
 	break;
 	case 537: 
 	case 538: 
-#line 478 "src/vcf/vcf_v41.ragel"
+#line 476 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15550,7 +15544,7 @@ case 658:
                 "END"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15563,7 +15557,7 @@ case 658:
 	break;
 	case 541: 
 	case 542: 
-#line 486 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15571,7 +15565,7 @@ case 658:
                 "H2"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15584,7 +15578,7 @@ case 658:
 	break;
 	case 544: 
 	case 545: 
-#line 494 "src/vcf/vcf_v41.ragel"
+#line 492 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15592,7 +15586,7 @@ case 658:
                 "H3"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15616,7 +15610,7 @@ case 658:
 	case 561: 
 	case 562: 
 	case 563: 
-#line 502 "src/vcf/vcf_v41.ragel"
+#line 500 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15624,7 +15618,7 @@ case 658:
                 "MQ"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15637,7 +15631,7 @@ case 658:
 	break;
 	case 549: 
 	case 550: 
-#line 510 "src/vcf/vcf_v41.ragel"
+#line 508 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15645,7 +15639,7 @@ case 658:
                 "MQ0"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15658,7 +15652,7 @@ case 658:
 	break;
 	case 566: 
 	case 567: 
-#line 518 "src/vcf/vcf_v41.ragel"
+#line 516 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15666,7 +15660,7 @@ case 658:
                 "NS"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15690,7 +15684,7 @@ case 658:
 	case 580: 
 	case 581: 
 	case 582: 
-#line 526 "src/vcf/vcf_v41.ragel"
+#line 524 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15698,7 +15692,7 @@ case 658:
                 "SB"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15711,7 +15705,7 @@ case 658:
 	break;
 	case 589: 
 	case 590: 
-#line 534 "src/vcf/vcf_v41.ragel"
+#line 532 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15719,7 +15713,7 @@ case 658:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15732,7 +15726,7 @@ case 658:
 	break;
 	case 600: 
 	case 601: 
-#line 542 "src/vcf/vcf_v41.ragel"
+#line 540 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15740,7 +15734,7 @@ case 658:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15753,7 +15747,7 @@ case 658:
 	break;
 	case 478: 
 	case 479: 
-#line 550 "src/vcf/vcf_v41.ragel"
+#line 548 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15761,7 +15755,7 @@ case 658:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15776,14 +15770,14 @@ case 658:
 	case 467: 
 	case 468: 
 	case 469: 
-#line 572 "src/vcf/vcf_v41.ragel"
+#line 570 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 563 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -15807,7 +15801,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 338 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -15836,17 +15830,17 @@ case 658:
     }
 	break;
 	case 272: 
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 311 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15858,17 +15852,17 @@ case 658:
     }
 	break;
 	case 282: 
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 316 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 327 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15880,17 +15874,17 @@ case 658:
     }
 	break;
 	case 262: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 322 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 311 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15902,7 +15896,7 @@ case 658:
     }
 	break;
 	case 528: 
-#line 462 "src/vcf/vcf_v41.ragel"
+#line 460 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15910,12 +15904,12 @@ case 658:
                 "DB"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15927,7 +15921,7 @@ case 658:
     }
 	break;
 	case 540: 
-#line 486 "src/vcf/vcf_v41.ragel"
+#line 484 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15935,12 +15929,12 @@ case 658:
                 "H2"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15952,7 +15946,7 @@ case 658:
     }
 	break;
 	case 543: 
-#line 494 "src/vcf/vcf_v41.ragel"
+#line 492 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15960,12 +15954,12 @@ case 658:
                 "H3"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15977,7 +15971,7 @@ case 658:
     }
 	break;
 	case 588: 
-#line 534 "src/vcf/vcf_v41.ragel"
+#line 532 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15985,12 +15979,12 @@ case 658:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -16002,7 +15996,7 @@ case 658:
     }
 	break;
 	case 599: 
-#line 542 "src/vcf/vcf_v41.ragel"
+#line 540 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -16010,12 +16004,12 @@ case 658:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -16027,7 +16021,7 @@ case 658:
     }
 	break;
 	case 477: 
-#line 550 "src/vcf/vcf_v41.ragel"
+#line 548 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -16035,12 +16029,12 @@ case 658:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 402 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 397 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -16052,47 +16046,47 @@ case 658:
     }
 	break;
 	case 24: 
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 232 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 256 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 262 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 278 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 244 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 250 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 306 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 294 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 300 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -16103,14 +16097,14 @@ case 658:
         p--; {goto st652;}
     }
 	break;
-#line 16107 "inc/vcf/validator_detail_v41.hpp"
+#line 16101 "inc/vcf/validator_detail_v41.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 851 "src/vcf/vcf_v41.ragel"
+#line 847 "src/vcf/vcf_v41.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 825 "src/vcf/vcf_v42.ragel"
+#line 823 "src/vcf/vcf_v42.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v42_en_meta_section_skip = 724;
 static const int vcf_v42_en_body_section_skip = 725;
 
 
-#line 831 "src/vcf/vcf_v42.ragel"
+#line 829 "src/vcf/vcf_v42.ragel"
 
 }
 
@@ -49,18 +49,16 @@ namespace ebi
   {
    
     template <typename Configuration>
-    ParserImpl_v42<Configuration>::ParserImpl_v42(std::shared_ptr<Source> const & source,
-                                                  std::shared_ptr<std::vector<Record>> const & records
-    )
-    : ParserImpl{source, records}
+    ParserImpl_v42<Configuration>::ParserImpl_v42(std::shared_ptr<Source> source)
+    : ParserImpl{source}
     {
       
-#line 59 "inc/vcf/validator_detail_v42.hpp"
+#line 57 "inc/vcf/validator_detail_v42.hpp"
 	{
 	cs = vcf_v42_start;
 	}
 
-#line 847 "src/vcf/vcf_v42.ragel"
+#line 843 "src/vcf/vcf_v42.ragel"
 
     }
 
@@ -68,7 +66,7 @@ namespace ebi
     void ParserImpl_v42<Configuration>::parse_buffer(char const * p, char const * pe, char const * eof)
     {
       
-#line 72 "inc/vcf/validator_detail_v42.hpp"
+#line 70 "inc/vcf/validator_detail_v42.hpp"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -86,7 +84,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 227 "src/vcf/vcf_v42.ragel"
+#line 225 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
@@ -109,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 338 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -143,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 338 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -172,47 +170,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -231,7 +229,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -243,13 +241,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 239 "src/vcf/vcf_v42.ragel"
+#line 237 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -261,12 +259,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -278,12 +276,12 @@ tr152:
     }
 	goto st0;
 tr161:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -295,17 +293,17 @@ tr161:
     }
 	goto st0;
 tr175:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -317,17 +315,17 @@ tr175:
     }
 	goto st0;
 tr187:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -339,12 +337,12 @@ tr187:
     }
 	goto st0;
 tr193:
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -356,7 +354,7 @@ tr193:
     }
 	goto st0;
 tr196:
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -368,12 +366,12 @@ tr196:
     }
 	goto st0;
 tr206:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -385,12 +383,12 @@ tr206:
     }
 	goto st0;
 tr225:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -402,17 +400,17 @@ tr225:
     }
 	goto st0;
 tr247:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -424,17 +422,17 @@ tr247:
     }
 	goto st0;
 tr259:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -446,7 +444,7 @@ tr259:
     }
 	goto st0;
 tr265:
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -458,12 +456,12 @@ tr265:
     }
 	goto st0;
 tr275:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -475,12 +473,12 @@ tr275:
     }
 	goto st0;
 tr288:
-#line 269 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -492,12 +490,12 @@ tr288:
     }
 	goto st0;
 tr297:
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -509,12 +507,12 @@ tr297:
     }
 	goto st0;
 tr314:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -526,17 +524,17 @@ tr314:
     }
 	goto st0;
 tr336:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -548,17 +546,17 @@ tr336:
     }
 	goto st0;
 tr348:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -570,7 +568,7 @@ tr348:
     }
 	goto st0;
 tr355:
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -582,12 +580,12 @@ tr355:
     }
 	goto st0;
 tr364:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -599,12 +597,12 @@ tr364:
     }
 	goto st0;
 tr377:
-#line 285 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -616,12 +614,12 @@ tr377:
     }
 	goto st0;
 tr386:
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -633,12 +631,12 @@ tr386:
     }
 	goto st0;
 tr403:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -650,17 +648,17 @@ tr403:
     }
 	goto st0;
 tr425:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -672,17 +670,17 @@ tr425:
     }
 	goto st0;
 tr437:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -694,7 +692,7 @@ tr437:
     }
 	goto st0;
 tr444:
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -706,12 +704,12 @@ tr444:
     }
 	goto st0;
 tr454:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -723,7 +721,7 @@ tr454:
     }
 	goto st0;
 tr466:
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -735,12 +733,12 @@ tr466:
     }
 	goto st0;
 tr477:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -752,17 +750,17 @@ tr477:
     }
 	goto st0;
 tr482:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -774,12 +772,12 @@ tr482:
     }
 	goto st0;
 tr484:
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -791,17 +789,17 @@ tr484:
     }
 	goto st0;
 tr494:
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -813,12 +811,12 @@ tr494:
     }
 	goto st0;
 tr497:
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -830,17 +828,17 @@ tr497:
     }
 	goto st0;
 tr507:
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -852,12 +850,12 @@ tr507:
     }
 	goto st0;
 tr510:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -869,7 +867,7 @@ tr510:
     }
 	goto st0;
 tr533:
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -881,12 +879,12 @@ tr533:
     }
 	goto st0;
 tr542:
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 332 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -898,7 +896,7 @@ tr542:
     }
 	goto st0;
 tr563:
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -910,12 +908,12 @@ tr563:
     }
 	goto st0;
 tr574:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -927,7 +925,7 @@ tr574:
     }
 	goto st0;
 tr612:
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -939,12 +937,12 @@ tr612:
     }
 	goto st0;
 tr624:
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 332 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -956,7 +954,7 @@ tr624:
     }
 	goto st0;
 tr647:
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 338 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -1000,7 +998,7 @@ tr687:
     }
 	goto st0;
 tr702:
-#line 357 "src/vcf/vcf_v42.ragel"
+#line 355 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
@@ -1012,7 +1010,7 @@ tr702:
     }
 	goto st0;
 tr705:
-#line 363 "src/vcf/vcf_v42.ragel"
+#line 361 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st725;}
@@ -1024,7 +1022,7 @@ tr705:
     }
 	goto st0;
 tr709:
-#line 369 "src/vcf/vcf_v42.ragel"
+#line 367 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st725;}
@@ -1036,7 +1034,7 @@ tr709:
     }
 	goto st0;
 tr714:
-#line 375 "src/vcf/vcf_v42.ragel"
+#line 373 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st725;}
@@ -1048,7 +1046,7 @@ tr714:
     }
 	goto st0;
 tr718:
-#line 381 "src/vcf/vcf_v42.ragel"
+#line 379 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st725;}
@@ -1060,7 +1058,7 @@ tr718:
     }
 	goto st0;
 tr727:
-#line 387 "src/vcf/vcf_v42.ragel"
+#line 385 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st725;}
@@ -1072,7 +1070,7 @@ tr727:
     }
 	goto st0;
 tr738:
-#line 393 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st725;}
@@ -1084,12 +1082,12 @@ tr738:
     }
 	goto st0;
 tr746:
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1101,7 +1099,7 @@ tr746:
     }
 	goto st0;
 tr768:
-#line 559 "src/vcf/vcf_v42.ragel"
+#line 557 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st725;}
@@ -1113,14 +1111,14 @@ tr768:
     }
 	goto st0;
 tr773:
-#line 572 "src/vcf/vcf_v42.ragel"
+#line 570 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 563 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1134,7 +1132,7 @@ tr773:
     }
 	goto st0;
 tr777:
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 563 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1155,12 +1153,12 @@ tr784:
     }
 	goto st0;
 tr793:
-#line 409 "src/vcf/vcf_v42.ragel"
+#line 407 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1172,7 +1170,7 @@ tr793:
     }
 	goto st0;
 tr795:
-#line 550 "src/vcf/vcf_v42.ragel"
+#line 548 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1180,12 +1178,12 @@ tr795:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1197,7 +1195,7 @@ tr795:
     }
 	goto st0;
 tr797:
-#line 550 "src/vcf/vcf_v42.ragel"
+#line 548 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1205,7 +1203,7 @@ tr797:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1217,7 +1215,7 @@ tr797:
     }
 	goto st0;
 tr804:
-#line 414 "src/vcf/vcf_v42.ragel"
+#line 412 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1225,7 +1223,7 @@ tr804:
                 "AA"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1237,7 +1235,7 @@ tr804:
     }
 	goto st0;
 tr807:
-#line 422 "src/vcf/vcf_v42.ragel"
+#line 420 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1245,7 +1243,7 @@ tr807:
                 "AC"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1257,7 +1255,7 @@ tr807:
     }
 	goto st0;
 tr810:
-#line 430 "src/vcf/vcf_v42.ragel"
+#line 428 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1265,7 +1263,7 @@ tr810:
                 "AF"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1277,7 +1275,7 @@ tr810:
     }
 	goto st0;
 tr824:
-#line 438 "src/vcf/vcf_v42.ragel"
+#line 436 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1285,7 +1283,7 @@ tr824:
                 "AN"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1297,7 +1295,7 @@ tr824:
     }
 	goto st0;
 tr828:
-#line 446 "src/vcf/vcf_v42.ragel"
+#line 444 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1305,7 +1303,7 @@ tr828:
                 "BQ"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1317,7 +1315,7 @@ tr828:
     }
 	goto st0;
 tr846:
-#line 454 "src/vcf/vcf_v42.ragel"
+#line 452 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1325,7 +1323,7 @@ tr846:
                 "CIGAR"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1337,7 +1335,7 @@ tr846:
     }
 	goto st0;
 tr851:
-#line 462 "src/vcf/vcf_v42.ragel"
+#line 460 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1345,12 +1343,12 @@ tr851:
                 "DB"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1362,7 +1360,7 @@ tr851:
     }
 	goto st0;
 tr853:
-#line 462 "src/vcf/vcf_v42.ragel"
+#line 460 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1370,7 +1368,7 @@ tr853:
                 "DB"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1382,7 +1380,7 @@ tr853:
     }
 	goto st0;
 tr856:
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 468 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1390,7 +1388,7 @@ tr856:
                 "DP"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1402,7 +1400,7 @@ tr856:
     }
 	goto st0;
 tr861:
-#line 478 "src/vcf/vcf_v42.ragel"
+#line 476 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1410,7 +1408,7 @@ tr861:
                 "END"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1422,7 +1420,7 @@ tr861:
     }
 	goto st0;
 tr865:
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1430,12 +1428,12 @@ tr865:
                 "H2"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1447,7 +1445,7 @@ tr865:
     }
 	goto st0;
 tr867:
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1455,7 +1453,7 @@ tr867:
                 "H2"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1467,7 +1465,7 @@ tr867:
     }
 	goto st0;
 tr869:
-#line 494 "src/vcf/vcf_v42.ragel"
+#line 492 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1475,12 +1473,12 @@ tr869:
                 "H3"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1492,7 +1490,7 @@ tr869:
     }
 	goto st0;
 tr871:
-#line 494 "src/vcf/vcf_v42.ragel"
+#line 492 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1500,7 +1498,7 @@ tr871:
                 "H3"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1512,7 +1510,7 @@ tr871:
     }
 	goto st0;
 tr877:
-#line 510 "src/vcf/vcf_v42.ragel"
+#line 508 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1520,7 +1518,7 @@ tr877:
                 "MQ0"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1532,7 +1530,7 @@ tr877:
     }
 	goto st0;
 tr879:
-#line 502 "src/vcf/vcf_v42.ragel"
+#line 500 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1540,7 +1538,7 @@ tr879:
                 "MQ"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1552,7 +1550,7 @@ tr879:
     }
 	goto st0;
 tr894:
-#line 518 "src/vcf/vcf_v42.ragel"
+#line 516 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1560,7 +1558,7 @@ tr894:
                 "NS"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1572,7 +1570,7 @@ tr894:
     }
 	goto st0;
 tr899:
-#line 526 "src/vcf/vcf_v42.ragel"
+#line 524 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1580,7 +1578,7 @@ tr899:
                 "SB"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1592,7 +1590,7 @@ tr899:
     }
 	goto st0;
 tr917:
-#line 534 "src/vcf/vcf_v42.ragel"
+#line 532 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1600,12 +1598,12 @@ tr917:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1617,7 +1615,7 @@ tr917:
     }
 	goto st0;
 tr919:
-#line 534 "src/vcf/vcf_v42.ragel"
+#line 532 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1625,7 +1623,7 @@ tr919:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1637,7 +1635,7 @@ tr919:
     }
 	goto st0;
 tr929:
-#line 542 "src/vcf/vcf_v42.ragel"
+#line 540 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1645,12 +1643,12 @@ tr929:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1662,7 +1660,7 @@ tr929:
     }
 	goto st0;
 tr931:
-#line 542 "src/vcf/vcf_v42.ragel"
+#line 540 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1670,7 +1668,7 @@ tr931:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1695,7 +1693,7 @@ tr980:
         
         p--; {goto st725;}
     }
-#line 357 "src/vcf/vcf_v42.ragel"
+#line 355 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
@@ -1706,7 +1704,7 @@ tr980:
         p--; {goto st725;}
     }
 	goto st0;
-#line 1710 "inc/vcf/validator_detail_v42.hpp"
+#line 1708 "inc/vcf/validator_detail_v42.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1815,7 +1813,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1819 "inc/vcf/validator_detail_v42.hpp"
+#line 1817 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1829,7 +1827,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1833 "inc/vcf/validator_detail_v42.hpp"
+#line 1831 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1843,7 +1841,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1847 "inc/vcf/validator_detail_v42.hpp"
+#line 1845 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1857,7 +1855,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1861 "inc/vcf/validator_detail_v42.hpp"
+#line 1859 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1871,7 +1869,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1875 "inc/vcf/validator_detail_v42.hpp"
+#line 1873 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1885,7 +1883,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1889 "inc/vcf/validator_detail_v42.hpp"
+#line 1887 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 50 )
 		goto tr21;
 	goto tr14;
@@ -1899,7 +1897,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1903 "inc/vcf/validator_detail_v42.hpp"
+#line 1901 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -1930,7 +1928,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1934 "inc/vcf/validator_detail_v42.hpp"
+#line 1932 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1983,7 +1981,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1987 "inc/vcf/validator_detail_v42.hpp"
+#line 1985 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1999,7 +1997,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2003 "inc/vcf/validator_detail_v42.hpp"
+#line 2001 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2027,7 +2025,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2031 "inc/vcf/validator_detail_v42.hpp"
+#line 2029 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -2083,7 +2081,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2087 "inc/vcf/validator_detail_v42.hpp"
+#line 2085 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -2135,7 +2133,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2139 "inc/vcf/validator_detail_v42.hpp"
+#line 2137 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -2170,7 +2168,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2174 "inc/vcf/validator_detail_v42.hpp"
+#line 2172 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2198,7 +2196,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2202 "inc/vcf/validator_detail_v42.hpp"
+#line 2200 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2224,7 +2222,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2228 "inc/vcf/validator_detail_v42.hpp"
+#line 2226 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2246,7 +2244,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2250 "inc/vcf/validator_detail_v42.hpp"
+#line 2248 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2307,7 +2305,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2311 "inc/vcf/validator_detail_v42.hpp"
+#line 2309 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2335,7 +2333,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2339 "inc/vcf/validator_detail_v42.hpp"
+#line 2337 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
@@ -2359,7 +2357,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2363 "inc/vcf/validator_detail_v42.hpp"
+#line 2361 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2381,7 +2379,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2385 "inc/vcf/validator_detail_v42.hpp"
+#line 2383 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2400,7 +2398,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2404 "inc/vcf/validator_detail_v42.hpp"
+#line 2402 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2420,7 +2418,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2424 "inc/vcf/validator_detail_v42.hpp"
+#line 2422 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2455,7 +2453,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2459 "inc/vcf/validator_detail_v42.hpp"
+#line 2457 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2482,7 +2480,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2486 "inc/vcf/validator_detail_v42.hpp"
+#line 2484 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2514,7 +2512,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2518 "inc/vcf/validator_detail_v42.hpp"
+#line 2516 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2535,7 +2533,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2539 "inc/vcf/validator_detail_v42.hpp"
+#line 2537 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2560,7 +2558,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2564 "inc/vcf/validator_detail_v42.hpp"
+#line 2562 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2595,7 +2593,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2599 "inc/vcf/validator_detail_v42.hpp"
+#line 2597 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2622,7 +2620,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2626 "inc/vcf/validator_detail_v42.hpp"
+#line 2624 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2665,7 +2663,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2669 "inc/vcf/validator_detail_v42.hpp"
+#line 2667 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2693,7 +2691,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2697 "inc/vcf/validator_detail_v42.hpp"
+#line 2695 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2719,7 +2717,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2723 "inc/vcf/validator_detail_v42.hpp"
+#line 2721 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2741,7 +2739,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2745 "inc/vcf/validator_detail_v42.hpp"
+#line 2743 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2781,7 +2779,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2785 "inc/vcf/validator_detail_v42.hpp"
+#line 2783 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2832,7 +2830,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2836 "inc/vcf/validator_detail_v42.hpp"
+#line 2834 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2883,7 +2881,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2887 "inc/vcf/validator_detail_v42.hpp"
+#line 2885 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2926,7 +2924,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2930 "inc/vcf/validator_detail_v42.hpp"
+#line 2928 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2956,7 +2954,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2960 "inc/vcf/validator_detail_v42.hpp"
+#line 2958 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2996,7 +2994,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 3000 "inc/vcf/validator_detail_v42.hpp"
+#line 2998 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3026,7 +3024,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3030 "inc/vcf/validator_detail_v42.hpp"
+#line 3028 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -3046,7 +3044,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3050 "inc/vcf/validator_detail_v42.hpp"
+#line 3048 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -3087,7 +3085,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3091 "inc/vcf/validator_detail_v42.hpp"
+#line 3089 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -3115,7 +3113,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3119 "inc/vcf/validator_detail_v42.hpp"
+#line 3117 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -3137,7 +3135,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3141 "inc/vcf/validator_detail_v42.hpp"
+#line 3139 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -3167,7 +3165,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3171 "inc/vcf/validator_detail_v42.hpp"
+#line 3169 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3218,7 +3216,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3222 "inc/vcf/validator_detail_v42.hpp"
+#line 3220 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3269,7 +3267,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3273 "inc/vcf/validator_detail_v42.hpp"
+#line 3271 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3312,7 +3310,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3316 "inc/vcf/validator_detail_v42.hpp"
+#line 3314 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3342,7 +3340,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3346 "inc/vcf/validator_detail_v42.hpp"
+#line 3344 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3372,7 +3370,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3376 "inc/vcf/validator_detail_v42.hpp"
+#line 3374 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3402,7 +3400,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3406 "inc/vcf/validator_detail_v42.hpp"
+#line 3404 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3426,7 +3424,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3430 "inc/vcf/validator_detail_v42.hpp"
+#line 3428 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3444,7 +3442,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3448 "inc/vcf/validator_detail_v42.hpp"
+#line 3446 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3471,7 +3469,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3475 "inc/vcf/validator_detail_v42.hpp"
+#line 3473 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3543,7 +3541,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3547 "inc/vcf/validator_detail_v42.hpp"
+#line 3545 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3597,7 +3595,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3601 "inc/vcf/validator_detail_v42.hpp"
+#line 3599 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3618,7 +3616,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3622 "inc/vcf/validator_detail_v42.hpp"
+#line 3620 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3716,7 +3714,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3720 "inc/vcf/validator_detail_v42.hpp"
+#line 3718 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3744,7 +3742,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3748 "inc/vcf/validator_detail_v42.hpp"
+#line 3746 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3772,7 +3770,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3776 "inc/vcf/validator_detail_v42.hpp"
+#line 3774 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3806,7 +3804,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3810 "inc/vcf/validator_detail_v42.hpp"
+#line 3808 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3841,7 +3839,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3845 "inc/vcf/validator_detail_v42.hpp"
+#line 3843 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr166;
 		case 95: goto tr165;
@@ -3868,7 +3866,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3872 "inc/vcf/validator_detail_v42.hpp"
+#line 3870 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr125;
@@ -3903,7 +3901,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3907 "inc/vcf/validator_detail_v42.hpp"
+#line 3905 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr171;
@@ -3931,7 +3929,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3935 "inc/vcf/validator_detail_v42.hpp"
+#line 3933 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr172;
 		case 92: goto tr171;
@@ -3953,7 +3951,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3957 "inc/vcf/validator_detail_v42.hpp"
+#line 3955 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr173;
@@ -3983,7 +3981,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3987 "inc/vcf/validator_detail_v42.hpp"
+#line 3985 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4034,7 +4032,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4038 "inc/vcf/validator_detail_v42.hpp"
+#line 4036 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4085,7 +4083,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4089 "inc/vcf/validator_detail_v42.hpp"
+#line 4087 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4128,7 +4126,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4132 "inc/vcf/validator_detail_v42.hpp"
+#line 4130 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr171;
@@ -4146,7 +4144,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4150 "inc/vcf/validator_detail_v42.hpp"
+#line 4148 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 44: goto tr182;
@@ -4176,7 +4174,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4180 "inc/vcf/validator_detail_v42.hpp"
+#line 4178 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4215,7 +4213,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4219 "inc/vcf/validator_detail_v42.hpp"
+#line 4217 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr184;
 		case 92: goto tr158;
@@ -4237,7 +4235,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4241 "inc/vcf/validator_detail_v42.hpp"
+#line 4239 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr185;
@@ -4257,7 +4255,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4261 "inc/vcf/validator_detail_v42.hpp"
+#line 4259 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4308,7 +4306,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4312 "inc/vcf/validator_detail_v42.hpp"
+#line 4310 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4359,7 +4357,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4363 "inc/vcf/validator_detail_v42.hpp"
+#line 4361 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4402,7 +4400,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4406 "inc/vcf/validator_detail_v42.hpp"
+#line 4404 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr158;
@@ -4420,7 +4418,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4424 "inc/vcf/validator_detail_v42.hpp"
+#line 4422 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4444,7 +4442,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4448 "inc/vcf/validator_detail_v42.hpp"
+#line 4446 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr194;
@@ -4463,7 +4461,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4467 "inc/vcf/validator_detail_v42.hpp"
+#line 4465 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr197;
@@ -4481,7 +4479,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4485 "inc/vcf/validator_detail_v42.hpp"
+#line 4483 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr198;
@@ -4499,7 +4497,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4503 "inc/vcf/validator_detail_v42.hpp"
+#line 4501 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr199;
@@ -4517,7 +4515,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4521 "inc/vcf/validator_detail_v42.hpp"
+#line 4519 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st127;
@@ -4544,7 +4542,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4548 "inc/vcf/validator_detail_v42.hpp"
+#line 4546 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr196;
@@ -4601,7 +4599,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4605 "inc/vcf/validator_detail_v42.hpp"
+#line 4603 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4640,7 +4638,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4644 "inc/vcf/validator_detail_v42.hpp"
+#line 4642 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr211;
 		case 95: goto tr210;
@@ -4667,7 +4665,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4671 "inc/vcf/validator_detail_v42.hpp"
+#line 4669 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr196;
@@ -4765,7 +4763,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4769 "inc/vcf/validator_detail_v42.hpp"
+#line 4767 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 92: goto tr228;
@@ -4793,7 +4791,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4797 "inc/vcf/validator_detail_v42.hpp"
+#line 4795 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr231;
@@ -4821,7 +4819,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4825 "inc/vcf/validator_detail_v42.hpp"
+#line 4823 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4855,7 +4853,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4859 "inc/vcf/validator_detail_v42.hpp"
+#line 4857 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4890,7 +4888,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4894 "inc/vcf/validator_detail_v42.hpp"
+#line 4892 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr238;
 		case 95: goto tr237;
@@ -4917,7 +4915,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 4921 "inc/vcf/validator_detail_v42.hpp"
+#line 4919 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr196;
@@ -4952,7 +4950,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 4956 "inc/vcf/validator_detail_v42.hpp"
+#line 4954 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr243;
@@ -4980,7 +4978,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4984 "inc/vcf/validator_detail_v42.hpp"
+#line 4982 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr244;
 		case 92: goto tr243;
@@ -5002,7 +5000,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5006 "inc/vcf/validator_detail_v42.hpp"
+#line 5004 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr245;
@@ -5032,7 +5030,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5036 "inc/vcf/validator_detail_v42.hpp"
+#line 5034 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5083,7 +5081,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5087 "inc/vcf/validator_detail_v42.hpp"
+#line 5085 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5134,7 +5132,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5138 "inc/vcf/validator_detail_v42.hpp"
+#line 5136 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5177,7 +5175,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5181 "inc/vcf/validator_detail_v42.hpp"
+#line 5179 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr243;
@@ -5195,7 +5193,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5199 "inc/vcf/validator_detail_v42.hpp"
+#line 5197 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 44: goto tr254;
@@ -5225,7 +5223,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5229 "inc/vcf/validator_detail_v42.hpp"
+#line 5227 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5264,7 +5262,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5268 "inc/vcf/validator_detail_v42.hpp"
+#line 5266 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr256;
 		case 92: goto tr231;
@@ -5286,7 +5284,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5290 "inc/vcf/validator_detail_v42.hpp"
+#line 5288 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr257;
@@ -5306,7 +5304,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5310 "inc/vcf/validator_detail_v42.hpp"
+#line 5308 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5357,7 +5355,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5361 "inc/vcf/validator_detail_v42.hpp"
+#line 5359 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5408,7 +5406,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5412 "inc/vcf/validator_detail_v42.hpp"
+#line 5410 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5451,7 +5449,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5455 "inc/vcf/validator_detail_v42.hpp"
+#line 5453 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr231;
@@ -5469,7 +5467,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5473 "inc/vcf/validator_detail_v42.hpp"
+#line 5471 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5489,7 +5487,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5493 "inc/vcf/validator_detail_v42.hpp"
+#line 5491 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr266;
@@ -5507,7 +5505,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5511 "inc/vcf/validator_detail_v42.hpp"
+#line 5509 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr267;
@@ -5525,7 +5523,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5529 "inc/vcf/validator_detail_v42.hpp"
+#line 5527 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr268;
@@ -5543,7 +5541,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5547 "inc/vcf/validator_detail_v42.hpp"
+#line 5545 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st177;
@@ -5570,7 +5568,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5574 "inc/vcf/validator_detail_v42.hpp"
+#line 5572 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr265;
@@ -5627,7 +5625,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5631 "inc/vcf/validator_detail_v42.hpp"
+#line 5629 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5666,7 +5664,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5670 "inc/vcf/validator_detail_v42.hpp"
+#line 5668 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr280;
 		case 95: goto tr279;
@@ -5693,7 +5691,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5697 "inc/vcf/validator_detail_v42.hpp"
+#line 5695 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr265;
@@ -5770,7 +5768,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5774 "inc/vcf/validator_detail_v42.hpp"
+#line 5772 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	goto tr288;
@@ -5784,7 +5782,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5788 "inc/vcf/validator_detail_v42.hpp"
+#line 5786 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr265;
@@ -5850,7 +5848,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5854 "inc/vcf/validator_detail_v42.hpp"
+#line 5852 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr299;
 	if ( (*p) > 90 ) {
@@ -5869,7 +5867,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5873 "inc/vcf/validator_detail_v42.hpp"
+#line 5871 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr265;
@@ -5967,7 +5965,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 5971 "inc/vcf/validator_detail_v42.hpp"
+#line 5969 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 92: goto tr317;
@@ -5995,7 +5993,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 5999 "inc/vcf/validator_detail_v42.hpp"
+#line 5997 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr320;
@@ -6023,7 +6021,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6027 "inc/vcf/validator_detail_v42.hpp"
+#line 6025 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6057,7 +6055,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6061 "inc/vcf/validator_detail_v42.hpp"
+#line 6059 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6092,7 +6090,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6096 "inc/vcf/validator_detail_v42.hpp"
+#line 6094 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr327;
 		case 95: goto tr326;
@@ -6119,7 +6117,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6123 "inc/vcf/validator_detail_v42.hpp"
+#line 6121 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr265;
@@ -6154,7 +6152,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6158 "inc/vcf/validator_detail_v42.hpp"
+#line 6156 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr332;
@@ -6182,7 +6180,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6186 "inc/vcf/validator_detail_v42.hpp"
+#line 6184 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr333;
 		case 92: goto tr332;
@@ -6204,7 +6202,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6208 "inc/vcf/validator_detail_v42.hpp"
+#line 6206 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr334;
@@ -6234,7 +6232,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6238 "inc/vcf/validator_detail_v42.hpp"
+#line 6236 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6285,7 +6283,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6289 "inc/vcf/validator_detail_v42.hpp"
+#line 6287 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6336,7 +6334,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6340 "inc/vcf/validator_detail_v42.hpp"
+#line 6338 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6379,7 +6377,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6383 "inc/vcf/validator_detail_v42.hpp"
+#line 6381 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr332;
@@ -6397,7 +6395,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6401 "inc/vcf/validator_detail_v42.hpp"
+#line 6399 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 44: goto tr343;
@@ -6427,7 +6425,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6431 "inc/vcf/validator_detail_v42.hpp"
+#line 6429 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6466,7 +6464,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6470 "inc/vcf/validator_detail_v42.hpp"
+#line 6468 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr345;
 		case 92: goto tr320;
@@ -6488,7 +6486,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6492 "inc/vcf/validator_detail_v42.hpp"
+#line 6490 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr346;
@@ -6508,7 +6506,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6512 "inc/vcf/validator_detail_v42.hpp"
+#line 6510 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6559,7 +6557,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6563 "inc/vcf/validator_detail_v42.hpp"
+#line 6561 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6610,7 +6608,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6614 "inc/vcf/validator_detail_v42.hpp"
+#line 6612 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6653,7 +6651,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6657 "inc/vcf/validator_detail_v42.hpp"
+#line 6655 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr320;
@@ -6671,7 +6669,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6675 "inc/vcf/validator_detail_v42.hpp"
+#line 6673 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6705,7 +6703,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6709 "inc/vcf/validator_detail_v42.hpp"
+#line 6707 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6725,7 +6723,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6729 "inc/vcf/validator_detail_v42.hpp"
+#line 6727 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr356;
@@ -6743,7 +6741,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6747 "inc/vcf/validator_detail_v42.hpp"
+#line 6745 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr357;
@@ -6761,7 +6759,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6765 "inc/vcf/validator_detail_v42.hpp"
+#line 6763 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st243;
@@ -6788,7 +6786,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6792 "inc/vcf/validator_detail_v42.hpp"
+#line 6790 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr355;
@@ -6845,7 +6843,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6849 "inc/vcf/validator_detail_v42.hpp"
+#line 6847 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6884,7 +6882,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6888 "inc/vcf/validator_detail_v42.hpp"
+#line 6886 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr369;
 		case 95: goto tr368;
@@ -6911,7 +6909,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 6915 "inc/vcf/validator_detail_v42.hpp"
+#line 6913 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr355;
@@ -6988,7 +6986,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 6992 "inc/vcf/validator_detail_v42.hpp"
+#line 6990 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	goto tr377;
@@ -7002,7 +7000,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7006 "inc/vcf/validator_detail_v42.hpp"
+#line 7004 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr355;
@@ -7068,7 +7066,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7072 "inc/vcf/validator_detail_v42.hpp"
+#line 7070 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) > 90 ) {
@@ -7087,7 +7085,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7091 "inc/vcf/validator_detail_v42.hpp"
+#line 7089 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr355;
@@ -7185,7 +7183,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7189 "inc/vcf/validator_detail_v42.hpp"
+#line 7187 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 92: goto tr406;
@@ -7213,7 +7211,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7217 "inc/vcf/validator_detail_v42.hpp"
+#line 7215 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr409;
@@ -7241,7 +7239,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7245 "inc/vcf/validator_detail_v42.hpp"
+#line 7243 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7275,7 +7273,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7279 "inc/vcf/validator_detail_v42.hpp"
+#line 7277 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7310,7 +7308,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7314 "inc/vcf/validator_detail_v42.hpp"
+#line 7312 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr416;
 		case 95: goto tr415;
@@ -7337,7 +7335,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7341 "inc/vcf/validator_detail_v42.hpp"
+#line 7339 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr355;
@@ -7372,7 +7370,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7376 "inc/vcf/validator_detail_v42.hpp"
+#line 7374 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr421;
@@ -7400,7 +7398,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7404 "inc/vcf/validator_detail_v42.hpp"
+#line 7402 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr422;
 		case 92: goto tr421;
@@ -7422,7 +7420,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7426 "inc/vcf/validator_detail_v42.hpp"
+#line 7424 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr423;
@@ -7452,7 +7450,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7456 "inc/vcf/validator_detail_v42.hpp"
+#line 7454 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7503,7 +7501,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7507 "inc/vcf/validator_detail_v42.hpp"
+#line 7505 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7554,7 +7552,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7558 "inc/vcf/validator_detail_v42.hpp"
+#line 7556 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7597,7 +7595,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7601 "inc/vcf/validator_detail_v42.hpp"
+#line 7599 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr421;
@@ -7615,7 +7613,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7619 "inc/vcf/validator_detail_v42.hpp"
+#line 7617 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 44: goto tr432;
@@ -7645,7 +7643,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7649 "inc/vcf/validator_detail_v42.hpp"
+#line 7647 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7684,7 +7682,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7688 "inc/vcf/validator_detail_v42.hpp"
+#line 7686 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr434;
 		case 92: goto tr409;
@@ -7706,7 +7704,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7710 "inc/vcf/validator_detail_v42.hpp"
+#line 7708 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr435;
@@ -7726,7 +7724,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7730 "inc/vcf/validator_detail_v42.hpp"
+#line 7728 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7777,7 +7775,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7781 "inc/vcf/validator_detail_v42.hpp"
+#line 7779 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7828,7 +7826,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7832 "inc/vcf/validator_detail_v42.hpp"
+#line 7830 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7871,7 +7869,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7875 "inc/vcf/validator_detail_v42.hpp"
+#line 7873 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr409;
@@ -7889,7 +7887,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7893 "inc/vcf/validator_detail_v42.hpp"
+#line 7891 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7923,7 +7921,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 7927 "inc/vcf/validator_detail_v42.hpp"
+#line 7925 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -7943,7 +7941,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 7947 "inc/vcf/validator_detail_v42.hpp"
+#line 7945 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr445;
@@ -7961,7 +7959,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 7965 "inc/vcf/validator_detail_v42.hpp"
+#line 7963 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr446;
@@ -7979,7 +7977,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 7983 "inc/vcf/validator_detail_v42.hpp"
+#line 7981 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr447;
@@ -7997,7 +7995,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 8001 "inc/vcf/validator_detail_v42.hpp"
+#line 7999 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr448;
@@ -8015,7 +8013,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8019 "inc/vcf/validator_detail_v42.hpp"
+#line 8017 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr449;
@@ -8033,7 +8031,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 8037 "inc/vcf/validator_detail_v42.hpp"
+#line 8035 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr450;
@@ -8051,7 +8049,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 8055 "inc/vcf/validator_detail_v42.hpp"
+#line 8053 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st313;
@@ -8078,7 +8076,7 @@ st314:
 	if ( ++p == pe )
 		goto _test_eof314;
 case 314:
-#line 8082 "inc/vcf/validator_detail_v42.hpp"
+#line 8080 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st315;
 	goto tr444;
@@ -8092,7 +8090,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8096 "inc/vcf/validator_detail_v42.hpp"
+#line 8094 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr455;
 	if ( (*p) < 48 ) {
@@ -8117,7 +8115,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8121 "inc/vcf/validator_detail_v42.hpp"
+#line 8119 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st316;
 	if ( (*p) < 48 ) {
@@ -8152,7 +8150,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8156 "inc/vcf/validator_detail_v42.hpp"
+#line 8154 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr459;
 		case 95: goto tr458;
@@ -8179,7 +8177,7 @@ st318:
 	if ( ++p == pe )
 		goto _test_eof318;
 case 318:
-#line 8183 "inc/vcf/validator_detail_v42.hpp"
+#line 8181 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr460;
 	if ( (*p) < 48 ) {
@@ -8204,7 +8202,7 @@ st319:
 	if ( ++p == pe )
 		goto _test_eof319;
 case 319:
-#line 8208 "inc/vcf/validator_detail_v42.hpp"
+#line 8206 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st319;
 	if ( (*p) < 48 ) {
@@ -8239,7 +8237,7 @@ st320:
 	if ( ++p == pe )
 		goto _test_eof320;
 case 320:
-#line 8243 "inc/vcf/validator_detail_v42.hpp"
+#line 8241 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr464;
 		case 62: goto tr465;
@@ -8267,7 +8265,7 @@ st321:
 	if ( ++p == pe )
 		goto _test_eof321;
 case 321:
-#line 8271 "inc/vcf/validator_detail_v42.hpp"
+#line 8269 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8287,7 +8285,7 @@ st322:
 	if ( ++p == pe )
 		goto _test_eof322;
 case 322:
-#line 8291 "inc/vcf/validator_detail_v42.hpp"
+#line 8289 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr467;
@@ -8305,7 +8303,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 8309 "inc/vcf/validator_detail_v42.hpp"
+#line 8307 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr468;
@@ -8323,7 +8321,7 @@ st324:
 	if ( ++p == pe )
 		goto _test_eof324;
 case 324:
-#line 8327 "inc/vcf/validator_detail_v42.hpp"
+#line 8325 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr469;
@@ -8341,7 +8339,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8345 "inc/vcf/validator_detail_v42.hpp"
+#line 8343 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr470;
@@ -8359,7 +8357,7 @@ st326:
 	if ( ++p == pe )
 		goto _test_eof326;
 case 326:
-#line 8363 "inc/vcf/validator_detail_v42.hpp"
+#line 8361 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st327;
@@ -8386,7 +8384,7 @@ st328:
 	if ( ++p == pe )
 		goto _test_eof328;
 case 328:
-#line 8390 "inc/vcf/validator_detail_v42.hpp"
+#line 8388 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st329;
 	goto tr466;
@@ -8443,7 +8441,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 8447 "inc/vcf/validator_detail_v42.hpp"
+#line 8445 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st333;
 	if ( (*p) < 48 ) {
@@ -8482,7 +8480,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 8486 "inc/vcf/validator_detail_v42.hpp"
+#line 8484 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr483;
 		case 95: goto tr481;
@@ -8509,7 +8507,7 @@ st335:
 	if ( ++p == pe )
 		goto _test_eof335;
 case 335:
-#line 8513 "inc/vcf/validator_detail_v42.hpp"
+#line 8511 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 71 )
 		goto st336;
 	goto tr484;
@@ -8602,7 +8600,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 8606 "inc/vcf/validator_detail_v42.hpp"
+#line 8604 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr496;
 	if ( (*p) < 35 ) {
@@ -8624,7 +8622,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 8628 "inc/vcf/validator_detail_v42.hpp"
+#line 8626 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 77 )
 		goto st346;
 	goto tr497;
@@ -8717,7 +8715,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8721 "inc/vcf/validator_detail_v42.hpp"
+#line 8719 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr509;
 	if ( (*p) < 35 ) {
@@ -8739,7 +8737,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8743 "inc/vcf/validator_detail_v42.hpp"
+#line 8741 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st356;
 	goto tr510;
@@ -8837,7 +8835,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 8841 "inc/vcf/validator_detail_v42.hpp"
+#line 8839 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr525;
 		case 92: goto tr526;
@@ -8865,7 +8863,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 8869 "inc/vcf/validator_detail_v42.hpp"
+#line 8867 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 92: goto tr529;
@@ -8893,7 +8891,7 @@ st370:
 	if ( ++p == pe )
 		goto _test_eof370;
 case 370:
-#line 8897 "inc/vcf/validator_detail_v42.hpp"
+#line 8895 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st371;
 	goto tr510;
@@ -8926,7 +8924,7 @@ st372:
 	if ( ++p == pe )
 		goto _test_eof372;
 case 372:
-#line 8930 "inc/vcf/validator_detail_v42.hpp"
+#line 8928 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr531;
 		case 92: goto tr529;
@@ -8948,7 +8946,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 8952 "inc/vcf/validator_detail_v42.hpp"
+#line 8950 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 62: goto tr532;
@@ -8967,7 +8965,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 8971 "inc/vcf/validator_detail_v42.hpp"
+#line 8969 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8991,7 +8989,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8995 "inc/vcf/validator_detail_v42.hpp"
+#line 8993 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr534;
@@ -9009,7 +9007,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 9013 "inc/vcf/validator_detail_v42.hpp"
+#line 9011 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr535;
@@ -9027,7 +9025,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 9031 "inc/vcf/validator_detail_v42.hpp"
+#line 9029 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr536;
@@ -9045,7 +9043,7 @@ st378:
 	if ( ++p == pe )
 		goto _test_eof378;
 case 378:
-#line 9049 "inc/vcf/validator_detail_v42.hpp"
+#line 9047 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr537;
@@ -9063,7 +9061,7 @@ st379:
 	if ( ++p == pe )
 		goto _test_eof379;
 case 379:
-#line 9067 "inc/vcf/validator_detail_v42.hpp"
+#line 9065 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr538;
@@ -9081,7 +9079,7 @@ st380:
 	if ( ++p == pe )
 		goto _test_eof380;
 case 380:
-#line 9085 "inc/vcf/validator_detail_v42.hpp"
+#line 9083 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr539;
@@ -9099,7 +9097,7 @@ st381:
 	if ( ++p == pe )
 		goto _test_eof381;
 case 381:
-#line 9103 "inc/vcf/validator_detail_v42.hpp"
+#line 9101 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st382;
@@ -9126,7 +9124,7 @@ st383:
 	if ( ++p == pe )
 		goto _test_eof383;
 case 383:
-#line 9130 "inc/vcf/validator_detail_v42.hpp"
+#line 9128 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr543;
@@ -9143,7 +9141,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 9147 "inc/vcf/validator_detail_v42.hpp"
+#line 9145 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9169,7 +9167,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9173 "inc/vcf/validator_detail_v42.hpp"
+#line 9171 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9292,7 +9290,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9296 "inc/vcf/validator_detail_v42.hpp"
+#line 9294 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr559;
@@ -9360,7 +9358,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 9364 "inc/vcf/validator_detail_v42.hpp"
+#line 9362 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr564;
@@ -9378,7 +9376,7 @@ st403:
 	if ( ++p == pe )
 		goto _test_eof403;
 case 403:
-#line 9382 "inc/vcf/validator_detail_v42.hpp"
+#line 9380 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr565;
@@ -9396,7 +9394,7 @@ st404:
 	if ( ++p == pe )
 		goto _test_eof404;
 case 404:
-#line 9400 "inc/vcf/validator_detail_v42.hpp"
+#line 9398 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr566;
@@ -9414,7 +9412,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 9418 "inc/vcf/validator_detail_v42.hpp"
+#line 9416 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr567;
@@ -9432,7 +9430,7 @@ st406:
 	if ( ++p == pe )
 		goto _test_eof406;
 case 406:
-#line 9436 "inc/vcf/validator_detail_v42.hpp"
+#line 9434 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st407;
@@ -9459,7 +9457,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9463 "inc/vcf/validator_detail_v42.hpp"
+#line 9461 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st409;
 	goto tr563;
@@ -9521,7 +9519,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9525 "inc/vcf/validator_detail_v42.hpp"
+#line 9523 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 59: goto tr576;
@@ -9543,7 +9541,7 @@ st414:
 	if ( ++p == pe )
 		goto _test_eof414;
 case 414:
-#line 9547 "inc/vcf/validator_detail_v42.hpp"
+#line 9545 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr579;
 	if ( (*p) < 48 ) {
@@ -9568,7 +9566,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9572 "inc/vcf/validator_detail_v42.hpp"
+#line 9570 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st415;
 	if ( (*p) < 48 ) {
@@ -9603,7 +9601,7 @@ st416:
 	if ( ++p == pe )
 		goto _test_eof416;
 case 416:
-#line 9607 "inc/vcf/validator_detail_v42.hpp"
+#line 9605 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr583;
 		case 95: goto tr582;
@@ -9630,7 +9628,7 @@ st417:
 	if ( ++p == pe )
 		goto _test_eof417;
 case 417:
-#line 9634 "inc/vcf/validator_detail_v42.hpp"
+#line 9632 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st420;
 	if ( (*p) < 45 ) {
@@ -9662,7 +9660,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 9666 "inc/vcf/validator_detail_v42.hpp"
+#line 9664 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 62: goto tr578;
@@ -9683,7 +9681,7 @@ st419:
 	if ( ++p == pe )
 		goto _test_eof419;
 case 419:
-#line 9687 "inc/vcf/validator_detail_v42.hpp"
+#line 9685 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -9720,7 +9718,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9724 "inc/vcf/validator_detail_v42.hpp"
+#line 9722 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 92: goto tr592;
@@ -9748,7 +9746,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9752 "inc/vcf/validator_detail_v42.hpp"
+#line 9750 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st414;
 		case 62: goto st419;
@@ -9774,7 +9772,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9778 "inc/vcf/validator_detail_v42.hpp"
+#line 9776 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 92: goto tr592;
@@ -9796,7 +9794,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9800 "inc/vcf/validator_detail_v42.hpp"
+#line 9798 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr596;
@@ -9836,7 +9834,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9840 "inc/vcf/validator_detail_v42.hpp"
+#line 9838 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9887,7 +9885,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9891 "inc/vcf/validator_detail_v42.hpp"
+#line 9889 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9938,7 +9936,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9942 "inc/vcf/validator_detail_v42.hpp"
+#line 9940 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9981,7 +9979,7 @@ st428:
 	if ( ++p == pe )
 		goto _test_eof428;
 case 428:
-#line 9985 "inc/vcf/validator_detail_v42.hpp"
+#line 9983 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr604;
 		case 44: goto tr590;
@@ -10011,7 +10009,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 10015 "inc/vcf/validator_detail_v42.hpp"
+#line 10013 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr607;
@@ -10051,7 +10049,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 10055 "inc/vcf/validator_detail_v42.hpp"
+#line 10053 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -10081,7 +10079,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 10085 "inc/vcf/validator_detail_v42.hpp"
+#line 10083 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 44: goto tr607;
@@ -10101,7 +10099,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 10105 "inc/vcf/validator_detail_v42.hpp"
+#line 10103 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr588;
 		case 44: goto tr610;
@@ -10125,7 +10123,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10129 "inc/vcf/validator_detail_v42.hpp"
+#line 10127 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr613;
@@ -10143,7 +10141,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10147 "inc/vcf/validator_detail_v42.hpp"
+#line 10145 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr614;
@@ -10161,7 +10159,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10165 "inc/vcf/validator_detail_v42.hpp"
+#line 10163 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr615;
@@ -10179,7 +10177,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10183 "inc/vcf/validator_detail_v42.hpp"
+#line 10181 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr616;
@@ -10197,7 +10195,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10201 "inc/vcf/validator_detail_v42.hpp"
+#line 10199 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr617;
@@ -10215,7 +10213,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10219 "inc/vcf/validator_detail_v42.hpp"
+#line 10217 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr618;
@@ -10233,7 +10231,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10237 "inc/vcf/validator_detail_v42.hpp"
+#line 10235 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr619;
@@ -10251,7 +10249,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10255 "inc/vcf/validator_detail_v42.hpp"
+#line 10253 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr620;
@@ -10269,7 +10267,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10273 "inc/vcf/validator_detail_v42.hpp"
+#line 10271 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st442;
@@ -10296,7 +10294,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10300 "inc/vcf/validator_detail_v42.hpp"
+#line 10298 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st444;
 	goto tr612;
@@ -10320,7 +10318,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10324 "inc/vcf/validator_detail_v42.hpp"
+#line 10322 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10346,7 +10344,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10350 "inc/vcf/validator_detail_v42.hpp"
+#line 10348 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10457,7 +10455,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 10461 "inc/vcf/validator_detail_v42.hpp"
+#line 10459 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr641;
@@ -10478,7 +10476,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 10482 "inc/vcf/validator_detail_v42.hpp"
+#line 10480 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr643;
@@ -10513,7 +10511,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 10517 "inc/vcf/validator_detail_v42.hpp"
+#line 10515 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr641;
@@ -10613,7 +10611,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10617 "inc/vcf/validator_detail_v42.hpp"
+#line 10615 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 80 )
 		goto st471;
 	goto tr647;
@@ -10648,7 +10646,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10652 "inc/vcf/validator_detail_v42.hpp"
+#line 10650 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st475;
 	goto tr647;
@@ -10676,7 +10674,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 10680 "inc/vcf/validator_detail_v42.hpp"
+#line 10678 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 82 )
 		goto st478;
 	goto tr647;
@@ -10711,7 +10709,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10715 "inc/vcf/validator_detail_v42.hpp"
+#line 10713 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 65 )
 		goto st482;
 	goto tr647;
@@ -10746,7 +10744,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10750 "inc/vcf/validator_detail_v42.hpp"
+#line 10748 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 81 )
 		goto st486;
 	goto tr647;
@@ -10788,7 +10786,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10792 "inc/vcf/validator_detail_v42.hpp"
+#line 10790 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st491;
 	goto tr647;
@@ -10844,7 +10842,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10848 "inc/vcf/validator_detail_v42.hpp"
+#line 10846 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st498;
 	goto tr647;
@@ -10889,7 +10887,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10893 "inc/vcf/validator_detail_v42.hpp"
+#line 10891 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st503;
 	goto tr687;
@@ -10955,7 +10953,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10959 "inc/vcf/validator_detail_v42.hpp"
+#line 10957 "inc/vcf/validator_detail_v42.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr695;
 	goto tr687;
@@ -10979,7 +10977,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10983 "inc/vcf/validator_detail_v42.hpp"
+#line 10981 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr696;
 		case 10: goto tr697;
@@ -11028,7 +11026,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 11032 "inc/vcf/validator_detail_v42.hpp"
+#line 11030 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr981;
 		case 13: goto tr982;
@@ -11079,7 +11077,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 11083 "inc/vcf/validator_detail_v42.hpp"
+#line 11081 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr985;
 		case 13: goto tr986;
@@ -11121,7 +11119,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11125 "inc/vcf/validator_detail_v42.hpp"
+#line 11123 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st727;
 	goto st0;
@@ -11163,7 +11161,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11167 "inc/vcf/validator_detail_v42.hpp"
+#line 11165 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr703;
 		case 59: goto tr704;
@@ -11206,7 +11204,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11210 "inc/vcf/validator_detail_v42.hpp"
+#line 11208 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr706;
 	goto tr705;
@@ -11230,7 +11228,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11234 "inc/vcf/validator_detail_v42.hpp"
+#line 11232 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr707;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11260,7 +11258,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11264 "inc/vcf/validator_detail_v42.hpp"
+#line 11262 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr710;
@@ -11287,7 +11285,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11291 "inc/vcf/validator_detail_v42.hpp"
+#line 11289 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr711;
 		case 59: goto tr713;
@@ -11313,7 +11311,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11317 "inc/vcf/validator_detail_v42.hpp"
+#line 11315 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr715;
 		case 67: goto tr715;
@@ -11347,7 +11345,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11351 "inc/vcf/validator_detail_v42.hpp"
+#line 11349 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr716;
 		case 65: goto tr717;
@@ -11380,7 +11378,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11384 "inc/vcf/validator_detail_v42.hpp"
+#line 11382 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr720;
@@ -11419,7 +11417,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11423 "inc/vcf/validator_detail_v42.hpp"
+#line 11421 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -11443,7 +11441,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11447 "inc/vcf/validator_detail_v42.hpp"
+#line 11445 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr728;
 		case 45: goto tr728;
@@ -11468,7 +11466,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11472 "inc/vcf/validator_detail_v42.hpp"
+#line 11470 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr734;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11494,7 +11492,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11498 "inc/vcf/validator_detail_v42.hpp"
+#line 11496 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 46: goto tr736;
@@ -11522,7 +11520,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11526 "inc/vcf/validator_detail_v42.hpp"
+#line 11524 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr740;
 		case 58: goto tr739;
@@ -11558,7 +11556,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11562 "inc/vcf/validator_detail_v42.hpp"
+#line 11560 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto st525;
 	if ( (*p) < 65 ) {
@@ -11602,7 +11600,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11606 "inc/vcf/validator_detail_v42.hpp"
+#line 11604 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 59: goto tr745;
@@ -11628,7 +11626,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11632 "inc/vcf/validator_detail_v42.hpp"
+#line 11630 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr748;
 		case 49: goto tr750;
@@ -11686,7 +11684,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11690 "inc/vcf/validator_detail_v42.hpp"
+#line 11688 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr761;
 		case 60: goto tr761;
@@ -11732,7 +11730,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 11736 "inc/vcf/validator_detail_v42.hpp"
+#line 11734 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -11767,7 +11765,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 11771 "inc/vcf/validator_detail_v42.hpp"
+#line 11769 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr769;
@@ -11797,7 +11795,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 11801 "inc/vcf/validator_detail_v42.hpp"
+#line 11799 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 58: goto tr772;
@@ -11829,7 +11827,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 11833 "inc/vcf/validator_detail_v42.hpp"
+#line 11831 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr775;
 	if ( (*p) < 48 ) {
@@ -11861,7 +11859,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 11865 "inc/vcf/validator_detail_v42.hpp"
+#line 11863 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -11886,16 +11884,14 @@ tr764:
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
-                    ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
+                ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -11920,7 +11916,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 11924 "inc/vcf/validator_detail_v42.hpp"
+#line 11920 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr985;
 		case 13: goto tr986;
@@ -11949,7 +11945,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 11953 "inc/vcf/validator_detail_v42.hpp"
+#line 11949 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr780;
@@ -11979,7 +11975,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 11983 "inc/vcf/validator_detail_v42.hpp"
+#line 11979 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr781;
 		case 62: goto tr782;
@@ -12003,7 +11999,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12007 "inc/vcf/validator_detail_v42.hpp"
+#line 12003 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr783;
 	goto tr702;
@@ -12022,16 +12018,14 @@ tr765:
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
-                    ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
+                ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -12056,7 +12050,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12060 "inc/vcf/validator_detail_v42.hpp"
+#line 12054 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st728;
 	goto tr784;
@@ -12070,7 +12064,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12074 "inc/vcf/validator_detail_v42.hpp"
+#line 12068 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr778;
@@ -12097,7 +12091,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12101 "inc/vcf/validator_detail_v42.hpp"
+#line 12095 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12119,7 +12113,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12123 "inc/vcf/validator_detail_v42.hpp"
+#line 12117 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12156,7 +12150,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12160 "inc/vcf/validator_detail_v42.hpp"
+#line 12154 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12184,7 +12178,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12188 "inc/vcf/validator_detail_v42.hpp"
+#line 12182 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 49: goto tr750;
 		case 58: goto tr747;
@@ -12235,7 +12229,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12239 "inc/vcf/validator_detail_v42.hpp"
+#line 12233 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12257,7 +12251,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12261 "inc/vcf/validator_detail_v42.hpp"
+#line 12255 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12279,7 +12273,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12283 "inc/vcf/validator_detail_v42.hpp"
+#line 12277 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12301,7 +12295,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12305 "inc/vcf/validator_detail_v42.hpp"
+#line 12299 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12323,7 +12317,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12327 "inc/vcf/validator_detail_v42.hpp"
+#line 12321 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr794;
@@ -12340,7 +12334,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12344 "inc/vcf/validator_detail_v42.hpp"
+#line 12338 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12360,7 +12354,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12364 "inc/vcf/validator_detail_v42.hpp"
+#line 12358 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12381,7 +12375,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12385 "inc/vcf/validator_detail_v42.hpp"
+#line 12379 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr798;
 	goto tr797;
@@ -12395,7 +12389,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12399 "inc/vcf/validator_detail_v42.hpp"
+#line 12393 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12417,7 +12411,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12421 "inc/vcf/validator_detail_v42.hpp"
+#line 12415 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12442,7 +12436,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12446 "inc/vcf/validator_detail_v42.hpp"
+#line 12440 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr803;
 	if ( (*p) > 58 ) {
@@ -12461,7 +12455,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12465 "inc/vcf/validator_detail_v42.hpp"
+#line 12459 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr805;
 	if ( (*p) < 45 ) {
@@ -12483,7 +12477,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12487 "inc/vcf/validator_detail_v42.hpp"
+#line 12481 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12509,7 +12503,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12513 "inc/vcf/validator_detail_v42.hpp"
+#line 12507 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr806;
 	if ( (*p) > 58 ) {
@@ -12528,7 +12522,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12532 "inc/vcf/validator_detail_v42.hpp"
+#line 12526 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr808;
 	goto tr807;
@@ -12542,7 +12536,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12546 "inc/vcf/validator_detail_v42.hpp"
+#line 12540 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12563,7 +12557,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12567 "inc/vcf/validator_detail_v42.hpp"
+#line 12561 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr809;
 	if ( (*p) > 58 ) {
@@ -12582,7 +12576,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12586 "inc/vcf/validator_detail_v42.hpp"
+#line 12580 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr811;
 		case 45: goto tr811;
@@ -12602,7 +12596,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 12606 "inc/vcf/validator_detail_v42.hpp"
+#line 12600 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr813;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12618,7 +12612,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 12622 "inc/vcf/validator_detail_v42.hpp"
+#line 12616 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12642,7 +12636,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12646 "inc/vcf/validator_detail_v42.hpp"
+#line 12640 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr817;
 	goto tr810;
@@ -12656,7 +12650,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 12660 "inc/vcf/validator_detail_v42.hpp"
+#line 12654 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12679,7 +12673,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 12683 "inc/vcf/validator_detail_v42.hpp"
+#line 12677 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr818;
 		case 45: goto tr818;
@@ -12697,7 +12691,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 12701 "inc/vcf/validator_detail_v42.hpp"
+#line 12695 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr819;
 	goto tr810;
@@ -12711,7 +12705,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 12715 "inc/vcf/validator_detail_v42.hpp"
+#line 12709 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12732,7 +12726,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12736 "inc/vcf/validator_detail_v42.hpp"
+#line 12730 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr820;
 	goto tr810;
@@ -12746,7 +12740,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 12750 "inc/vcf/validator_detail_v42.hpp"
+#line 12744 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr821;
 	goto tr810;
@@ -12760,7 +12754,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 12764 "inc/vcf/validator_detail_v42.hpp"
+#line 12758 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12779,7 +12773,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 12783 "inc/vcf/validator_detail_v42.hpp"
+#line 12777 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr822;
 	goto tr810;
@@ -12793,7 +12787,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 12797 "inc/vcf/validator_detail_v42.hpp"
+#line 12791 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr821;
 	goto tr810;
@@ -12807,7 +12801,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 12811 "inc/vcf/validator_detail_v42.hpp"
+#line 12805 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr823;
 	if ( (*p) > 58 ) {
@@ -12826,7 +12820,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 12830 "inc/vcf/validator_detail_v42.hpp"
+#line 12824 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr825;
 	goto tr824;
@@ -12840,7 +12834,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12844 "inc/vcf/validator_detail_v42.hpp"
+#line 12838 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12864,7 +12858,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12868 "inc/vcf/validator_detail_v42.hpp"
+#line 12862 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12886,7 +12880,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12890 "inc/vcf/validator_detail_v42.hpp"
+#line 12884 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr827;
 	if ( (*p) > 58 ) {
@@ -12905,7 +12899,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12909 "inc/vcf/validator_detail_v42.hpp"
+#line 12903 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr829;
 		case 45: goto tr829;
@@ -12925,7 +12919,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12929 "inc/vcf/validator_detail_v42.hpp"
+#line 12923 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr831;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12941,7 +12935,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12945 "inc/vcf/validator_detail_v42.hpp"
+#line 12939 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12964,7 +12958,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12968 "inc/vcf/validator_detail_v42.hpp"
+#line 12962 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr828;
@@ -12978,7 +12972,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12982 "inc/vcf/validator_detail_v42.hpp"
+#line 12976 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13000,7 +12994,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 13004 "inc/vcf/validator_detail_v42.hpp"
+#line 12998 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr836;
 		case 45: goto tr836;
@@ -13018,7 +13012,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 13022 "inc/vcf/validator_detail_v42.hpp"
+#line 13016 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr837;
 	goto tr828;
@@ -13032,7 +13026,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 13036 "inc/vcf/validator_detail_v42.hpp"
+#line 13030 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13052,7 +13046,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 13056 "inc/vcf/validator_detail_v42.hpp"
+#line 13050 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr838;
 	goto tr828;
@@ -13066,7 +13060,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 13070 "inc/vcf/validator_detail_v42.hpp"
+#line 13064 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr839;
 	goto tr828;
@@ -13080,7 +13074,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 13084 "inc/vcf/validator_detail_v42.hpp"
+#line 13078 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13098,7 +13092,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 13102 "inc/vcf/validator_detail_v42.hpp"
+#line 13096 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr840;
 	goto tr828;
@@ -13112,7 +13106,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 13116 "inc/vcf/validator_detail_v42.hpp"
+#line 13110 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr839;
 	goto tr828;
@@ -13130,7 +13124,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 13134 "inc/vcf/validator_detail_v42.hpp"
+#line 13128 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13152,7 +13146,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 13156 "inc/vcf/validator_detail_v42.hpp"
+#line 13150 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13174,7 +13168,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 13178 "inc/vcf/validator_detail_v42.hpp"
+#line 13172 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13196,7 +13190,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13200 "inc/vcf/validator_detail_v42.hpp"
+#line 13194 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13218,7 +13212,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13222 "inc/vcf/validator_detail_v42.hpp"
+#line 13216 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr845;
 	if ( (*p) > 58 ) {
@@ -13237,7 +13231,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13241 "inc/vcf/validator_detail_v42.hpp"
+#line 13235 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr847;
 	goto tr846;
@@ -13251,7 +13245,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13255 "inc/vcf/validator_detail_v42.hpp"
+#line 13249 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 68: goto tr848;
 		case 80: goto tr848;
@@ -13277,7 +13271,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13281 "inc/vcf/validator_detail_v42.hpp"
+#line 13275 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13301,7 +13295,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13305 "inc/vcf/validator_detail_v42.hpp"
+#line 13299 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13324,7 +13318,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13328 "inc/vcf/validator_detail_v42.hpp"
+#line 13322 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13345,7 +13339,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13349 "inc/vcf/validator_detail_v42.hpp"
+#line 13343 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr854;
 	goto tr853;
@@ -13359,7 +13353,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13363 "inc/vcf/validator_detail_v42.hpp"
+#line 13357 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13377,7 +13371,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13381 "inc/vcf/validator_detail_v42.hpp"
+#line 13375 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr855;
 	if ( (*p) > 58 ) {
@@ -13396,7 +13390,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13400 "inc/vcf/validator_detail_v42.hpp"
+#line 13394 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr857;
 	goto tr856;
@@ -13410,7 +13404,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13414 "inc/vcf/validator_detail_v42.hpp"
+#line 13408 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13434,7 +13428,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13438 "inc/vcf/validator_detail_v42.hpp"
+#line 13432 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13456,7 +13450,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13460 "inc/vcf/validator_detail_v42.hpp"
+#line 13454 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13478,7 +13472,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13482 "inc/vcf/validator_detail_v42.hpp"
+#line 13476 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr860;
 	if ( (*p) > 58 ) {
@@ -13497,7 +13491,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13501 "inc/vcf/validator_detail_v42.hpp"
+#line 13495 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr862;
 	goto tr861;
@@ -13511,7 +13505,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13515 "inc/vcf/validator_detail_v42.hpp"
+#line 13509 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13535,7 +13529,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13539 "inc/vcf/validator_detail_v42.hpp"
+#line 13533 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13558,7 +13552,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13562 "inc/vcf/validator_detail_v42.hpp"
+#line 13556 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13579,7 +13573,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13583 "inc/vcf/validator_detail_v42.hpp"
+#line 13577 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr868;
 	goto tr867;
@@ -13593,7 +13587,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13597 "inc/vcf/validator_detail_v42.hpp"
+#line 13591 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13611,7 +13605,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13615 "inc/vcf/validator_detail_v42.hpp"
+#line 13609 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13632,7 +13626,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13636 "inc/vcf/validator_detail_v42.hpp"
+#line 13630 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr872;
 	goto tr871;
@@ -13646,7 +13640,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13650 "inc/vcf/validator_detail_v42.hpp"
+#line 13644 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13668,7 +13662,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13672 "inc/vcf/validator_detail_v42.hpp"
+#line 13666 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13690,7 +13684,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13694 "inc/vcf/validator_detail_v42.hpp"
+#line 13688 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 48: goto tr874;
 		case 61: goto tr875;
@@ -13711,7 +13705,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13715 "inc/vcf/validator_detail_v42.hpp"
+#line 13709 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr876;
 	if ( (*p) > 58 ) {
@@ -13730,7 +13724,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13734 "inc/vcf/validator_detail_v42.hpp"
+#line 13728 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr878;
 	goto tr877;
@@ -13744,7 +13738,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13748 "inc/vcf/validator_detail_v42.hpp"
+#line 13742 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13764,7 +13758,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13768 "inc/vcf/validator_detail_v42.hpp"
+#line 13762 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr880;
 		case 45: goto tr880;
@@ -13784,7 +13778,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13788 "inc/vcf/validator_detail_v42.hpp"
+#line 13782 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr882;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13800,7 +13794,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13804 "inc/vcf/validator_detail_v42.hpp"
+#line 13798 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13823,7 +13817,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13827 "inc/vcf/validator_detail_v42.hpp"
+#line 13821 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr886;
 	goto tr879;
@@ -13837,7 +13831,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13841 "inc/vcf/validator_detail_v42.hpp"
+#line 13835 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13859,7 +13853,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 13863 "inc/vcf/validator_detail_v42.hpp"
+#line 13857 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr887;
 		case 45: goto tr887;
@@ -13877,7 +13871,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 13881 "inc/vcf/validator_detail_v42.hpp"
+#line 13875 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr888;
 	goto tr879;
@@ -13891,7 +13885,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 13895 "inc/vcf/validator_detail_v42.hpp"
+#line 13889 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13911,7 +13905,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 13915 "inc/vcf/validator_detail_v42.hpp"
+#line 13909 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr889;
 	goto tr879;
@@ -13925,7 +13919,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 13929 "inc/vcf/validator_detail_v42.hpp"
+#line 13923 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr890;
 	goto tr879;
@@ -13939,7 +13933,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 13943 "inc/vcf/validator_detail_v42.hpp"
+#line 13937 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13957,7 +13951,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 13961 "inc/vcf/validator_detail_v42.hpp"
+#line 13955 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr891;
 	goto tr879;
@@ -13971,7 +13965,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 13975 "inc/vcf/validator_detail_v42.hpp"
+#line 13969 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr890;
 	goto tr879;
@@ -13989,7 +13983,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13993 "inc/vcf/validator_detail_v42.hpp"
+#line 13987 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14011,7 +14005,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14015 "inc/vcf/validator_detail_v42.hpp"
+#line 14009 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr893;
 	if ( (*p) > 58 ) {
@@ -14030,7 +14024,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14034 "inc/vcf/validator_detail_v42.hpp"
+#line 14028 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr895;
 	goto tr894;
@@ -14044,7 +14038,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14048 "inc/vcf/validator_detail_v42.hpp"
+#line 14042 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14068,7 +14062,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14072 "inc/vcf/validator_detail_v42.hpp"
+#line 14066 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14091,7 +14085,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14095 "inc/vcf/validator_detail_v42.hpp"
+#line 14089 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr898;
 	if ( (*p) > 58 ) {
@@ -14110,7 +14104,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14114 "inc/vcf/validator_detail_v42.hpp"
+#line 14108 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr900;
 		case 45: goto tr900;
@@ -14130,7 +14124,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14134 "inc/vcf/validator_detail_v42.hpp"
+#line 14128 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr902;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14146,7 +14140,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14150 "inc/vcf/validator_detail_v42.hpp"
+#line 14144 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14169,7 +14163,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14173 "inc/vcf/validator_detail_v42.hpp"
+#line 14167 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr906;
 	goto tr899;
@@ -14183,7 +14177,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14187 "inc/vcf/validator_detail_v42.hpp"
+#line 14181 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14205,7 +14199,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14209 "inc/vcf/validator_detail_v42.hpp"
+#line 14203 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr907;
 		case 45: goto tr907;
@@ -14223,7 +14217,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14227 "inc/vcf/validator_detail_v42.hpp"
+#line 14221 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr908;
 	goto tr899;
@@ -14237,7 +14231,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14241 "inc/vcf/validator_detail_v42.hpp"
+#line 14235 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14257,7 +14251,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14261 "inc/vcf/validator_detail_v42.hpp"
+#line 14255 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr909;
 	goto tr899;
@@ -14271,7 +14265,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14275 "inc/vcf/validator_detail_v42.hpp"
+#line 14269 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr910;
 	goto tr899;
@@ -14285,7 +14279,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14289 "inc/vcf/validator_detail_v42.hpp"
+#line 14283 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14303,7 +14297,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14307 "inc/vcf/validator_detail_v42.hpp"
+#line 14301 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr911;
 	goto tr899;
@@ -14317,7 +14311,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14321 "inc/vcf/validator_detail_v42.hpp"
+#line 14315 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr910;
 	goto tr899;
@@ -14331,7 +14325,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14335 "inc/vcf/validator_detail_v42.hpp"
+#line 14329 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14353,7 +14347,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14357 "inc/vcf/validator_detail_v42.hpp"
+#line 14351 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14375,7 +14369,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14379 "inc/vcf/validator_detail_v42.hpp"
+#line 14373 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14397,7 +14391,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14401 "inc/vcf/validator_detail_v42.hpp"
+#line 14395 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14419,7 +14413,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14423 "inc/vcf/validator_detail_v42.hpp"
+#line 14417 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14441,7 +14435,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14445 "inc/vcf/validator_detail_v42.hpp"
+#line 14439 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14462,7 +14456,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14466 "inc/vcf/validator_detail_v42.hpp"
+#line 14460 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr920;
 	goto tr919;
@@ -14476,7 +14470,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14480 "inc/vcf/validator_detail_v42.hpp"
+#line 14474 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14498,7 +14492,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14502 "inc/vcf/validator_detail_v42.hpp"
+#line 14496 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14520,7 +14514,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14524 "inc/vcf/validator_detail_v42.hpp"
+#line 14518 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14542,7 +14536,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14546 "inc/vcf/validator_detail_v42.hpp"
+#line 14540 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14564,7 +14558,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14568 "inc/vcf/validator_detail_v42.hpp"
+#line 14562 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14586,7 +14580,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14590 "inc/vcf/validator_detail_v42.hpp"
+#line 14584 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14608,7 +14602,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14612 "inc/vcf/validator_detail_v42.hpp"
+#line 14606 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14630,7 +14624,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14634 "inc/vcf/validator_detail_v42.hpp"
+#line 14628 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14652,7 +14646,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14656 "inc/vcf/validator_detail_v42.hpp"
+#line 14650 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14674,7 +14668,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14678 "inc/vcf/validator_detail_v42.hpp"
+#line 14672 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14695,7 +14689,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14699 "inc/vcf/validator_detail_v42.hpp"
+#line 14693 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr932;
 	goto tr931;
@@ -14709,7 +14703,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14713 "inc/vcf/validator_detail_v42.hpp"
+#line 14707 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14731,7 +14725,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14735 "inc/vcf/validator_detail_v42.hpp"
+#line 14729 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14770,7 +14764,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14774 "inc/vcf/validator_detail_v42.hpp"
+#line 14768 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr739;
 	if ( (*p) < 65 ) {
@@ -14808,7 +14802,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14812 "inc/vcf/validator_detail_v42.hpp"
+#line 14806 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 58: goto st525;
@@ -14844,7 +14838,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 14848 "inc/vcf/validator_detail_v42.hpp"
+#line 14842 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr727;
@@ -14858,7 +14852,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 14862 "inc/vcf/validator_detail_v42.hpp"
+#line 14856 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 69: goto tr737;
@@ -14877,7 +14871,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 14881 "inc/vcf/validator_detail_v42.hpp"
+#line 14875 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr934;
 		case 45: goto tr934;
@@ -14895,7 +14889,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 14899 "inc/vcf/validator_detail_v42.hpp"
+#line 14893 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr935;
 	goto tr727;
@@ -14909,7 +14903,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 14913 "inc/vcf/validator_detail_v42.hpp"
+#line 14907 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14935,7 +14929,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 14939 "inc/vcf/validator_detail_v42.hpp"
+#line 14933 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr936;
 	goto tr727;
@@ -14949,7 +14943,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 14953 "inc/vcf/validator_detail_v42.hpp"
+#line 14947 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr937;
 	goto tr727;
@@ -14973,7 +14967,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 14977 "inc/vcf/validator_detail_v42.hpp"
+#line 14971 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	goto tr727;
@@ -14991,7 +14985,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 14995 "inc/vcf/validator_detail_v42.hpp"
+#line 14989 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr938;
 	goto tr727;
@@ -15005,7 +14999,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15009 "inc/vcf/validator_detail_v42.hpp"
+#line 15003 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr937;
 	goto tr727;
@@ -15019,7 +15013,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15023 "inc/vcf/validator_detail_v42.hpp"
+#line 15017 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr939;
@@ -15058,7 +15052,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15062 "inc/vcf/validator_detail_v42.hpp"
+#line 15056 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr940;
 		case 67: goto tr940;
@@ -15082,7 +15076,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15086 "inc/vcf/validator_detail_v42.hpp"
+#line 15080 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15118,7 +15112,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15122 "inc/vcf/validator_detail_v42.hpp"
+#line 15116 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr941;
 	if ( (*p) < 63 ) {
@@ -15158,7 +15152,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15162 "inc/vcf/validator_detail_v42.hpp"
+#line 15156 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto tr943;
 	if ( (*p) < 45 ) {
@@ -15190,7 +15184,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15194 "inc/vcf/validator_detail_v42.hpp"
+#line 15188 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15219,7 +15213,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15223 "inc/vcf/validator_detail_v42.hpp"
+#line 15217 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr948;
 	if ( (*p) < 65 ) {
@@ -15241,7 +15235,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15245 "inc/vcf/validator_detail_v42.hpp"
+#line 15239 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr949;
 		case 61: goto tr947;
@@ -15265,7 +15259,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15269 "inc/vcf/validator_detail_v42.hpp"
+#line 15263 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr950;
 	goto tr718;
@@ -15279,7 +15273,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15283 "inc/vcf/validator_detail_v42.hpp"
+#line 15277 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr943;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15295,7 +15289,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15299 "inc/vcf/validator_detail_v42.hpp"
+#line 15293 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr951;
@@ -15315,7 +15309,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15319 "inc/vcf/validator_detail_v42.hpp"
+#line 15313 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr951;
 		case 62: goto tr952;
@@ -15339,7 +15333,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15343 "inc/vcf/validator_detail_v42.hpp"
+#line 15337 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr949;
 	goto tr718;
@@ -15353,7 +15347,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15357 "inc/vcf/validator_detail_v42.hpp"
+#line 15351 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr954;
 	if ( (*p) < 65 ) {
@@ -15375,7 +15369,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15379 "inc/vcf/validator_detail_v42.hpp"
+#line 15373 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr955;
 		case 61: goto tr953;
@@ -15399,7 +15393,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15403 "inc/vcf/validator_detail_v42.hpp"
+#line 15397 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr718;
@@ -15413,7 +15407,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15417 "inc/vcf/validator_detail_v42.hpp"
+#line 15411 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr943;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15429,7 +15423,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15433 "inc/vcf/validator_detail_v42.hpp"
+#line 15427 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr957;
@@ -15449,7 +15443,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15453 "inc/vcf/validator_detail_v42.hpp"
+#line 15447 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr957;
 		case 62: goto tr958;
@@ -15473,7 +15467,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15477 "inc/vcf/validator_detail_v42.hpp"
+#line 15471 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr955;
 	goto tr718;
@@ -15491,7 +15485,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15495 "inc/vcf/validator_detail_v42.hpp"
+#line 15489 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr960;
 	if ( (*p) < 65 ) {
@@ -15513,7 +15507,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15517 "inc/vcf/validator_detail_v42.hpp"
+#line 15511 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr961;
 		case 61: goto tr959;
@@ -15537,7 +15531,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15541 "inc/vcf/validator_detail_v42.hpp"
+#line 15535 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr962;
 	goto tr718;
@@ -15551,7 +15545,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15555 "inc/vcf/validator_detail_v42.hpp"
+#line 15549 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr963;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15567,7 +15561,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15571 "inc/vcf/validator_detail_v42.hpp"
+#line 15565 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr964;
@@ -15587,7 +15581,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15591 "inc/vcf/validator_detail_v42.hpp"
+#line 15585 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr964;
 		case 62: goto tr965;
@@ -15611,7 +15605,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15615 "inc/vcf/validator_detail_v42.hpp"
+#line 15609 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr961;
 	goto tr718;
@@ -15629,7 +15623,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15633 "inc/vcf/validator_detail_v42.hpp"
+#line 15627 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr967;
 	if ( (*p) < 65 ) {
@@ -15651,7 +15645,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15655 "inc/vcf/validator_detail_v42.hpp"
+#line 15649 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr968;
 		case 61: goto tr966;
@@ -15675,7 +15669,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15679 "inc/vcf/validator_detail_v42.hpp"
+#line 15673 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr969;
 	goto tr718;
@@ -15689,7 +15683,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15693 "inc/vcf/validator_detail_v42.hpp"
+#line 15687 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr963;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15705,7 +15699,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15709 "inc/vcf/validator_detail_v42.hpp"
+#line 15703 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr970;
@@ -15725,7 +15719,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15729 "inc/vcf/validator_detail_v42.hpp"
+#line 15723 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr970;
 		case 62: goto tr971;
@@ -15749,7 +15743,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15753 "inc/vcf/validator_detail_v42.hpp"
+#line 15747 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr968;
 	goto tr718;
@@ -15767,7 +15761,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15771 "inc/vcf/validator_detail_v42.hpp"
+#line 15765 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 65: goto tr940;
@@ -15822,7 +15816,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15826 "inc/vcf/validator_detail_v42.hpp"
+#line 15820 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st726;
 	goto tr687;
@@ -15851,7 +15845,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15855 "inc/vcf/validator_detail_v42.hpp"
+#line 15849 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -15871,7 +15865,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15875 "inc/vcf/validator_detail_v42.hpp"
+#line 15869 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr975;
 		case 13: goto tr976;
@@ -15888,14 +15882,14 @@ tr975:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 823 "src/vcf/vcf_v42.ragel"
+#line 821 "src/vcf/vcf_v42.ragel"
 	{ {goto st28;} }
 	goto st729;
 st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 15899 "inc/vcf/validator_detail_v42.hpp"
+#line 15893 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 tr979:
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -15913,7 +15907,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 15917 "inc/vcf/validator_detail_v42.hpp"
+#line 15911 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr978;
 		case 13: goto tr979;
@@ -15930,14 +15924,14 @@ tr978:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 824 "src/vcf/vcf_v42.ragel"
+#line 822 "src/vcf/vcf_v42.ragel"
 	{ {goto st728;} }
 	goto st730;
 st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 15941 "inc/vcf/validator_detail_v42.hpp"
+#line 15935 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -16797,7 +16791,7 @@ case 730:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 227 "src/vcf/vcf_v42.ragel"
+#line 225 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
@@ -16831,7 +16825,7 @@ case 730:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -16850,7 +16844,7 @@ case 730:
 	case 380: 
 	case 381: 
 	case 382: 
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -16890,7 +16884,7 @@ case 730:
 	case 430: 
 	case 431: 
 	case 432: 
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -16925,7 +16919,7 @@ case 730:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -16972,7 +16966,7 @@ case 730:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17018,7 +17012,7 @@ case 730:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17039,7 +17033,7 @@ case 730:
 	case 313: 
 	case 314: 
 	case 321: 
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -17061,7 +17055,7 @@ case 730:
 	case 441: 
 	case 442: 
 	case 443: 
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -17083,7 +17077,7 @@ case 730:
 	case 330: 
 	case 331: 
 	case 371: 
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17131,7 +17125,7 @@ case 730:
 	case 499: 
 	case 500: 
 	case 501: 
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 338 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17163,7 +17157,7 @@ case 730:
 	case 534: 
 	case 535: 
 	case 536: 
-#line 357 "src/vcf/vcf_v42.ragel"
+#line 355 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
@@ -17176,7 +17170,7 @@ case 730:
 	break;
 	case 513: 
 	case 514: 
-#line 363 "src/vcf/vcf_v42.ragel"
+#line 361 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st725;}
@@ -17189,7 +17183,7 @@ case 730:
 	break;
 	case 515: 
 	case 516: 
-#line 369 "src/vcf/vcf_v42.ragel"
+#line 367 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st725;}
@@ -17202,7 +17196,7 @@ case 730:
 	break;
 	case 517: 
 	case 518: 
-#line 375 "src/vcf/vcf_v42.ragel"
+#line 373 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st725;}
@@ -17250,7 +17244,7 @@ case 730:
 	case 719: 
 	case 720: 
 	case 721: 
-#line 381 "src/vcf/vcf_v42.ragel"
+#line 379 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st725;}
@@ -17274,7 +17268,7 @@ case 730:
 	case 684: 
 	case 685: 
 	case 686: 
-#line 387 "src/vcf/vcf_v42.ragel"
+#line 385 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st725;}
@@ -17290,7 +17284,7 @@ case 730:
 	case 526: 
 	case 675: 
 	case 676: 
-#line 393 "src/vcf/vcf_v42.ragel"
+#line 391 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st725;}
@@ -17303,7 +17297,7 @@ case 730:
 	break;
 	case 530: 
 	case 531: 
-#line 559 "src/vcf/vcf_v42.ragel"
+#line 557 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st725;}
@@ -17316,7 +17310,7 @@ case 730:
 	break;
 	case 533: 
 	case 538: 
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 563 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -17336,7 +17330,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 338 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17367,13 +17361,13 @@ case 730:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 239 "src/vcf/vcf_v42.ragel"
+#line 237 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -17385,12 +17379,12 @@ case 730:
     }
 	break;
 	case 122: 
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17404,12 +17398,12 @@ case 730:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 269 "src/vcf/vcf_v42.ragel"
+#line 267 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17423,12 +17417,12 @@ case 730:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 285 "src/vcf/vcf_v42.ragel"
+#line 283 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17441,12 +17435,12 @@ case 730:
 	break;
 	case 199: 
 	case 200: 
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17459,12 +17453,12 @@ case 730:
 	break;
 	case 265: 
 	case 266: 
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 288 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17484,12 +17478,12 @@ case 730:
 	case 341: 
 	case 342: 
 	case 343: 
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17509,12 +17503,12 @@ case 730:
 	case 351: 
 	case 352: 
 	case 353: 
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17528,12 +17522,12 @@ case 730:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -17546,12 +17540,12 @@ case 730:
 	break;
 	case 412: 
 	case 413: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -17568,12 +17562,12 @@ case 730:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -17590,12 +17584,12 @@ case 730:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17612,12 +17606,12 @@ case 730:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17634,12 +17628,12 @@ case 730:
 	case 318: 
 	case 319: 
 	case 320: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -17652,12 +17646,12 @@ case 730:
 	break;
 	case 332: 
 	case 333: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17682,12 +17676,12 @@ case 730:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -17712,12 +17706,12 @@ case 730:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -17742,12 +17736,12 @@ case 730:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17772,12 +17766,12 @@ case 730:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17807,12 +17801,12 @@ case 730:
 	case 372: 
 	case 373: 
 	case 374: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17842,12 +17836,12 @@ case 730:
 	case 399: 
 	case 400: 
 	case 401: 
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 332 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -17879,12 +17873,12 @@ case 730:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 332 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -17942,12 +17936,12 @@ case 730:
 	case 669: 
 	case 670: 
 	case 674: 
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -17960,12 +17954,12 @@ case 730:
 	break;
 	case 547: 
 	case 548: 
-#line 409 "src/vcf/vcf_v42.ragel"
+#line 407 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -17978,7 +17972,7 @@ case 730:
 	break;
 	case 554: 
 	case 555: 
-#line 414 "src/vcf/vcf_v42.ragel"
+#line 412 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -17986,7 +17980,7 @@ case 730:
                 "AA"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -17999,7 +17993,7 @@ case 730:
 	break;
 	case 557: 
 	case 558: 
-#line 422 "src/vcf/vcf_v42.ragel"
+#line 420 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18007,7 +18001,7 @@ case 730:
                 "AC"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18031,7 +18025,7 @@ case 730:
 	case 570: 
 	case 571: 
 	case 572: 
-#line 430 "src/vcf/vcf_v42.ragel"
+#line 428 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18039,7 +18033,7 @@ case 730:
                 "AF"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18052,7 +18046,7 @@ case 730:
 	break;
 	case 574: 
 	case 575: 
-#line 438 "src/vcf/vcf_v42.ragel"
+#line 436 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18060,7 +18054,7 @@ case 730:
                 "AN"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18084,7 +18078,7 @@ case 730:
 	case 588: 
 	case 589: 
 	case 590: 
-#line 446 "src/vcf/vcf_v42.ragel"
+#line 444 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18092,7 +18086,7 @@ case 730:
                 "BQ"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18106,7 +18100,7 @@ case 730:
 	case 596: 
 	case 597: 
 	case 598: 
-#line 454 "src/vcf/vcf_v42.ragel"
+#line 452 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18114,7 +18108,7 @@ case 730:
                 "CIGAR"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18127,7 +18121,7 @@ case 730:
 	break;
 	case 601: 
 	case 602: 
-#line 462 "src/vcf/vcf_v42.ragel"
+#line 460 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18135,7 +18129,7 @@ case 730:
                 "DB"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18148,7 +18142,7 @@ case 730:
 	break;
 	case 604: 
 	case 605: 
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 468 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18156,7 +18150,7 @@ case 730:
                 "DP"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18169,7 +18163,7 @@ case 730:
 	break;
 	case 609: 
 	case 610: 
-#line 478 "src/vcf/vcf_v42.ragel"
+#line 476 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18177,7 +18171,7 @@ case 730:
                 "END"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18190,7 +18184,7 @@ case 730:
 	break;
 	case 613: 
 	case 614: 
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18198,7 +18192,7 @@ case 730:
                 "H2"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18211,7 +18205,7 @@ case 730:
 	break;
 	case 616: 
 	case 617: 
-#line 494 "src/vcf/vcf_v42.ragel"
+#line 492 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18219,7 +18213,7 @@ case 730:
                 "H3"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18243,7 +18237,7 @@ case 730:
 	case 633: 
 	case 634: 
 	case 635: 
-#line 502 "src/vcf/vcf_v42.ragel"
+#line 500 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18251,7 +18245,7 @@ case 730:
                 "MQ"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18264,7 +18258,7 @@ case 730:
 	break;
 	case 621: 
 	case 622: 
-#line 510 "src/vcf/vcf_v42.ragel"
+#line 508 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18272,7 +18266,7 @@ case 730:
                 "MQ0"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18285,7 +18279,7 @@ case 730:
 	break;
 	case 638: 
 	case 639: 
-#line 518 "src/vcf/vcf_v42.ragel"
+#line 516 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18293,7 +18287,7 @@ case 730:
                 "NS"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18317,7 +18311,7 @@ case 730:
 	case 652: 
 	case 653: 
 	case 654: 
-#line 526 "src/vcf/vcf_v42.ragel"
+#line 524 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18325,7 +18319,7 @@ case 730:
                 "SB"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18338,7 +18332,7 @@ case 730:
 	break;
 	case 661: 
 	case 662: 
-#line 534 "src/vcf/vcf_v42.ragel"
+#line 532 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18346,7 +18340,7 @@ case 730:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18359,7 +18353,7 @@ case 730:
 	break;
 	case 672: 
 	case 673: 
-#line 542 "src/vcf/vcf_v42.ragel"
+#line 540 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18367,7 +18361,7 @@ case 730:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18380,7 +18374,7 @@ case 730:
 	break;
 	case 550: 
 	case 551: 
-#line 550 "src/vcf/vcf_v42.ragel"
+#line 548 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18388,7 +18382,7 @@ case 730:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18403,14 +18397,14 @@ case 730:
 	case 539: 
 	case 540: 
 	case 541: 
-#line 572 "src/vcf/vcf_v42.ragel"
+#line 570 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 563 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -18434,7 +18428,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 338 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -18463,17 +18457,17 @@ case 730:
     }
 	break;
 	case 344: 
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -18485,17 +18479,17 @@ case 730:
     }
 	break;
 	case 354: 
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 316 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -18507,17 +18501,17 @@ case 730:
     }
 	break;
 	case 334: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 311 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -18531,17 +18525,17 @@ case 730:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -18555,17 +18549,17 @@ case 730:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -18579,17 +18573,17 @@ case 730:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -18603,17 +18597,17 @@ case 730:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -18627,17 +18621,17 @@ case 730:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -18651,17 +18645,17 @@ case 730:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -18675,17 +18669,17 @@ case 730:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -18699,17 +18693,17 @@ case 730:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 327 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 322 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -18721,7 +18715,7 @@ case 730:
     }
 	break;
 	case 600: 
-#line 462 "src/vcf/vcf_v42.ragel"
+#line 460 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18729,12 +18723,12 @@ case 730:
                 "DB"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18746,7 +18740,7 @@ case 730:
     }
 	break;
 	case 612: 
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 484 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18754,12 +18748,12 @@ case 730:
                 "H2"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18771,7 +18765,7 @@ case 730:
     }
 	break;
 	case 615: 
-#line 494 "src/vcf/vcf_v42.ragel"
+#line 492 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18779,12 +18773,12 @@ case 730:
                 "H3"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18796,7 +18790,7 @@ case 730:
     }
 	break;
 	case 660: 
-#line 534 "src/vcf/vcf_v42.ragel"
+#line 532 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18804,12 +18798,12 @@ case 730:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18821,7 +18815,7 @@ case 730:
     }
 	break;
 	case 671: 
-#line 542 "src/vcf/vcf_v42.ragel"
+#line 540 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18829,12 +18823,12 @@ case 730:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18846,7 +18840,7 @@ case 730:
     }
 	break;
 	case 549: 
-#line 550 "src/vcf/vcf_v42.ragel"
+#line 548 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18854,12 +18848,12 @@ case 730:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 402 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 397 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18871,47 +18865,47 @@ case 730:
     }
 	break;
 	case 24: 
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 232 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 256 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 262 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 278 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 244 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 250 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 306 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 294 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 300 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -18922,14 +18916,14 @@ case 730:
         p--; {goto st724;}
     }
 	break;
-#line 18926 "inc/vcf/validator_detail_v42.hpp"
+#line 18920 "inc/vcf/validator_detail_v42.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 855 "src/vcf/vcf_v42.ragel"
+#line 851 "src/vcf/vcf_v42.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 911 "src/vcf/vcf_v43.ragel"
+#line 909 "src/vcf/vcf_v43.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v43_en_meta_section_skip = 798;
 static const int vcf_v43_en_body_section_skip = 799;
 
 
-#line 917 "src/vcf/vcf_v43.ragel"
+#line 915 "src/vcf/vcf_v43.ragel"
 
 }
 
@@ -49,18 +49,16 @@ namespace ebi
   {
     
     template <typename Configuration>
-    ParserImpl_v43<Configuration>::ParserImpl_v43(std::shared_ptr<Source> const & source,
-                                                  std::shared_ptr<std::vector<Record>> const & records
-    )
-    : ParserImpl{source, records}
+    ParserImpl_v43<Configuration>::ParserImpl_v43(std::shared_ptr<Source> source)
+    : ParserImpl{source}
     {
       
-#line 59 "inc/vcf/validator_detail_v43.hpp"
+#line 57 "inc/vcf/validator_detail_v43.hpp"
 	{
 	cs = vcf_v43_start;
 	}
 
-#line 933 "src/vcf/vcf_v43.ragel"
+#line 929 "src/vcf/vcf_v43.ragel"
 
     }
 
@@ -68,7 +66,7 @@ namespace ebi
     void ParserImpl_v43<Configuration>::parse_buffer(char const * p, char const * pe, char const * eof)
     {
       
-#line 72 "inc/vcf/validator_detail_v43.hpp"
+#line 70 "inc/vcf/validator_detail_v43.hpp"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -86,7 +84,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 239 "src/vcf/vcf_v43.ragel"
+#line 237 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
@@ -109,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 376 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -143,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 376 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -172,52 +170,52 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 262 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -236,7 +234,7 @@ tr40:
     }
 	goto st0;
 tr126:
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -248,13 +246,13 @@ tr126:
     }
 	goto st0;
 tr134:
-#line 251 "src/vcf/vcf_v43.ragel"
+#line 249 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -266,12 +264,12 @@ tr134:
     }
 	goto st0;
 tr153:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -283,12 +281,12 @@ tr153:
     }
 	goto st0;
 tr162:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -300,17 +298,17 @@ tr162:
     }
 	goto st0;
 tr176:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -322,17 +320,17 @@ tr176:
     }
 	goto st0;
 tr188:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -344,12 +342,12 @@ tr188:
     }
 	goto st0;
 tr194:
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -361,7 +359,7 @@ tr194:
     }
 	goto st0;
 tr197:
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -373,12 +371,12 @@ tr197:
     }
 	goto st0;
 tr207:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -390,12 +388,12 @@ tr207:
     }
 	goto st0;
 tr226:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -407,17 +405,17 @@ tr226:
     }
 	goto st0;
 tr248:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -429,17 +427,17 @@ tr248:
     }
 	goto st0;
 tr260:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -451,7 +449,7 @@ tr260:
     }
 	goto st0;
 tr266:
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -463,12 +461,12 @@ tr266:
     }
 	goto st0;
 tr276:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -480,12 +478,12 @@ tr276:
     }
 	goto st0;
 tr289:
-#line 281 "src/vcf/vcf_v43.ragel"
+#line 279 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -497,12 +495,12 @@ tr289:
     }
 	goto st0;
 tr298:
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -514,12 +512,12 @@ tr298:
     }
 	goto st0;
 tr315:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -531,17 +529,17 @@ tr315:
     }
 	goto st0;
 tr337:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -553,17 +551,17 @@ tr337:
     }
 	goto st0;
 tr349:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -575,7 +573,7 @@ tr349:
     }
 	goto st0;
 tr356:
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -587,12 +585,12 @@ tr356:
     }
 	goto st0;
 tr365:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -604,12 +602,12 @@ tr365:
     }
 	goto st0;
 tr378:
-#line 297 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -621,12 +619,12 @@ tr378:
     }
 	goto st0;
 tr387:
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -638,12 +636,12 @@ tr387:
     }
 	goto st0;
 tr404:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -655,17 +653,17 @@ tr404:
     }
 	goto st0;
 tr426:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -677,17 +675,17 @@ tr426:
     }
 	goto st0;
 tr438:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -699,7 +697,7 @@ tr438:
     }
 	goto st0;
 tr445:
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -711,12 +709,12 @@ tr445:
     }
 	goto st0;
 tr454:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -728,12 +726,12 @@ tr454:
     }
 	goto st0;
 tr467:
-#line 340 "src/vcf/vcf_v43.ragel"
+#line 338 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -745,12 +743,12 @@ tr467:
     }
 	goto st0;
 tr475:
-#line 345 "src/vcf/vcf_v43.ragel"
+#line 343 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -762,12 +760,12 @@ tr475:
     }
 	goto st0;
 tr492:
-#line 350 "src/vcf/vcf_v43.ragel"
+#line 348 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -779,7 +777,7 @@ tr492:
     }
 	goto st0;
 tr498:
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -791,12 +789,12 @@ tr498:
     }
 	goto st0;
 tr511:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -808,12 +806,12 @@ tr511:
     }
 	goto st0;
 tr517:
-#line 323 "src/vcf/vcf_v43.ragel"
+#line 321 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -825,12 +823,12 @@ tr517:
     }
 	goto st0;
 tr527:
-#line 318 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -842,12 +840,12 @@ tr527:
     }
 	goto st0;
 tr564:
-#line 313 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -859,7 +857,7 @@ tr564:
     }
 	goto st0;
 tr569:
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -871,12 +869,12 @@ tr569:
     }
 	goto st0;
 tr580:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -888,7 +886,7 @@ tr580:
     }
 	goto st0;
 tr620:
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -900,12 +898,12 @@ tr620:
     }
 	goto st0;
 tr629:
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 370 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -917,7 +915,7 @@ tr629:
     }
 	goto st0;
 tr650:
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 262 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -929,12 +927,12 @@ tr650:
     }
 	goto st0;
 tr661:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 262 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -946,7 +944,7 @@ tr661:
     }
 	goto st0;
 tr699:
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -958,12 +956,12 @@ tr699:
     }
 	goto st0;
 tr711:
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 370 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -975,7 +973,7 @@ tr711:
     }
 	goto st0;
 tr734:
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 376 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -1019,7 +1017,7 @@ tr774:
     }
 	goto st0;
 tr789:
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 393 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
@@ -1031,7 +1029,7 @@ tr789:
     }
 	goto st0;
 tr792:
-#line 401 "src/vcf/vcf_v43.ragel"
+#line 399 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st799;}
@@ -1043,7 +1041,7 @@ tr792:
     }
 	goto st0;
 tr796:
-#line 407 "src/vcf/vcf_v43.ragel"
+#line 405 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st799;}
@@ -1055,7 +1053,7 @@ tr796:
     }
 	goto st0;
 tr801:
-#line 413 "src/vcf/vcf_v43.ragel"
+#line 411 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st799;}
@@ -1067,7 +1065,7 @@ tr801:
     }
 	goto st0;
 tr805:
-#line 419 "src/vcf/vcf_v43.ragel"
+#line 417 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st799;}
@@ -1079,7 +1077,7 @@ tr805:
     }
 	goto st0;
 tr814:
-#line 425 "src/vcf/vcf_v43.ragel"
+#line 423 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st799;}
@@ -1091,7 +1089,7 @@ tr814:
     }
 	goto st0;
 tr825:
-#line 431 "src/vcf/vcf_v43.ragel"
+#line 429 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st799;}
@@ -1103,12 +1101,12 @@ tr825:
     }
 	goto st0;
 tr833:
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1120,7 +1118,7 @@ tr833:
     }
 	goto st0;
 tr847:
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1132,7 +1130,7 @@ tr847:
     }
 	goto st0;
 tr851:
-#line 621 "src/vcf/vcf_v43.ragel"
+#line 619 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st799;}
@@ -1144,14 +1142,14 @@ tr851:
     }
 	goto st0;
 tr856:
-#line 634 "src/vcf/vcf_v43.ragel"
+#line 632 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 625 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1165,7 +1163,7 @@ tr856:
     }
 	goto st0;
 tr860:
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 625 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1186,12 +1184,12 @@ tr867:
     }
 	goto st0;
 tr879:
-#line 447 "src/vcf/vcf_v43.ragel"
+#line 445 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1203,7 +1201,7 @@ tr879:
     }
 	goto st0;
 tr881:
-#line 612 "src/vcf/vcf_v43.ragel"
+#line 610 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1211,12 +1209,12 @@ tr881:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1228,7 +1226,7 @@ tr881:
     }
 	goto st0;
 tr883:
-#line 612 "src/vcf/vcf_v43.ragel"
+#line 610 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1236,7 +1234,7 @@ tr883:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1248,7 +1246,7 @@ tr883:
     }
 	goto st0;
 tr891:
-#line 452 "src/vcf/vcf_v43.ragel"
+#line 450 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1256,7 +1254,7 @@ tr891:
                 "AA"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1268,7 +1266,7 @@ tr891:
     }
 	goto st0;
 tr894:
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 458 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1276,7 +1274,7 @@ tr894:
                 "AC"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1288,7 +1286,7 @@ tr894:
     }
 	goto st0;
 tr899:
-#line 468 "src/vcf/vcf_v43.ragel"
+#line 466 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1296,7 +1294,7 @@ tr899:
                 "AD"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1308,7 +1306,7 @@ tr899:
     }
 	goto st0;
 tr902:
-#line 476 "src/vcf/vcf_v43.ragel"
+#line 474 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1316,7 +1314,7 @@ tr902:
                 "ADF"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1328,7 +1326,7 @@ tr902:
     }
 	goto st0;
 tr905:
-#line 484 "src/vcf/vcf_v43.ragel"
+#line 482 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1336,7 +1334,7 @@ tr905:
                 "ADR"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1348,7 +1346,7 @@ tr905:
     }
 	goto st0;
 tr908:
-#line 492 "src/vcf/vcf_v43.ragel"
+#line 490 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1356,7 +1354,7 @@ tr908:
                 "AF"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1368,7 +1366,7 @@ tr908:
     }
 	goto st0;
 tr922:
-#line 500 "src/vcf/vcf_v43.ragel"
+#line 498 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1376,7 +1374,7 @@ tr922:
                 "AN"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1388,7 +1386,7 @@ tr922:
     }
 	goto st0;
 tr926:
-#line 508 "src/vcf/vcf_v43.ragel"
+#line 506 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1396,7 +1394,7 @@ tr926:
                 "BQ"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1408,7 +1406,7 @@ tr926:
     }
 	goto st0;
 tr944:
-#line 516 "src/vcf/vcf_v43.ragel"
+#line 514 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1416,7 +1414,7 @@ tr944:
                 "CIGAR"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1428,7 +1426,7 @@ tr944:
     }
 	goto st0;
 tr949:
-#line 524 "src/vcf/vcf_v43.ragel"
+#line 522 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1436,12 +1434,12 @@ tr949:
                 "DB"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1453,7 +1451,7 @@ tr949:
     }
 	goto st0;
 tr951:
-#line 524 "src/vcf/vcf_v43.ragel"
+#line 522 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1461,7 +1459,7 @@ tr951:
                 "DB"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1473,7 +1471,7 @@ tr951:
     }
 	goto st0;
 tr954:
-#line 532 "src/vcf/vcf_v43.ragel"
+#line 530 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1481,7 +1479,7 @@ tr954:
                 "DP"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1493,7 +1491,7 @@ tr954:
     }
 	goto st0;
 tr959:
-#line 540 "src/vcf/vcf_v43.ragel"
+#line 538 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1501,7 +1499,7 @@ tr959:
                 "END"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1513,7 +1511,7 @@ tr959:
     }
 	goto st0;
 tr963:
-#line 548 "src/vcf/vcf_v43.ragel"
+#line 546 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1521,12 +1519,12 @@ tr963:
                 "H2"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1538,7 +1536,7 @@ tr963:
     }
 	goto st0;
 tr965:
-#line 548 "src/vcf/vcf_v43.ragel"
+#line 546 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1546,7 +1544,7 @@ tr965:
                 "H2"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1558,7 +1556,7 @@ tr965:
     }
 	goto st0;
 tr967:
-#line 556 "src/vcf/vcf_v43.ragel"
+#line 554 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1566,12 +1564,12 @@ tr967:
                 "H3"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1583,7 +1581,7 @@ tr967:
     }
 	goto st0;
 tr969:
-#line 556 "src/vcf/vcf_v43.ragel"
+#line 554 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1591,7 +1589,7 @@ tr969:
                 "H3"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1603,7 +1601,7 @@ tr969:
     }
 	goto st0;
 tr975:
-#line 572 "src/vcf/vcf_v43.ragel"
+#line 570 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1611,7 +1609,7 @@ tr975:
                 "MQ0"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1623,7 +1621,7 @@ tr975:
     }
 	goto st0;
 tr977:
-#line 564 "src/vcf/vcf_v43.ragel"
+#line 562 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1631,7 +1629,7 @@ tr977:
                 "MQ"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1643,7 +1641,7 @@ tr977:
     }
 	goto st0;
 tr992:
-#line 580 "src/vcf/vcf_v43.ragel"
+#line 578 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1651,7 +1649,7 @@ tr992:
                 "NS"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1663,7 +1661,7 @@ tr992:
     }
 	goto st0;
 tr997:
-#line 588 "src/vcf/vcf_v43.ragel"
+#line 586 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1671,7 +1669,7 @@ tr997:
                 "SB"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1683,7 +1681,7 @@ tr997:
     }
 	goto st0;
 tr1015:
-#line 596 "src/vcf/vcf_v43.ragel"
+#line 594 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1691,12 +1689,12 @@ tr1015:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1708,7 +1706,7 @@ tr1015:
     }
 	goto st0;
 tr1017:
-#line 596 "src/vcf/vcf_v43.ragel"
+#line 594 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1716,7 +1714,7 @@ tr1017:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1728,7 +1726,7 @@ tr1017:
     }
 	goto st0;
 tr1027:
-#line 604 "src/vcf/vcf_v43.ragel"
+#line 602 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1736,12 +1734,12 @@ tr1027:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1753,7 +1751,7 @@ tr1027:
     }
 	goto st0;
 tr1029:
-#line 604 "src/vcf/vcf_v43.ragel"
+#line 602 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1761,7 +1759,7 @@ tr1029:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1786,7 +1784,7 @@ tr1078:
         
         p--; {goto st799;}
     }
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 393 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
@@ -1797,7 +1795,7 @@ tr1078:
         p--; {goto st799;}
     }
 	goto st0;
-#line 1801 "inc/vcf/validator_detail_v43.hpp"
+#line 1799 "inc/vcf/validator_detail_v43.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1906,7 +1904,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1910 "inc/vcf/validator_detail_v43.hpp"
+#line 1908 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1920,7 +1918,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1924 "inc/vcf/validator_detail_v43.hpp"
+#line 1922 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1934,7 +1932,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1938 "inc/vcf/validator_detail_v43.hpp"
+#line 1936 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1948,7 +1946,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1952 "inc/vcf/validator_detail_v43.hpp"
+#line 1950 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1962,7 +1960,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1966 "inc/vcf/validator_detail_v43.hpp"
+#line 1964 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1976,7 +1974,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1980 "inc/vcf/validator_detail_v43.hpp"
+#line 1978 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 51 )
 		goto tr21;
 	goto tr14;
@@ -1990,7 +1988,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1994 "inc/vcf/validator_detail_v43.hpp"
+#line 1992 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -2021,7 +2019,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 2025 "inc/vcf/validator_detail_v43.hpp"
+#line 2023 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -2075,7 +2073,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 2079 "inc/vcf/validator_detail_v43.hpp"
+#line 2077 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr42;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -2091,7 +2089,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2095 "inc/vcf/validator_detail_v43.hpp"
+#line 2093 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2119,7 +2117,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2123 "inc/vcf/validator_detail_v43.hpp"
+#line 2121 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr47;
@@ -2175,7 +2173,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2179 "inc/vcf/validator_detail_v43.hpp"
+#line 2177 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -2227,7 +2225,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2231 "inc/vcf/validator_detail_v43.hpp"
+#line 2229 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr40;
@@ -2262,7 +2260,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2266 "inc/vcf/validator_detail_v43.hpp"
+#line 2264 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr54;
 		case 92: goto tr55;
@@ -2290,7 +2288,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2294 "inc/vcf/validator_detail_v43.hpp"
+#line 2292 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2316,7 +2314,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2320 "inc/vcf/validator_detail_v43.hpp"
+#line 2318 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr58;
 		case 92: goto tr55;
@@ -2338,7 +2336,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2342 "inc/vcf/validator_detail_v43.hpp"
+#line 2340 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2399,7 +2397,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2403 "inc/vcf/validator_detail_v43.hpp"
+#line 2401 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 92: goto tr67;
@@ -2427,7 +2425,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2431 "inc/vcf/validator_detail_v43.hpp"
+#line 2429 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr40;
@@ -2451,7 +2449,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2455 "inc/vcf/validator_detail_v43.hpp"
+#line 2453 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr69;
 		case 92: goto tr67;
@@ -2473,7 +2471,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2477 "inc/vcf/validator_detail_v43.hpp"
+#line 2475 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 62: goto tr70;
@@ -2492,7 +2490,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2496 "inc/vcf/validator_detail_v43.hpp"
+#line 2494 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2512,7 +2510,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2516 "inc/vcf/validator_detail_v43.hpp"
+#line 2514 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2547,7 +2545,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2551 "inc/vcf/validator_detail_v43.hpp"
+#line 2549 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr73;
 		case 95: goto tr72;
@@ -2574,7 +2572,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2578 "inc/vcf/validator_detail_v43.hpp"
+#line 2576 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2606,7 +2604,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2610 "inc/vcf/validator_detail_v43.hpp"
+#line 2608 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr77;
 		case 62: goto tr54;
@@ -2627,7 +2625,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2631 "inc/vcf/validator_detail_v43.hpp"
+#line 2629 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr78;
 	if ( (*p) < 48 ) {
@@ -2652,7 +2650,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2656 "inc/vcf/validator_detail_v43.hpp"
+#line 2654 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2687,7 +2685,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2691 "inc/vcf/validator_detail_v43.hpp"
+#line 2689 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr82;
 		case 95: goto tr81;
@@ -2714,7 +2712,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2718 "inc/vcf/validator_detail_v43.hpp"
+#line 2716 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2757,7 +2755,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2761 "inc/vcf/validator_detail_v43.hpp"
+#line 2759 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr89;
@@ -2785,7 +2783,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2789 "inc/vcf/validator_detail_v43.hpp"
+#line 2787 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2811,7 +2809,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2815 "inc/vcf/validator_detail_v43.hpp"
+#line 2813 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 92: goto tr89;
@@ -2833,7 +2831,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2837 "inc/vcf/validator_detail_v43.hpp"
+#line 2835 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr92;
@@ -2873,7 +2871,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2877 "inc/vcf/validator_detail_v43.hpp"
+#line 2875 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2924,7 +2922,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2928 "inc/vcf/validator_detail_v43.hpp"
+#line 2926 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2975,7 +2973,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2979 "inc/vcf/validator_detail_v43.hpp"
+#line 2977 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -3018,7 +3016,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 3022 "inc/vcf/validator_detail_v43.hpp"
+#line 3020 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr87;
@@ -3048,7 +3046,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 3052 "inc/vcf/validator_detail_v43.hpp"
+#line 3050 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr103;
@@ -3088,7 +3086,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 3092 "inc/vcf/validator_detail_v43.hpp"
+#line 3090 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3118,7 +3116,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3122 "inc/vcf/validator_detail_v43.hpp"
+#line 3120 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 44: goto tr103;
@@ -3138,7 +3136,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3142 "inc/vcf/validator_detail_v43.hpp"
+#line 3140 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr85;
 		case 44: goto tr106;
@@ -3179,7 +3177,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3183 "inc/vcf/validator_detail_v43.hpp"
+#line 3181 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr111;
@@ -3207,7 +3205,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3211 "inc/vcf/validator_detail_v43.hpp"
+#line 3209 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 92: goto tr111;
@@ -3229,7 +3227,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3233 "inc/vcf/validator_detail_v43.hpp"
+#line 3231 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr113;
@@ -3259,7 +3257,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3263 "inc/vcf/validator_detail_v43.hpp"
+#line 3261 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3310,7 +3308,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3314 "inc/vcf/validator_detail_v43.hpp"
+#line 3312 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3361,7 +3359,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3365 "inc/vcf/validator_detail_v43.hpp"
+#line 3363 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3404,7 +3402,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3408 "inc/vcf/validator_detail_v43.hpp"
+#line 3406 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr110;
@@ -3434,7 +3432,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3438 "inc/vcf/validator_detail_v43.hpp"
+#line 3436 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr123;
@@ -3464,7 +3462,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3468 "inc/vcf/validator_detail_v43.hpp"
+#line 3466 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3494,7 +3492,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3498 "inc/vcf/validator_detail_v43.hpp"
+#line 3496 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 44: goto tr123;
@@ -3518,7 +3516,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3522 "inc/vcf/validator_detail_v43.hpp"
+#line 3520 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr127;
@@ -3536,7 +3534,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3540 "inc/vcf/validator_detail_v43.hpp"
+#line 3538 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st76;
@@ -3563,7 +3561,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3567 "inc/vcf/validator_detail_v43.hpp"
+#line 3565 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr126;
@@ -3635,7 +3633,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3639 "inc/vcf/validator_detail_v43.hpp"
+#line 3637 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3689,7 +3687,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3693 "inc/vcf/validator_detail_v43.hpp"
+#line 3691 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr139;
 		case 61: goto tr138;
@@ -3710,7 +3708,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3714 "inc/vcf/validator_detail_v43.hpp"
+#line 3712 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr126;
@@ -3808,7 +3806,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3812 "inc/vcf/validator_detail_v43.hpp"
+#line 3810 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 92: goto tr156;
@@ -3836,7 +3834,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3840 "inc/vcf/validator_detail_v43.hpp"
+#line 3838 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr159;
@@ -3864,7 +3862,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3868 "inc/vcf/validator_detail_v43.hpp"
+#line 3866 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3898,7 +3896,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3902 "inc/vcf/validator_detail_v43.hpp"
+#line 3900 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3933,7 +3931,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3937 "inc/vcf/validator_detail_v43.hpp"
+#line 3935 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr167;
 		case 95: goto tr166;
@@ -3960,7 +3958,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3964 "inc/vcf/validator_detail_v43.hpp"
+#line 3962 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr126;
@@ -3995,7 +3993,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3999 "inc/vcf/validator_detail_v43.hpp"
+#line 3997 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr172;
@@ -4023,7 +4021,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 4027 "inc/vcf/validator_detail_v43.hpp"
+#line 4025 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr173;
 		case 92: goto tr172;
@@ -4045,7 +4043,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 4049 "inc/vcf/validator_detail_v43.hpp"
+#line 4047 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr174;
@@ -4075,7 +4073,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 4079 "inc/vcf/validator_detail_v43.hpp"
+#line 4077 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4126,7 +4124,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4130 "inc/vcf/validator_detail_v43.hpp"
+#line 4128 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4177,7 +4175,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4181 "inc/vcf/validator_detail_v43.hpp"
+#line 4179 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4220,7 +4218,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4224 "inc/vcf/validator_detail_v43.hpp"
+#line 4222 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr172;
@@ -4238,7 +4236,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4242 "inc/vcf/validator_detail_v43.hpp"
+#line 4240 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 44: goto tr183;
@@ -4268,7 +4266,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4272 "inc/vcf/validator_detail_v43.hpp"
+#line 4270 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4307,7 +4305,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4311 "inc/vcf/validator_detail_v43.hpp"
+#line 4309 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr185;
 		case 92: goto tr159;
@@ -4329,7 +4327,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4333 "inc/vcf/validator_detail_v43.hpp"
+#line 4331 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr186;
@@ -4349,7 +4347,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4353 "inc/vcf/validator_detail_v43.hpp"
+#line 4351 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4400,7 +4398,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4404 "inc/vcf/validator_detail_v43.hpp"
+#line 4402 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4451,7 +4449,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4455 "inc/vcf/validator_detail_v43.hpp"
+#line 4453 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4494,7 +4492,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4498 "inc/vcf/validator_detail_v43.hpp"
+#line 4496 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr159;
@@ -4512,7 +4510,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4516 "inc/vcf/validator_detail_v43.hpp"
+#line 4514 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4536,7 +4534,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4540 "inc/vcf/validator_detail_v43.hpp"
+#line 4538 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr195;
@@ -4555,7 +4553,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4559 "inc/vcf/validator_detail_v43.hpp"
+#line 4557 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr198;
@@ -4573,7 +4571,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4577 "inc/vcf/validator_detail_v43.hpp"
+#line 4575 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr199;
@@ -4591,7 +4589,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4595 "inc/vcf/validator_detail_v43.hpp"
+#line 4593 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr200;
@@ -4609,7 +4607,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4613 "inc/vcf/validator_detail_v43.hpp"
+#line 4611 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto st127;
@@ -4636,7 +4634,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4640 "inc/vcf/validator_detail_v43.hpp"
+#line 4638 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr197;
@@ -4693,7 +4691,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4697 "inc/vcf/validator_detail_v43.hpp"
+#line 4695 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4732,7 +4730,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4736 "inc/vcf/validator_detail_v43.hpp"
+#line 4734 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr212;
 		case 95: goto tr211;
@@ -4759,7 +4757,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4763 "inc/vcf/validator_detail_v43.hpp"
+#line 4761 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr197;
@@ -4857,7 +4855,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4861 "inc/vcf/validator_detail_v43.hpp"
+#line 4859 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 92: goto tr229;
@@ -4885,7 +4883,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4889 "inc/vcf/validator_detail_v43.hpp"
+#line 4887 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr232;
@@ -4913,7 +4911,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4917 "inc/vcf/validator_detail_v43.hpp"
+#line 4915 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4947,7 +4945,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4951 "inc/vcf/validator_detail_v43.hpp"
+#line 4949 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4982,7 +4980,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4986 "inc/vcf/validator_detail_v43.hpp"
+#line 4984 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr239;
 		case 95: goto tr238;
@@ -5009,7 +5007,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 5013 "inc/vcf/validator_detail_v43.hpp"
+#line 5011 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr197;
@@ -5044,7 +5042,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 5048 "inc/vcf/validator_detail_v43.hpp"
+#line 5046 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr244;
@@ -5072,7 +5070,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 5076 "inc/vcf/validator_detail_v43.hpp"
+#line 5074 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr245;
 		case 92: goto tr244;
@@ -5094,7 +5092,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5098 "inc/vcf/validator_detail_v43.hpp"
+#line 5096 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr246;
@@ -5124,7 +5122,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5128 "inc/vcf/validator_detail_v43.hpp"
+#line 5126 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5175,7 +5173,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5179 "inc/vcf/validator_detail_v43.hpp"
+#line 5177 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5226,7 +5224,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5230 "inc/vcf/validator_detail_v43.hpp"
+#line 5228 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5269,7 +5267,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5273 "inc/vcf/validator_detail_v43.hpp"
+#line 5271 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr244;
@@ -5287,7 +5285,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5291 "inc/vcf/validator_detail_v43.hpp"
+#line 5289 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 44: goto tr255;
@@ -5317,7 +5315,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5321 "inc/vcf/validator_detail_v43.hpp"
+#line 5319 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5356,7 +5354,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5360 "inc/vcf/validator_detail_v43.hpp"
+#line 5358 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr257;
 		case 92: goto tr232;
@@ -5378,7 +5376,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5382 "inc/vcf/validator_detail_v43.hpp"
+#line 5380 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr258;
@@ -5398,7 +5396,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5402 "inc/vcf/validator_detail_v43.hpp"
+#line 5400 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5449,7 +5447,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5453 "inc/vcf/validator_detail_v43.hpp"
+#line 5451 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5500,7 +5498,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5504 "inc/vcf/validator_detail_v43.hpp"
+#line 5502 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5543,7 +5541,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5547 "inc/vcf/validator_detail_v43.hpp"
+#line 5545 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr232;
@@ -5561,7 +5559,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5565 "inc/vcf/validator_detail_v43.hpp"
+#line 5563 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5581,7 +5579,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5585 "inc/vcf/validator_detail_v43.hpp"
+#line 5583 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr267;
@@ -5599,7 +5597,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5603 "inc/vcf/validator_detail_v43.hpp"
+#line 5601 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr268;
@@ -5617,7 +5615,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5621 "inc/vcf/validator_detail_v43.hpp"
+#line 5619 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr269;
@@ -5635,7 +5633,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5639 "inc/vcf/validator_detail_v43.hpp"
+#line 5637 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st177;
@@ -5662,7 +5660,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5666 "inc/vcf/validator_detail_v43.hpp"
+#line 5664 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr266;
@@ -5719,7 +5717,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5723 "inc/vcf/validator_detail_v43.hpp"
+#line 5721 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5758,7 +5756,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5762 "inc/vcf/validator_detail_v43.hpp"
+#line 5760 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr281;
 		case 95: goto tr280;
@@ -5785,7 +5783,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5789 "inc/vcf/validator_detail_v43.hpp"
+#line 5787 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr266;
@@ -5862,7 +5860,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5866 "inc/vcf/validator_detail_v43.hpp"
+#line 5864 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	goto tr289;
@@ -5876,7 +5874,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5880 "inc/vcf/validator_detail_v43.hpp"
+#line 5878 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr266;
@@ -5942,7 +5940,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5946 "inc/vcf/validator_detail_v43.hpp"
+#line 5944 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr300;
 	if ( (*p) > 90 ) {
@@ -5961,7 +5959,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5965 "inc/vcf/validator_detail_v43.hpp"
+#line 5963 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr266;
@@ -6059,7 +6057,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 6063 "inc/vcf/validator_detail_v43.hpp"
+#line 6061 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -6087,7 +6085,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 6091 "inc/vcf/validator_detail_v43.hpp"
+#line 6089 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr321;
@@ -6115,7 +6113,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6119 "inc/vcf/validator_detail_v43.hpp"
+#line 6117 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6149,7 +6147,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6153 "inc/vcf/validator_detail_v43.hpp"
+#line 6151 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6184,7 +6182,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6188 "inc/vcf/validator_detail_v43.hpp"
+#line 6186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr328;
 		case 95: goto tr327;
@@ -6211,7 +6209,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6215 "inc/vcf/validator_detail_v43.hpp"
+#line 6213 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr266;
@@ -6246,7 +6244,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6250 "inc/vcf/validator_detail_v43.hpp"
+#line 6248 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr333;
@@ -6274,7 +6272,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6278 "inc/vcf/validator_detail_v43.hpp"
+#line 6276 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr334;
 		case 92: goto tr333;
@@ -6296,7 +6294,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6300 "inc/vcf/validator_detail_v43.hpp"
+#line 6298 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr335;
@@ -6326,7 +6324,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6330 "inc/vcf/validator_detail_v43.hpp"
+#line 6328 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6377,7 +6375,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6381 "inc/vcf/validator_detail_v43.hpp"
+#line 6379 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6428,7 +6426,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6432 "inc/vcf/validator_detail_v43.hpp"
+#line 6430 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6471,7 +6469,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6475 "inc/vcf/validator_detail_v43.hpp"
+#line 6473 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr333;
@@ -6489,7 +6487,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6493 "inc/vcf/validator_detail_v43.hpp"
+#line 6491 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 44: goto tr344;
@@ -6519,7 +6517,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6523 "inc/vcf/validator_detail_v43.hpp"
+#line 6521 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6558,7 +6556,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6562 "inc/vcf/validator_detail_v43.hpp"
+#line 6560 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr346;
 		case 92: goto tr321;
@@ -6580,7 +6578,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6584 "inc/vcf/validator_detail_v43.hpp"
+#line 6582 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr347;
@@ -6600,7 +6598,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6604 "inc/vcf/validator_detail_v43.hpp"
+#line 6602 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6651,7 +6649,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6655 "inc/vcf/validator_detail_v43.hpp"
+#line 6653 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6702,7 +6700,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6706 "inc/vcf/validator_detail_v43.hpp"
+#line 6704 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6745,7 +6743,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6749 "inc/vcf/validator_detail_v43.hpp"
+#line 6747 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr321;
@@ -6763,7 +6761,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6767 "inc/vcf/validator_detail_v43.hpp"
+#line 6765 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6797,7 +6795,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6801 "inc/vcf/validator_detail_v43.hpp"
+#line 6799 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6817,7 +6815,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6821 "inc/vcf/validator_detail_v43.hpp"
+#line 6819 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 78: goto tr357;
@@ -6835,7 +6833,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6839 "inc/vcf/validator_detail_v43.hpp"
+#line 6837 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 70: goto tr358;
@@ -6853,7 +6851,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6857 "inc/vcf/validator_detail_v43.hpp"
+#line 6855 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 79: goto st243;
@@ -6880,7 +6878,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6884 "inc/vcf/validator_detail_v43.hpp"
+#line 6882 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr356;
@@ -6937,7 +6935,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6941 "inc/vcf/validator_detail_v43.hpp"
+#line 6939 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6976,7 +6974,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6980 "inc/vcf/validator_detail_v43.hpp"
+#line 6978 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr370;
 		case 95: goto tr369;
@@ -7003,7 +7001,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 7007 "inc/vcf/validator_detail_v43.hpp"
+#line 7005 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr356;
@@ -7080,7 +7078,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 7084 "inc/vcf/validator_detail_v43.hpp"
+#line 7082 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	goto tr378;
@@ -7094,7 +7092,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7098 "inc/vcf/validator_detail_v43.hpp"
+#line 7096 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr356;
@@ -7160,7 +7158,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7164 "inc/vcf/validator_detail_v43.hpp"
+#line 7162 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr389;
 	if ( (*p) > 90 ) {
@@ -7179,7 +7177,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7183 "inc/vcf/validator_detail_v43.hpp"
+#line 7181 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr356;
@@ -7277,7 +7275,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7281 "inc/vcf/validator_detail_v43.hpp"
+#line 7279 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 92: goto tr407;
@@ -7305,7 +7303,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7309 "inc/vcf/validator_detail_v43.hpp"
+#line 7307 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr410;
@@ -7333,7 +7331,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7337 "inc/vcf/validator_detail_v43.hpp"
+#line 7335 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7367,7 +7365,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7371 "inc/vcf/validator_detail_v43.hpp"
+#line 7369 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7402,7 +7400,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7406 "inc/vcf/validator_detail_v43.hpp"
+#line 7404 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr417;
 		case 95: goto tr416;
@@ -7429,7 +7427,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7433 "inc/vcf/validator_detail_v43.hpp"
+#line 7431 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr356;
@@ -7464,7 +7462,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7468 "inc/vcf/validator_detail_v43.hpp"
+#line 7466 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr422;
@@ -7492,7 +7490,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7496 "inc/vcf/validator_detail_v43.hpp"
+#line 7494 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr423;
 		case 92: goto tr422;
@@ -7514,7 +7512,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7518 "inc/vcf/validator_detail_v43.hpp"
+#line 7516 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr424;
@@ -7544,7 +7542,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7548 "inc/vcf/validator_detail_v43.hpp"
+#line 7546 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7595,7 +7593,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7599 "inc/vcf/validator_detail_v43.hpp"
+#line 7597 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7646,7 +7644,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7650 "inc/vcf/validator_detail_v43.hpp"
+#line 7648 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7689,7 +7687,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7693 "inc/vcf/validator_detail_v43.hpp"
+#line 7691 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr422;
@@ -7707,7 +7705,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7711 "inc/vcf/validator_detail_v43.hpp"
+#line 7709 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 44: goto tr433;
@@ -7737,7 +7735,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7741 "inc/vcf/validator_detail_v43.hpp"
+#line 7739 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -7776,7 +7774,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7780 "inc/vcf/validator_detail_v43.hpp"
+#line 7778 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr435;
 		case 92: goto tr410;
@@ -7798,7 +7796,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7802 "inc/vcf/validator_detail_v43.hpp"
+#line 7800 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr436;
@@ -7818,7 +7816,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7822 "inc/vcf/validator_detail_v43.hpp"
+#line 7820 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7869,7 +7867,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7873 "inc/vcf/validator_detail_v43.hpp"
+#line 7871 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7920,7 +7918,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7924 "inc/vcf/validator_detail_v43.hpp"
+#line 7922 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7963,7 +7961,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7967 "inc/vcf/validator_detail_v43.hpp"
+#line 7965 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr410;
@@ -7981,7 +7979,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7985 "inc/vcf/validator_detail_v43.hpp"
+#line 7983 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -8015,7 +8013,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 8019 "inc/vcf/validator_detail_v43.hpp"
+#line 8017 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8035,7 +8033,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 8039 "inc/vcf/validator_detail_v43.hpp"
+#line 8037 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr446;
@@ -8053,7 +8051,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 8057 "inc/vcf/validator_detail_v43.hpp"
+#line 8055 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr447;
@@ -8071,7 +8069,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 8075 "inc/vcf/validator_detail_v43.hpp"
+#line 8073 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto st309;
@@ -8098,7 +8096,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8102 "inc/vcf/validator_detail_v43.hpp"
+#line 8100 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st311;
 	goto tr445;
@@ -8155,7 +8153,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8159 "inc/vcf/validator_detail_v43.hpp"
+#line 8157 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st315;
 	if ( (*p) < 48 ) {
@@ -8194,7 +8192,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8198 "inc/vcf/validator_detail_v43.hpp"
+#line 8196 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr459;
 		case 95: goto tr458;
@@ -8221,7 +8219,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8225 "inc/vcf/validator_detail_v43.hpp"
+#line 8223 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st318;
 	goto tr445;
@@ -8284,7 +8282,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8288 "inc/vcf/validator_detail_v43.hpp"
+#line 8286 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto st326;
 	goto tr467;
@@ -8340,7 +8338,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 8344 "inc/vcf/validator_detail_v43.hpp"
+#line 8342 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 116 )
 		goto st333;
 	goto tr475;
@@ -8445,7 +8443,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 8449 "inc/vcf/validator_detail_v43.hpp"
+#line 8447 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr491;
 	if ( (*p) < 45 ) {
@@ -8477,7 +8475,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 8481 "inc/vcf/validator_detail_v43.hpp"
+#line 8479 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 61: goto tr493;
@@ -8499,7 +8497,7 @@ st348:
 	if ( ++p == pe )
 		goto _test_eof348;
 case 348:
-#line 8503 "inc/vcf/validator_detail_v43.hpp"
+#line 8501 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr496;
 		case 61: goto tr493;
@@ -8526,7 +8524,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 8530 "inc/vcf/validator_detail_v43.hpp"
+#line 8528 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr493;
 	if ( (*p) < 45 ) {
@@ -8552,7 +8550,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 8556 "inc/vcf/validator_detail_v43.hpp"
+#line 8554 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 62: goto st351;
@@ -8587,7 +8585,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 8591 "inc/vcf/validator_detail_v43.hpp"
+#line 8589 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr499;
@@ -8605,7 +8603,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 8609 "inc/vcf/validator_detail_v43.hpp"
+#line 8607 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr500;
@@ -8623,7 +8621,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8627 "inc/vcf/validator_detail_v43.hpp"
+#line 8625 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr501;
@@ -8641,7 +8639,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8645 "inc/vcf/validator_detail_v43.hpp"
+#line 8643 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 71: goto tr502;
@@ -8659,7 +8657,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 8663 "inc/vcf/validator_detail_v43.hpp"
+#line 8661 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr503;
@@ -8677,7 +8675,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 8681 "inc/vcf/validator_detail_v43.hpp"
+#line 8679 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr504;
@@ -8695,7 +8693,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 8699 "inc/vcf/validator_detail_v43.hpp"
+#line 8697 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st359;
@@ -8722,7 +8720,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 8726 "inc/vcf/validator_detail_v43.hpp"
+#line 8724 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st361;
 	goto tr498;
@@ -8779,7 +8777,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 8783 "inc/vcf/validator_detail_v43.hpp"
+#line 8781 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st365;
 	if ( (*p) < 48 ) {
@@ -8818,7 +8816,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 8822 "inc/vcf/validator_detail_v43.hpp"
+#line 8820 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr516;
 		case 95: goto tr515;
@@ -8845,7 +8843,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 8849 "inc/vcf/validator_detail_v43.hpp"
+#line 8847 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 70: goto st368;
 		case 78: goto tr519;
@@ -8926,7 +8924,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8930 "inc/vcf/validator_detail_v43.hpp"
+#line 8928 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st375;
 	if ( (*p) < 48 ) {
@@ -8965,7 +8963,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 8969 "inc/vcf/validator_detail_v43.hpp"
+#line 8967 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr532;
 		case 95: goto tr531;
@@ -8992,7 +8990,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 8996 "inc/vcf/validator_detail_v43.hpp"
+#line 8994 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 77 )
 		goto st378;
 	goto tr498;
@@ -9070,7 +9068,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9074 "inc/vcf/validator_detail_v43.hpp"
+#line 9072 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st385;
 	if ( (*p) < 48 ) {
@@ -9109,7 +9107,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 9113 "inc/vcf/validator_detail_v43.hpp"
+#line 9111 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr543;
@@ -9136,7 +9134,7 @@ st387:
 	if ( ++p == pe )
 		goto _test_eof387;
 case 387:
-#line 9140 "inc/vcf/validator_detail_v43.hpp"
+#line 9138 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -9156,7 +9154,7 @@ st388:
 	if ( ++p == pe )
 		goto _test_eof388;
 case 388:
-#line 9160 "inc/vcf/validator_detail_v43.hpp"
+#line 9158 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr545;
 	goto tr517;
@@ -9170,7 +9168,7 @@ st389:
 	if ( ++p == pe )
 		goto _test_eof389;
 case 389:
-#line 9174 "inc/vcf/validator_detail_v43.hpp"
+#line 9172 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 109 )
 		goto tr546;
 	goto tr517;
@@ -9184,7 +9182,7 @@ st390:
 	if ( ++p == pe )
 		goto _test_eof390;
 case 390:
-#line 9188 "inc/vcf/validator_detail_v43.hpp"
+#line 9186 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 101 )
 		goto tr547;
 	goto tr517;
@@ -9198,7 +9196,7 @@ st391:
 	if ( ++p == pe )
 		goto _test_eof391;
 case 391:
-#line 9202 "inc/vcf/validator_detail_v43.hpp"
+#line 9200 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr548;
 	goto tr517;
@@ -9212,7 +9210,7 @@ st392:
 	if ( ++p == pe )
 		goto _test_eof392;
 case 392:
-#line 9216 "inc/vcf/validator_detail_v43.hpp"
+#line 9214 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr549;
 	goto tr517;
@@ -9226,7 +9224,7 @@ st393:
 	if ( ++p == pe )
 		goto _test_eof393;
 case 393:
-#line 9230 "inc/vcf/validator_detail_v43.hpp"
+#line 9228 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr550;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9242,7 +9240,7 @@ st394:
 	if ( ++p == pe )
 		goto _test_eof394;
 case 394:
-#line 9246 "inc/vcf/validator_detail_v43.hpp"
+#line 9244 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr551;
 	if ( (*p) < 48 ) {
@@ -9267,7 +9265,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9271 "inc/vcf/validator_detail_v43.hpp"
+#line 9269 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st395;
 	if ( (*p) < 48 ) {
@@ -9302,7 +9300,7 @@ st396:
 	if ( ++p == pe )
 		goto _test_eof396;
 case 396:
-#line 9306 "inc/vcf/validator_detail_v43.hpp"
+#line 9304 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr555;
 		case 62: goto tr544;
@@ -9330,7 +9328,7 @@ st397:
 	if ( ++p == pe )
 		goto _test_eof397;
 case 397:
-#line 9334 "inc/vcf/validator_detail_v43.hpp"
+#line 9332 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr519;
 	goto tr517;
@@ -9422,7 +9420,7 @@ st407:
 	if ( ++p == pe )
 		goto _test_eof407;
 case 407:
-#line 9426 "inc/vcf/validator_detail_v43.hpp"
+#line 9424 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st407;
 	if ( (*p) < 48 ) {
@@ -9461,7 +9459,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9465 "inc/vcf/validator_detail_v43.hpp"
+#line 9463 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr568;
@@ -9492,7 +9490,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 9496 "inc/vcf/validator_detail_v43.hpp"
+#line 9494 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr570;
@@ -9510,7 +9508,7 @@ st410:
 	if ( ++p == pe )
 		goto _test_eof410;
 case 410:
-#line 9514 "inc/vcf/validator_detail_v43.hpp"
+#line 9512 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr571;
@@ -9528,7 +9526,7 @@ st411:
 	if ( ++p == pe )
 		goto _test_eof411;
 case 411:
-#line 9532 "inc/vcf/validator_detail_v43.hpp"
+#line 9530 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 80: goto tr572;
@@ -9546,7 +9544,7 @@ st412:
 	if ( ++p == pe )
 		goto _test_eof412;
 case 412:
-#line 9550 "inc/vcf/validator_detail_v43.hpp"
+#line 9548 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr573;
@@ -9564,7 +9562,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9568 "inc/vcf/validator_detail_v43.hpp"
+#line 9566 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st414;
@@ -9591,7 +9589,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9595 "inc/vcf/validator_detail_v43.hpp"
+#line 9593 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st416;
 	goto tr569;
@@ -9648,7 +9646,7 @@ st420:
 	if ( ++p == pe )
 		goto _test_eof420;
 case 420:
-#line 9652 "inc/vcf/validator_detail_v43.hpp"
+#line 9650 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st420;
 	if ( (*p) < 48 ) {
@@ -9687,7 +9685,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9691 "inc/vcf/validator_detail_v43.hpp"
+#line 9689 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9715,7 +9713,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9719 "inc/vcf/validator_detail_v43.hpp"
+#line 9717 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr587;
 	if ( (*p) < 48 ) {
@@ -9740,7 +9738,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9744 "inc/vcf/validator_detail_v43.hpp"
+#line 9742 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st423;
 	if ( (*p) < 48 ) {
@@ -9775,7 +9773,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9779 "inc/vcf/validator_detail_v43.hpp"
+#line 9777 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr591;
 		case 95: goto tr590;
@@ -9802,7 +9800,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9806 "inc/vcf/validator_detail_v43.hpp"
+#line 9804 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st428;
 	if ( (*p) < 45 ) {
@@ -9834,7 +9832,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9838 "inc/vcf/validator_detail_v43.hpp"
+#line 9836 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9855,7 +9853,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9859 "inc/vcf/validator_detail_v43.hpp"
+#line 9857 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -9892,7 +9890,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 9896 "inc/vcf/validator_detail_v43.hpp"
+#line 9894 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 92: goto tr600;
@@ -9920,7 +9918,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 9924 "inc/vcf/validator_detail_v43.hpp"
+#line 9922 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st422;
 		case 62: goto st427;
@@ -9946,7 +9944,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 9950 "inc/vcf/validator_detail_v43.hpp"
+#line 9948 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 92: goto tr600;
@@ -9968,7 +9966,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 9972 "inc/vcf/validator_detail_v43.hpp"
+#line 9970 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr604;
@@ -10008,7 +10006,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10012 "inc/vcf/validator_detail_v43.hpp"
+#line 10010 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10059,7 +10057,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10063 "inc/vcf/validator_detail_v43.hpp"
+#line 10061 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10110,7 +10108,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10114 "inc/vcf/validator_detail_v43.hpp"
+#line 10112 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10153,7 +10151,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10157 "inc/vcf/validator_detail_v43.hpp"
+#line 10155 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr612;
 		case 44: goto tr598;
@@ -10183,7 +10181,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10187 "inc/vcf/validator_detail_v43.hpp"
+#line 10185 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr615;
@@ -10223,7 +10221,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10227 "inc/vcf/validator_detail_v43.hpp"
+#line 10225 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -10253,7 +10251,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10257 "inc/vcf/validator_detail_v43.hpp"
+#line 10255 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 44: goto tr615;
@@ -10273,7 +10271,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10277 "inc/vcf/validator_detail_v43.hpp"
+#line 10275 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr596;
 		case 44: goto tr618;
@@ -10297,7 +10295,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10301 "inc/vcf/validator_detail_v43.hpp"
+#line 10299 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr621;
@@ -10315,7 +10313,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 10319 "inc/vcf/validator_detail_v43.hpp"
+#line 10317 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr622;
@@ -10333,7 +10331,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10337 "inc/vcf/validator_detail_v43.hpp"
+#line 10335 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr623;
@@ -10351,7 +10349,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 10355 "inc/vcf/validator_detail_v43.hpp"
+#line 10353 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 109: goto tr624;
@@ -10369,7 +10367,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10373 "inc/vcf/validator_detail_v43.hpp"
+#line 10371 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 98: goto tr625;
@@ -10387,7 +10385,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10391 "inc/vcf/validator_detail_v43.hpp"
+#line 10389 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 108: goto tr626;
@@ -10405,7 +10403,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 10409 "inc/vcf/validator_detail_v43.hpp"
+#line 10407 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 121: goto st448;
@@ -10432,7 +10430,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 10436 "inc/vcf/validator_detail_v43.hpp"
+#line 10434 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr630;
@@ -10449,7 +10447,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 10453 "inc/vcf/validator_detail_v43.hpp"
+#line 10451 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10475,7 +10473,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 10479 "inc/vcf/validator_detail_v43.hpp"
+#line 10477 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10598,7 +10596,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 10602 "inc/vcf/validator_detail_v43.hpp"
+#line 10600 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr646;
@@ -10666,7 +10664,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 10670 "inc/vcf/validator_detail_v43.hpp"
+#line 10668 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 111: goto tr651;
@@ -10684,7 +10682,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 10688 "inc/vcf/validator_detail_v43.hpp"
+#line 10686 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 110: goto tr652;
@@ -10702,7 +10700,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10706 "inc/vcf/validator_detail_v43.hpp"
+#line 10704 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 116: goto tr653;
@@ -10720,7 +10718,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 10724 "inc/vcf/validator_detail_v43.hpp"
+#line 10722 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr654;
@@ -10738,7 +10736,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 10742 "inc/vcf/validator_detail_v43.hpp"
+#line 10740 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto st473;
@@ -10765,7 +10763,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10769 "inc/vcf/validator_detail_v43.hpp"
+#line 10767 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st475;
 	goto tr650;
@@ -10838,7 +10836,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 10842 "inc/vcf/validator_detail_v43.hpp"
+#line 10840 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 59: goto tr663;
@@ -10867,7 +10865,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 10871 "inc/vcf/validator_detail_v43.hpp"
+#line 10869 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr666;
 	if ( (*p) < 48 ) {
@@ -10892,7 +10890,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10896 "inc/vcf/validator_detail_v43.hpp"
+#line 10894 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st481;
 	if ( (*p) < 48 ) {
@@ -10927,7 +10925,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 10931 "inc/vcf/validator_detail_v43.hpp"
+#line 10929 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr670;
 		case 95: goto tr669;
@@ -10954,7 +10952,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 10958 "inc/vcf/validator_detail_v43.hpp"
+#line 10956 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st486;
 	if ( (*p) < 45 ) {
@@ -10986,7 +10984,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10990 "inc/vcf/validator_detail_v43.hpp"
+#line 10988 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 62: goto tr665;
@@ -11007,7 +11005,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 11011 "inc/vcf/validator_detail_v43.hpp"
+#line 11009 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11044,7 +11042,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 11048 "inc/vcf/validator_detail_v43.hpp"
+#line 11046 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 92: goto tr679;
@@ -11072,7 +11070,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 11076 "inc/vcf/validator_detail_v43.hpp"
+#line 11074 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st480;
 		case 62: goto st485;
@@ -11098,7 +11096,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 11102 "inc/vcf/validator_detail_v43.hpp"
+#line 11100 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 92: goto tr679;
@@ -11120,7 +11118,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 11124 "inc/vcf/validator_detail_v43.hpp"
+#line 11122 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr683;
@@ -11160,7 +11158,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 11164 "inc/vcf/validator_detail_v43.hpp"
+#line 11162 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11211,7 +11209,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 11215 "inc/vcf/validator_detail_v43.hpp"
+#line 11213 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11262,7 +11260,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 11266 "inc/vcf/validator_detail_v43.hpp"
+#line 11264 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11305,7 +11303,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 11309 "inc/vcf/validator_detail_v43.hpp"
+#line 11307 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr691;
 		case 44: goto tr677;
@@ -11335,7 +11333,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 11339 "inc/vcf/validator_detail_v43.hpp"
+#line 11337 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr694;
@@ -11375,7 +11373,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 11379 "inc/vcf/validator_detail_v43.hpp"
+#line 11377 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11405,7 +11403,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 11409 "inc/vcf/validator_detail_v43.hpp"
+#line 11407 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 44: goto tr694;
@@ -11425,7 +11423,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 11429 "inc/vcf/validator_detail_v43.hpp"
+#line 11427 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr675;
 		case 44: goto tr697;
@@ -11449,7 +11447,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 11453 "inc/vcf/validator_detail_v43.hpp"
+#line 11451 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr700;
@@ -11467,7 +11465,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 11471 "inc/vcf/validator_detail_v43.hpp"
+#line 11469 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 100: goto tr701;
@@ -11485,7 +11483,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 11489 "inc/vcf/validator_detail_v43.hpp"
+#line 11487 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr702;
@@ -11503,7 +11501,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 11507 "inc/vcf/validator_detail_v43.hpp"
+#line 11505 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto tr703;
@@ -11521,7 +11519,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11525 "inc/vcf/validator_detail_v43.hpp"
+#line 11523 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 114: goto tr704;
@@ -11539,7 +11537,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11543 "inc/vcf/validator_detail_v43.hpp"
+#line 11541 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr705;
@@ -11557,7 +11555,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11561 "inc/vcf/validator_detail_v43.hpp"
+#line 11559 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr706;
@@ -11575,7 +11573,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11579 "inc/vcf/validator_detail_v43.hpp"
+#line 11577 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr707;
@@ -11593,7 +11591,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11597 "inc/vcf/validator_detail_v43.hpp"
+#line 11595 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 66: goto st508;
@@ -11620,7 +11618,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11624 "inc/vcf/validator_detail_v43.hpp"
+#line 11622 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st510;
 	goto tr699;
@@ -11644,7 +11642,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11648 "inc/vcf/validator_detail_v43.hpp"
+#line 11646 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11670,7 +11668,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11674 "inc/vcf/validator_detail_v43.hpp"
+#line 11672 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11781,7 +11779,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11785 "inc/vcf/validator_detail_v43.hpp"
+#line 11783 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr728;
@@ -11802,7 +11800,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11806 "inc/vcf/validator_detail_v43.hpp"
+#line 11804 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr730;
@@ -11837,7 +11835,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11841 "inc/vcf/validator_detail_v43.hpp"
+#line 11839 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr728;
@@ -11937,7 +11935,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 11941 "inc/vcf/validator_detail_v43.hpp"
+#line 11939 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 80 )
 		goto st537;
 	goto tr734;
@@ -11972,7 +11970,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 11976 "inc/vcf/validator_detail_v43.hpp"
+#line 11974 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st541;
 	goto tr734;
@@ -12000,7 +11998,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12004 "inc/vcf/validator_detail_v43.hpp"
+#line 12002 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 82 )
 		goto st544;
 	goto tr734;
@@ -12035,7 +12033,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12039 "inc/vcf/validator_detail_v43.hpp"
+#line 12037 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 65 )
 		goto st548;
 	goto tr734;
@@ -12070,7 +12068,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12074 "inc/vcf/validator_detail_v43.hpp"
+#line 12072 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 81 )
 		goto st552;
 	goto tr734;
@@ -12112,7 +12110,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12116 "inc/vcf/validator_detail_v43.hpp"
+#line 12114 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st557;
 	goto tr734;
@@ -12168,7 +12166,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12172 "inc/vcf/validator_detail_v43.hpp"
+#line 12170 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st564;
 	goto tr734;
@@ -12213,7 +12211,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12217 "inc/vcf/validator_detail_v43.hpp"
+#line 12215 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st569;
 	goto tr774;
@@ -12279,7 +12277,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12283 "inc/vcf/validator_detail_v43.hpp"
+#line 12281 "inc/vcf/validator_detail_v43.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr782;
 	goto tr774;
@@ -12303,7 +12301,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12307 "inc/vcf/validator_detail_v43.hpp"
+#line 12305 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr783;
 		case 10: goto tr784;
@@ -12352,7 +12350,7 @@ st800:
 	if ( ++p == pe )
 		goto _test_eof800;
 case 800:
-#line 12356 "inc/vcf/validator_detail_v43.hpp"
+#line 12354 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1079;
 		case 13: goto tr1080;
@@ -12412,7 +12410,7 @@ st801:
 	if ( ++p == pe )
 		goto _test_eof801;
 case 801:
-#line 12416 "inc/vcf/validator_detail_v43.hpp"
+#line 12414 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1083;
 		case 13: goto tr1084;
@@ -12454,7 +12452,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12458 "inc/vcf/validator_detail_v43.hpp"
+#line 12456 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st801;
 	goto st0;
@@ -12496,7 +12494,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12500 "inc/vcf/validator_detail_v43.hpp"
+#line 12498 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr790;
 		case 43: goto tr791;
@@ -12543,7 +12541,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12547 "inc/vcf/validator_detail_v43.hpp"
+#line 12545 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr793;
 	goto tr792;
@@ -12567,7 +12565,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12571 "inc/vcf/validator_detail_v43.hpp"
+#line 12569 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr794;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12597,7 +12595,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12601 "inc/vcf/validator_detail_v43.hpp"
+#line 12599 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr797;
@@ -12624,7 +12622,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12628 "inc/vcf/validator_detail_v43.hpp"
+#line 12626 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr798;
 		case 59: goto tr800;
@@ -12650,7 +12648,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12654 "inc/vcf/validator_detail_v43.hpp"
+#line 12652 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr802;
 		case 67: goto tr802;
@@ -12684,7 +12682,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 12688 "inc/vcf/validator_detail_v43.hpp"
+#line 12686 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr803;
 		case 65: goto tr804;
@@ -12717,7 +12715,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 12721 "inc/vcf/validator_detail_v43.hpp"
+#line 12719 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr807;
@@ -12756,7 +12754,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 12760 "inc/vcf/validator_detail_v43.hpp"
+#line 12758 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -12780,7 +12778,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 12784 "inc/vcf/validator_detail_v43.hpp"
+#line 12782 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr815;
 		case 45: goto tr815;
@@ -12805,7 +12803,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 12809 "inc/vcf/validator_detail_v43.hpp"
+#line 12807 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr821;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12831,7 +12829,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 12835 "inc/vcf/validator_detail_v43.hpp"
+#line 12833 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 46: goto tr823;
@@ -12859,7 +12857,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 12863 "inc/vcf/validator_detail_v43.hpp"
+#line 12861 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr827;
 		case 58: goto tr826;
@@ -12895,7 +12893,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12899 "inc/vcf/validator_detail_v43.hpp"
+#line 12897 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto st591;
 	if ( (*p) < 65 ) {
@@ -12939,7 +12937,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12943 "inc/vcf/validator_detail_v43.hpp"
+#line 12941 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 59: goto tr832;
@@ -12965,7 +12963,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12969 "inc/vcf/validator_detail_v43.hpp"
+#line 12967 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr834;
 		case 49: goto tr836;
@@ -13004,7 +13002,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13008 "inc/vcf/validator_detail_v43.hpp"
+#line 13006 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13035,7 +13033,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13039 "inc/vcf/validator_detail_v43.hpp"
+#line 13037 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr852;
 	if ( (*p) > 90 ) {
@@ -13064,7 +13062,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13068 "inc/vcf/validator_detail_v43.hpp"
+#line 13066 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 37: goto tr854;
@@ -13099,7 +13097,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13103 "inc/vcf/validator_detail_v43.hpp"
+#line 13101 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr858;
 	if ( (*p) < 48 ) {
@@ -13131,7 +13129,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13135 "inc/vcf/validator_detail_v43.hpp"
+#line 13133 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13156,16 +13154,14 @@ tr849:
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
-                    ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
+                ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -13190,7 +13186,7 @@ st802:
 	if ( ++p == pe )
 		goto _test_eof802;
 case 802:
-#line 13194 "inc/vcf/validator_detail_v43.hpp"
+#line 13190 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1083;
 		case 13: goto tr1084;
@@ -13228,7 +13224,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13232 "inc/vcf/validator_detail_v43.hpp"
+#line 13228 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr863;
 		case 59: goto tr863;
@@ -13269,7 +13265,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13273 "inc/vcf/validator_detail_v43.hpp"
+#line 13269 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr864;
 		case 59: goto tr864;
@@ -13298,7 +13294,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13302 "inc/vcf/validator_detail_v43.hpp"
+#line 13298 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr866;
 	goto tr789;
@@ -13317,16 +13313,14 @@ tr850:
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
-                    ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
+                ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -13351,7 +13345,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13355 "inc/vcf/validator_detail_v43.hpp"
+#line 13349 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st802;
 	goto tr867;
@@ -13365,7 +13359,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13369 "inc/vcf/validator_detail_v43.hpp"
+#line 13363 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr861;
@@ -13392,7 +13386,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13396 "inc/vcf/validator_detail_v43.hpp"
+#line 13390 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13414,7 +13408,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13418 "inc/vcf/validator_detail_v43.hpp"
+#line 13412 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13451,7 +13445,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13455 "inc/vcf/validator_detail_v43.hpp"
+#line 13449 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13489,7 +13483,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13493 "inc/vcf/validator_detail_v43.hpp"
+#line 13487 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13518,7 +13512,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13522 "inc/vcf/validator_detail_v43.hpp"
+#line 13516 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 49: goto tr836;
 		case 65: goto tr837;
@@ -13556,7 +13550,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13560 "inc/vcf/validator_detail_v43.hpp"
+#line 13554 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13586,7 +13580,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13590 "inc/vcf/validator_detail_v43.hpp"
+#line 13584 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13616,7 +13610,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13620 "inc/vcf/validator_detail_v43.hpp"
+#line 13614 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13646,7 +13640,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13650 "inc/vcf/validator_detail_v43.hpp"
+#line 13644 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13676,7 +13670,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13680 "inc/vcf/validator_detail_v43.hpp"
+#line 13674 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr880;
@@ -13693,7 +13687,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13697 "inc/vcf/validator_detail_v43.hpp"
+#line 13691 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13713,7 +13707,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13717 "inc/vcf/validator_detail_v43.hpp"
+#line 13711 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13742,7 +13736,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13746 "inc/vcf/validator_detail_v43.hpp"
+#line 13740 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr884;
 	goto tr883;
@@ -13756,7 +13750,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13760 "inc/vcf/validator_detail_v43.hpp"
+#line 13754 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13778,7 +13772,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13782 "inc/vcf/validator_detail_v43.hpp"
+#line 13776 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13812,7 +13806,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13816 "inc/vcf/validator_detail_v43.hpp"
+#line 13810 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr890;
@@ -13837,7 +13831,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13841 "inc/vcf/validator_detail_v43.hpp"
+#line 13835 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr892;
 	if ( (*p) < 45 ) {
@@ -13859,7 +13853,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13863 "inc/vcf/validator_detail_v43.hpp"
+#line 13857 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13885,7 +13879,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13889 "inc/vcf/validator_detail_v43.hpp"
+#line 13883 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr893;
@@ -13910,7 +13904,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13914 "inc/vcf/validator_detail_v43.hpp"
+#line 13908 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr895;
 	goto tr894;
@@ -13924,7 +13918,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13928 "inc/vcf/validator_detail_v43.hpp"
+#line 13922 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13945,7 +13939,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13949 "inc/vcf/validator_detail_v43.hpp"
+#line 13943 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr896;
@@ -13972,7 +13966,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13976 "inc/vcf/validator_detail_v43.hpp"
+#line 13970 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr900;
 	goto tr899;
@@ -13986,7 +13980,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13990 "inc/vcf/validator_detail_v43.hpp"
+#line 13984 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14007,7 +14001,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 14011 "inc/vcf/validator_detail_v43.hpp"
+#line 14005 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr901;
@@ -14032,7 +14026,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 14036 "inc/vcf/validator_detail_v43.hpp"
+#line 14030 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr903;
 	goto tr902;
@@ -14046,7 +14040,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 14050 "inc/vcf/validator_detail_v43.hpp"
+#line 14044 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14067,7 +14061,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 14071 "inc/vcf/validator_detail_v43.hpp"
+#line 14065 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr904;
@@ -14092,7 +14086,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 14096 "inc/vcf/validator_detail_v43.hpp"
+#line 14090 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr906;
 	goto tr905;
@@ -14106,7 +14100,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 14110 "inc/vcf/validator_detail_v43.hpp"
+#line 14104 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14127,7 +14121,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 14131 "inc/vcf/validator_detail_v43.hpp"
+#line 14125 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr907;
@@ -14152,7 +14146,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 14156 "inc/vcf/validator_detail_v43.hpp"
+#line 14150 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr909;
 		case 45: goto tr909;
@@ -14172,7 +14166,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 14176 "inc/vcf/validator_detail_v43.hpp"
+#line 14170 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr911;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14188,7 +14182,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14192 "inc/vcf/validator_detail_v43.hpp"
+#line 14186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14212,7 +14206,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14216 "inc/vcf/validator_detail_v43.hpp"
+#line 14210 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr915;
 	goto tr908;
@@ -14226,7 +14220,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14230 "inc/vcf/validator_detail_v43.hpp"
+#line 14224 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14249,7 +14243,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14253 "inc/vcf/validator_detail_v43.hpp"
+#line 14247 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr916;
 		case 45: goto tr916;
@@ -14267,7 +14261,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14271 "inc/vcf/validator_detail_v43.hpp"
+#line 14265 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr917;
 	goto tr908;
@@ -14281,7 +14275,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14285 "inc/vcf/validator_detail_v43.hpp"
+#line 14279 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14302,7 +14296,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14306 "inc/vcf/validator_detail_v43.hpp"
+#line 14300 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr918;
 	goto tr908;
@@ -14316,7 +14310,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14320 "inc/vcf/validator_detail_v43.hpp"
+#line 14314 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr919;
 	goto tr908;
@@ -14330,7 +14324,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14334 "inc/vcf/validator_detail_v43.hpp"
+#line 14328 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14349,7 +14343,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14353 "inc/vcf/validator_detail_v43.hpp"
+#line 14347 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr920;
 	goto tr908;
@@ -14363,7 +14357,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14367 "inc/vcf/validator_detail_v43.hpp"
+#line 14361 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr919;
 	goto tr908;
@@ -14377,7 +14371,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14381 "inc/vcf/validator_detail_v43.hpp"
+#line 14375 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr921;
@@ -14402,7 +14396,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14406 "inc/vcf/validator_detail_v43.hpp"
+#line 14400 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr923;
 	goto tr922;
@@ -14416,7 +14410,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14420 "inc/vcf/validator_detail_v43.hpp"
+#line 14414 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14440,7 +14434,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14444 "inc/vcf/validator_detail_v43.hpp"
+#line 14438 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14470,7 +14464,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14474 "inc/vcf/validator_detail_v43.hpp"
+#line 14468 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr925;
@@ -14495,7 +14489,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14499 "inc/vcf/validator_detail_v43.hpp"
+#line 14493 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr927;
 		case 45: goto tr927;
@@ -14515,7 +14509,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14519 "inc/vcf/validator_detail_v43.hpp"
+#line 14513 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr929;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14531,7 +14525,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14535 "inc/vcf/validator_detail_v43.hpp"
+#line 14529 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14554,7 +14548,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14558 "inc/vcf/validator_detail_v43.hpp"
+#line 14552 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr926;
@@ -14568,7 +14562,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14572 "inc/vcf/validator_detail_v43.hpp"
+#line 14566 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14590,7 +14584,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14594 "inc/vcf/validator_detail_v43.hpp"
+#line 14588 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr934;
 		case 45: goto tr934;
@@ -14608,7 +14602,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14612 "inc/vcf/validator_detail_v43.hpp"
+#line 14606 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr935;
 	goto tr926;
@@ -14622,7 +14616,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14626 "inc/vcf/validator_detail_v43.hpp"
+#line 14620 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14642,7 +14636,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14646 "inc/vcf/validator_detail_v43.hpp"
+#line 14640 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr936;
 	goto tr926;
@@ -14656,7 +14650,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14660 "inc/vcf/validator_detail_v43.hpp"
+#line 14654 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr937;
 	goto tr926;
@@ -14670,7 +14664,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14674 "inc/vcf/validator_detail_v43.hpp"
+#line 14668 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14688,7 +14682,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14692 "inc/vcf/validator_detail_v43.hpp"
+#line 14686 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr938;
 	goto tr926;
@@ -14702,7 +14696,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14706 "inc/vcf/validator_detail_v43.hpp"
+#line 14700 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr937;
 	goto tr926;
@@ -14720,7 +14714,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14724 "inc/vcf/validator_detail_v43.hpp"
+#line 14718 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14750,7 +14744,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14754 "inc/vcf/validator_detail_v43.hpp"
+#line 14748 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14780,7 +14774,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14784 "inc/vcf/validator_detail_v43.hpp"
+#line 14778 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14810,7 +14804,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14814 "inc/vcf/validator_detail_v43.hpp"
+#line 14808 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14840,7 +14834,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14844 "inc/vcf/validator_detail_v43.hpp"
+#line 14838 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr943;
@@ -14865,7 +14859,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14869 "inc/vcf/validator_detail_v43.hpp"
+#line 14863 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr945;
 	goto tr944;
@@ -14879,7 +14873,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14883 "inc/vcf/validator_detail_v43.hpp"
+#line 14877 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 68: goto tr946;
 		case 80: goto tr946;
@@ -14905,7 +14899,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14909 "inc/vcf/validator_detail_v43.hpp"
+#line 14903 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14929,7 +14923,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14933 "inc/vcf/validator_detail_v43.hpp"
+#line 14927 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14960,7 +14954,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14964 "inc/vcf/validator_detail_v43.hpp"
+#line 14958 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14989,7 +14983,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14993 "inc/vcf/validator_detail_v43.hpp"
+#line 14987 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr952;
 	goto tr951;
@@ -15003,7 +14997,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 15007 "inc/vcf/validator_detail_v43.hpp"
+#line 15001 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15021,7 +15015,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 15025 "inc/vcf/validator_detail_v43.hpp"
+#line 15019 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr953;
@@ -15046,7 +15040,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 15050 "inc/vcf/validator_detail_v43.hpp"
+#line 15044 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr955;
 	goto tr954;
@@ -15060,7 +15054,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 15064 "inc/vcf/validator_detail_v43.hpp"
+#line 15058 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15084,7 +15078,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 15088 "inc/vcf/validator_detail_v43.hpp"
+#line 15082 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15114,7 +15108,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 15118 "inc/vcf/validator_detail_v43.hpp"
+#line 15112 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15144,7 +15138,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 15148 "inc/vcf/validator_detail_v43.hpp"
+#line 15142 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr958;
@@ -15169,7 +15163,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 15173 "inc/vcf/validator_detail_v43.hpp"
+#line 15167 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr960;
 	goto tr959;
@@ -15183,7 +15177,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 15187 "inc/vcf/validator_detail_v43.hpp"
+#line 15181 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15207,7 +15201,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15211 "inc/vcf/validator_detail_v43.hpp"
+#line 15205 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15238,7 +15232,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15242 "inc/vcf/validator_detail_v43.hpp"
+#line 15236 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15267,7 +15261,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15271 "inc/vcf/validator_detail_v43.hpp"
+#line 15265 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr966;
 	goto tr965;
@@ -15281,7 +15275,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15285 "inc/vcf/validator_detail_v43.hpp"
+#line 15279 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15299,7 +15293,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15303 "inc/vcf/validator_detail_v43.hpp"
+#line 15297 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15328,7 +15322,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15332 "inc/vcf/validator_detail_v43.hpp"
+#line 15326 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr970;
 	goto tr969;
@@ -15342,7 +15336,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15346 "inc/vcf/validator_detail_v43.hpp"
+#line 15340 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15364,7 +15358,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15368 "inc/vcf/validator_detail_v43.hpp"
+#line 15362 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15394,7 +15388,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15398 "inc/vcf/validator_detail_v43.hpp"
+#line 15392 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 48: goto tr972;
@@ -15420,7 +15414,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15424 "inc/vcf/validator_detail_v43.hpp"
+#line 15418 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr974;
@@ -15445,7 +15439,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15449 "inc/vcf/validator_detail_v43.hpp"
+#line 15443 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr976;
 	goto tr975;
@@ -15459,7 +15453,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15463 "inc/vcf/validator_detail_v43.hpp"
+#line 15457 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15479,7 +15473,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15483 "inc/vcf/validator_detail_v43.hpp"
+#line 15477 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr978;
 		case 45: goto tr978;
@@ -15499,7 +15493,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15503 "inc/vcf/validator_detail_v43.hpp"
+#line 15497 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr980;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15515,7 +15509,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15519 "inc/vcf/validator_detail_v43.hpp"
+#line 15513 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15538,7 +15532,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15542 "inc/vcf/validator_detail_v43.hpp"
+#line 15536 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr984;
 	goto tr977;
@@ -15552,7 +15546,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15556 "inc/vcf/validator_detail_v43.hpp"
+#line 15550 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15574,7 +15568,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15578 "inc/vcf/validator_detail_v43.hpp"
+#line 15572 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr985;
 		case 45: goto tr985;
@@ -15592,7 +15586,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15596 "inc/vcf/validator_detail_v43.hpp"
+#line 15590 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr986;
 	goto tr977;
@@ -15606,7 +15600,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15610 "inc/vcf/validator_detail_v43.hpp"
+#line 15604 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15626,7 +15620,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15630 "inc/vcf/validator_detail_v43.hpp"
+#line 15624 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr987;
 	goto tr977;
@@ -15640,7 +15634,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15644 "inc/vcf/validator_detail_v43.hpp"
+#line 15638 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr988;
 	goto tr977;
@@ -15654,7 +15648,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15658 "inc/vcf/validator_detail_v43.hpp"
+#line 15652 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15672,7 +15666,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15676 "inc/vcf/validator_detail_v43.hpp"
+#line 15670 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr989;
 	goto tr977;
@@ -15686,7 +15680,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15690 "inc/vcf/validator_detail_v43.hpp"
+#line 15684 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr988;
 	goto tr977;
@@ -15704,7 +15698,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15708 "inc/vcf/validator_detail_v43.hpp"
+#line 15702 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15734,7 +15728,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15738 "inc/vcf/validator_detail_v43.hpp"
+#line 15732 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr991;
@@ -15759,7 +15753,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15763 "inc/vcf/validator_detail_v43.hpp"
+#line 15757 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr993;
 	goto tr992;
@@ -15773,7 +15767,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15777 "inc/vcf/validator_detail_v43.hpp"
+#line 15771 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15797,7 +15791,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15801 "inc/vcf/validator_detail_v43.hpp"
+#line 15795 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15828,7 +15822,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15832 "inc/vcf/validator_detail_v43.hpp"
+#line 15826 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr996;
@@ -15853,7 +15847,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15857 "inc/vcf/validator_detail_v43.hpp"
+#line 15851 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr998;
 		case 45: goto tr998;
@@ -15873,7 +15867,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15877 "inc/vcf/validator_detail_v43.hpp"
+#line 15871 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr1000;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15889,7 +15883,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15893 "inc/vcf/validator_detail_v43.hpp"
+#line 15887 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15912,7 +15906,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15916 "inc/vcf/validator_detail_v43.hpp"
+#line 15910 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1004;
 	goto tr997;
@@ -15926,7 +15920,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15930 "inc/vcf/validator_detail_v43.hpp"
+#line 15924 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15948,7 +15942,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15952 "inc/vcf/validator_detail_v43.hpp"
+#line 15946 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1005;
 		case 45: goto tr1005;
@@ -15966,7 +15960,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15970 "inc/vcf/validator_detail_v43.hpp"
+#line 15964 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1006;
 	goto tr997;
@@ -15980,7 +15974,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15984 "inc/vcf/validator_detail_v43.hpp"
+#line 15978 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16000,7 +15994,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 16004 "inc/vcf/validator_detail_v43.hpp"
+#line 15998 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr1007;
 	goto tr997;
@@ -16014,7 +16008,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 16018 "inc/vcf/validator_detail_v43.hpp"
+#line 16012 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr1008;
 	goto tr997;
@@ -16028,7 +16022,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 16032 "inc/vcf/validator_detail_v43.hpp"
+#line 16026 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16046,7 +16040,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 16050 "inc/vcf/validator_detail_v43.hpp"
+#line 16044 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr1009;
 	goto tr997;
@@ -16060,7 +16054,7 @@ st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 16064 "inc/vcf/validator_detail_v43.hpp"
+#line 16058 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr1008;
 	goto tr997;
@@ -16074,7 +16068,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 16078 "inc/vcf/validator_detail_v43.hpp"
+#line 16072 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16104,7 +16098,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 16108 "inc/vcf/validator_detail_v43.hpp"
+#line 16102 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16134,7 +16128,7 @@ st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 16138 "inc/vcf/validator_detail_v43.hpp"
+#line 16132 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16164,7 +16158,7 @@ st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 16168 "inc/vcf/validator_detail_v43.hpp"
+#line 16162 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16194,7 +16188,7 @@ st734:
 	if ( ++p == pe )
 		goto _test_eof734;
 case 734:
-#line 16198 "inc/vcf/validator_detail_v43.hpp"
+#line 16192 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16224,7 +16218,7 @@ st735:
 	if ( ++p == pe )
 		goto _test_eof735;
 case 735:
-#line 16228 "inc/vcf/validator_detail_v43.hpp"
+#line 16222 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16253,7 +16247,7 @@ st736:
 	if ( ++p == pe )
 		goto _test_eof736;
 case 736:
-#line 16257 "inc/vcf/validator_detail_v43.hpp"
+#line 16251 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr1018;
 	goto tr1017;
@@ -16267,7 +16261,7 @@ st737:
 	if ( ++p == pe )
 		goto _test_eof737;
 case 737:
-#line 16271 "inc/vcf/validator_detail_v43.hpp"
+#line 16265 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16289,7 +16283,7 @@ st738:
 	if ( ++p == pe )
 		goto _test_eof738;
 case 738:
-#line 16293 "inc/vcf/validator_detail_v43.hpp"
+#line 16287 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16319,7 +16313,7 @@ st739:
 	if ( ++p == pe )
 		goto _test_eof739;
 case 739:
-#line 16323 "inc/vcf/validator_detail_v43.hpp"
+#line 16317 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16349,7 +16343,7 @@ st740:
 	if ( ++p == pe )
 		goto _test_eof740;
 case 740:
-#line 16353 "inc/vcf/validator_detail_v43.hpp"
+#line 16347 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16379,7 +16373,7 @@ st741:
 	if ( ++p == pe )
 		goto _test_eof741;
 case 741:
-#line 16383 "inc/vcf/validator_detail_v43.hpp"
+#line 16377 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16409,7 +16403,7 @@ st742:
 	if ( ++p == pe )
 		goto _test_eof742;
 case 742:
-#line 16413 "inc/vcf/validator_detail_v43.hpp"
+#line 16407 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16439,7 +16433,7 @@ st743:
 	if ( ++p == pe )
 		goto _test_eof743;
 case 743:
-#line 16443 "inc/vcf/validator_detail_v43.hpp"
+#line 16437 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16469,7 +16463,7 @@ st744:
 	if ( ++p == pe )
 		goto _test_eof744;
 case 744:
-#line 16473 "inc/vcf/validator_detail_v43.hpp"
+#line 16467 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16499,7 +16493,7 @@ st745:
 	if ( ++p == pe )
 		goto _test_eof745;
 case 745:
-#line 16503 "inc/vcf/validator_detail_v43.hpp"
+#line 16497 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16529,7 +16523,7 @@ st746:
 	if ( ++p == pe )
 		goto _test_eof746;
 case 746:
-#line 16533 "inc/vcf/validator_detail_v43.hpp"
+#line 16527 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16558,7 +16552,7 @@ st747:
 	if ( ++p == pe )
 		goto _test_eof747;
 case 747:
-#line 16562 "inc/vcf/validator_detail_v43.hpp"
+#line 16556 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr1030;
 	goto tr1029;
@@ -16572,7 +16566,7 @@ st748:
 	if ( ++p == pe )
 		goto _test_eof748;
 case 748:
-#line 16576 "inc/vcf/validator_detail_v43.hpp"
+#line 16570 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16590,7 +16584,7 @@ st749:
 	if ( ++p == pe )
 		goto _test_eof749;
 case 749:
-#line 16594 "inc/vcf/validator_detail_v43.hpp"
+#line 16588 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr826;
 	if ( (*p) < 65 ) {
@@ -16628,7 +16622,7 @@ st750:
 	if ( ++p == pe )
 		goto _test_eof750;
 case 750:
-#line 16632 "inc/vcf/validator_detail_v43.hpp"
+#line 16626 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 58: goto st591;
@@ -16664,7 +16658,7 @@ st751:
 	if ( ++p == pe )
 		goto _test_eof751;
 case 751:
-#line 16668 "inc/vcf/validator_detail_v43.hpp"
+#line 16662 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1031;
 	goto tr814;
@@ -16678,7 +16672,7 @@ st752:
 	if ( ++p == pe )
 		goto _test_eof752;
 case 752:
-#line 16682 "inc/vcf/validator_detail_v43.hpp"
+#line 16676 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 69: goto tr824;
@@ -16697,7 +16691,7 @@ st753:
 	if ( ++p == pe )
 		goto _test_eof753;
 case 753:
-#line 16701 "inc/vcf/validator_detail_v43.hpp"
+#line 16695 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1032;
 		case 45: goto tr1032;
@@ -16715,7 +16709,7 @@ st754:
 	if ( ++p == pe )
 		goto _test_eof754;
 case 754:
-#line 16719 "inc/vcf/validator_detail_v43.hpp"
+#line 16713 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1033;
 	goto tr814;
@@ -16729,7 +16723,7 @@ st755:
 	if ( ++p == pe )
 		goto _test_eof755;
 case 755:
-#line 16733 "inc/vcf/validator_detail_v43.hpp"
+#line 16727 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16755,7 +16749,7 @@ st756:
 	if ( ++p == pe )
 		goto _test_eof756;
 case 756:
-#line 16759 "inc/vcf/validator_detail_v43.hpp"
+#line 16753 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr1034;
 	goto tr814;
@@ -16769,7 +16763,7 @@ st757:
 	if ( ++p == pe )
 		goto _test_eof757;
 case 757:
-#line 16773 "inc/vcf/validator_detail_v43.hpp"
+#line 16767 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr1035;
 	goto tr814;
@@ -16793,7 +16787,7 @@ st758:
 	if ( ++p == pe )
 		goto _test_eof758;
 case 758:
-#line 16797 "inc/vcf/validator_detail_v43.hpp"
+#line 16791 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	goto tr814;
@@ -16811,7 +16805,7 @@ st759:
 	if ( ++p == pe )
 		goto _test_eof759;
 case 759:
-#line 16815 "inc/vcf/validator_detail_v43.hpp"
+#line 16809 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr1036;
 	goto tr814;
@@ -16825,7 +16819,7 @@ st760:
 	if ( ++p == pe )
 		goto _test_eof760;
 case 760:
-#line 16829 "inc/vcf/validator_detail_v43.hpp"
+#line 16823 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr1035;
 	goto tr814;
@@ -16839,7 +16833,7 @@ st761:
 	if ( ++p == pe )
 		goto _test_eof761;
 case 761:
-#line 16843 "inc/vcf/validator_detail_v43.hpp"
+#line 16837 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr1037;
@@ -16878,7 +16872,7 @@ st762:
 	if ( ++p == pe )
 		goto _test_eof762;
 case 762:
-#line 16882 "inc/vcf/validator_detail_v43.hpp"
+#line 16876 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr1038;
 		case 67: goto tr1038;
@@ -16902,7 +16896,7 @@ st763:
 	if ( ++p == pe )
 		goto _test_eof763;
 case 763:
-#line 16906 "inc/vcf/validator_detail_v43.hpp"
+#line 16900 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -16938,7 +16932,7 @@ st764:
 	if ( ++p == pe )
 		goto _test_eof764;
 case 764:
-#line 16942 "inc/vcf/validator_detail_v43.hpp"
+#line 16936 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr1039;
 	if ( (*p) < 63 ) {
@@ -16978,7 +16972,7 @@ st765:
 	if ( ++p == pe )
 		goto _test_eof765;
 case 765:
-#line 16982 "inc/vcf/validator_detail_v43.hpp"
+#line 16976 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto tr1041;
 	if ( (*p) < 45 ) {
@@ -17010,7 +17004,7 @@ st766:
 	if ( ++p == pe )
 		goto _test_eof766;
 case 766:
-#line 17014 "inc/vcf/validator_detail_v43.hpp"
+#line 17008 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -17039,7 +17033,7 @@ st767:
 	if ( ++p == pe )
 		goto _test_eof767;
 case 767:
-#line 17043 "inc/vcf/validator_detail_v43.hpp"
+#line 17037 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1045;
 		case 59: goto tr1045;
@@ -17071,7 +17065,7 @@ st768:
 	if ( ++p == pe )
 		goto _test_eof768;
 case 768:
-#line 17075 "inc/vcf/validator_detail_v43.hpp"
+#line 17069 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1045;
 		case 58: goto tr1047;
@@ -17099,7 +17093,7 @@ st769:
 	if ( ++p == pe )
 		goto _test_eof769;
 case 769:
-#line 17103 "inc/vcf/validator_detail_v43.hpp"
+#line 17097 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1048;
 	goto tr805;
@@ -17113,7 +17107,7 @@ st770:
 	if ( ++p == pe )
 		goto _test_eof770;
 case 770:
-#line 17117 "inc/vcf/validator_detail_v43.hpp"
+#line 17111 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr1041;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17129,7 +17123,7 @@ st771:
 	if ( ++p == pe )
 		goto _test_eof771;
 case 771:
-#line 17133 "inc/vcf/validator_detail_v43.hpp"
+#line 17127 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1049;
 		case 59: goto tr1049;
@@ -17160,7 +17154,7 @@ st772:
 	if ( ++p == pe )
 		goto _test_eof772;
 case 772:
-#line 17164 "inc/vcf/validator_detail_v43.hpp"
+#line 17158 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1049;
 		case 59: goto tr1049;
@@ -17189,7 +17183,7 @@ st773:
 	if ( ++p == pe )
 		goto _test_eof773;
 case 773:
-#line 17193 "inc/vcf/validator_detail_v43.hpp"
+#line 17187 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1047;
 	goto tr805;
@@ -17203,7 +17197,7 @@ st774:
 	if ( ++p == pe )
 		goto _test_eof774;
 case 774:
-#line 17207 "inc/vcf/validator_detail_v43.hpp"
+#line 17201 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1051;
 		case 59: goto tr1051;
@@ -17235,7 +17229,7 @@ st775:
 	if ( ++p == pe )
 		goto _test_eof775;
 case 775:
-#line 17239 "inc/vcf/validator_detail_v43.hpp"
+#line 17233 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1051;
 		case 58: goto tr1053;
@@ -17263,7 +17257,7 @@ st776:
 	if ( ++p == pe )
 		goto _test_eof776;
 case 776:
-#line 17267 "inc/vcf/validator_detail_v43.hpp"
+#line 17261 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1054;
 	goto tr805;
@@ -17277,7 +17271,7 @@ st777:
 	if ( ++p == pe )
 		goto _test_eof777;
 case 777:
-#line 17281 "inc/vcf/validator_detail_v43.hpp"
+#line 17275 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr1041;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17293,7 +17287,7 @@ st778:
 	if ( ++p == pe )
 		goto _test_eof778;
 case 778:
-#line 17297 "inc/vcf/validator_detail_v43.hpp"
+#line 17291 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1055;
 		case 59: goto tr1055;
@@ -17324,7 +17318,7 @@ st779:
 	if ( ++p == pe )
 		goto _test_eof779;
 case 779:
-#line 17328 "inc/vcf/validator_detail_v43.hpp"
+#line 17322 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1055;
 		case 59: goto tr1055;
@@ -17353,7 +17347,7 @@ st780:
 	if ( ++p == pe )
 		goto _test_eof780;
 case 780:
-#line 17357 "inc/vcf/validator_detail_v43.hpp"
+#line 17351 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1053;
 	goto tr805;
@@ -17371,7 +17365,7 @@ st781:
 	if ( ++p == pe )
 		goto _test_eof781;
 case 781:
-#line 17375 "inc/vcf/validator_detail_v43.hpp"
+#line 17369 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1057;
 		case 59: goto tr1057;
@@ -17403,7 +17397,7 @@ st782:
 	if ( ++p == pe )
 		goto _test_eof782;
 case 782:
-#line 17407 "inc/vcf/validator_detail_v43.hpp"
+#line 17401 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1057;
 		case 58: goto tr1059;
@@ -17431,7 +17425,7 @@ st783:
 	if ( ++p == pe )
 		goto _test_eof783;
 case 783:
-#line 17435 "inc/vcf/validator_detail_v43.hpp"
+#line 17429 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1060;
 	goto tr805;
@@ -17445,7 +17439,7 @@ st784:
 	if ( ++p == pe )
 		goto _test_eof784;
 case 784:
-#line 17449 "inc/vcf/validator_detail_v43.hpp"
+#line 17443 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr1061;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17461,7 +17455,7 @@ st785:
 	if ( ++p == pe )
 		goto _test_eof785;
 case 785:
-#line 17465 "inc/vcf/validator_detail_v43.hpp"
+#line 17459 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1062;
 		case 59: goto tr1062;
@@ -17492,7 +17486,7 @@ st786:
 	if ( ++p == pe )
 		goto _test_eof786;
 case 786:
-#line 17496 "inc/vcf/validator_detail_v43.hpp"
+#line 17490 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1062;
 		case 59: goto tr1062;
@@ -17521,7 +17515,7 @@ st787:
 	if ( ++p == pe )
 		goto _test_eof787;
 case 787:
-#line 17525 "inc/vcf/validator_detail_v43.hpp"
+#line 17519 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1059;
 	goto tr805;
@@ -17539,7 +17533,7 @@ st788:
 	if ( ++p == pe )
 		goto _test_eof788;
 case 788:
-#line 17543 "inc/vcf/validator_detail_v43.hpp"
+#line 17537 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1064;
 		case 59: goto tr1064;
@@ -17571,7 +17565,7 @@ st789:
 	if ( ++p == pe )
 		goto _test_eof789;
 case 789:
-#line 17575 "inc/vcf/validator_detail_v43.hpp"
+#line 17569 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1064;
 		case 58: goto tr1066;
@@ -17599,7 +17593,7 @@ st790:
 	if ( ++p == pe )
 		goto _test_eof790;
 case 790:
-#line 17603 "inc/vcf/validator_detail_v43.hpp"
+#line 17597 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1067;
 	goto tr805;
@@ -17613,7 +17607,7 @@ st791:
 	if ( ++p == pe )
 		goto _test_eof791;
 case 791:
-#line 17617 "inc/vcf/validator_detail_v43.hpp"
+#line 17611 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr1061;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17629,7 +17623,7 @@ st792:
 	if ( ++p == pe )
 		goto _test_eof792;
 case 792:
-#line 17633 "inc/vcf/validator_detail_v43.hpp"
+#line 17627 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1068;
 		case 59: goto tr1068;
@@ -17660,7 +17654,7 @@ st793:
 	if ( ++p == pe )
 		goto _test_eof793;
 case 793:
-#line 17664 "inc/vcf/validator_detail_v43.hpp"
+#line 17658 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1068;
 		case 59: goto tr1068;
@@ -17689,7 +17683,7 @@ st794:
 	if ( ++p == pe )
 		goto _test_eof794;
 case 794:
-#line 17693 "inc/vcf/validator_detail_v43.hpp"
+#line 17687 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1066;
 	goto tr805;
@@ -17707,7 +17701,7 @@ st795:
 	if ( ++p == pe )
 		goto _test_eof795;
 case 795:
-#line 17711 "inc/vcf/validator_detail_v43.hpp"
+#line 17705 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 65: goto tr1038;
@@ -17762,7 +17756,7 @@ st796:
 	if ( ++p == pe )
 		goto _test_eof796;
 case 796:
-#line 17766 "inc/vcf/validator_detail_v43.hpp"
+#line 17760 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st800;
 	goto tr774;
@@ -17791,7 +17785,7 @@ st797:
 	if ( ++p == pe )
 		goto _test_eof797;
 case 797:
-#line 17795 "inc/vcf/validator_detail_v43.hpp"
+#line 17789 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -17811,7 +17805,7 @@ st798:
 	if ( ++p == pe )
 		goto _test_eof798;
 case 798:
-#line 17815 "inc/vcf/validator_detail_v43.hpp"
+#line 17809 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1073;
 		case 13: goto tr1074;
@@ -17828,14 +17822,14 @@ tr1073:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 909 "src/vcf/vcf_v43.ragel"
+#line 907 "src/vcf/vcf_v43.ragel"
 	{ {goto st28;} }
 	goto st803;
 st803:
 	if ( ++p == pe )
 		goto _test_eof803;
 case 803:
-#line 17839 "inc/vcf/validator_detail_v43.hpp"
+#line 17833 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 tr1077:
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -17853,7 +17847,7 @@ st799:
 	if ( ++p == pe )
 		goto _test_eof799;
 case 799:
-#line 17857 "inc/vcf/validator_detail_v43.hpp"
+#line 17851 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1076;
 		case 13: goto tr1077;
@@ -17870,14 +17864,14 @@ tr1076:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 910 "src/vcf/vcf_v43.ragel"
+#line 908 "src/vcf/vcf_v43.ragel"
 	{ {goto st802;} }
 	goto st804;
 st804:
 	if ( ++p == pe )
 		goto _test_eof804;
 case 804:
-#line 17881 "inc/vcf/validator_detail_v43.hpp"
+#line 17875 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -18811,7 +18805,7 @@ case 804:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 239 "src/vcf/vcf_v43.ragel"
+#line 237 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
@@ -18845,7 +18839,7 @@ case 804:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -18864,7 +18858,7 @@ case 804:
 	case 446: 
 	case 447: 
 	case 448: 
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -18904,7 +18898,7 @@ case 804:
 	case 496: 
 	case 497: 
 	case 498: 
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 262 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -18939,7 +18933,7 @@ case 804:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -18986,7 +18980,7 @@ case 804:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19032,7 +19026,7 @@ case 804:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19077,7 +19071,7 @@ case 804:
 	case 403: 
 	case 404: 
 	case 405: 
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19099,7 +19093,7 @@ case 804:
 	case 507: 
 	case 508: 
 	case 509: 
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -19142,7 +19136,7 @@ case 804:
 	case 348: 
 	case 349: 
 	case 351: 
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19182,7 +19176,7 @@ case 804:
 	case 438: 
 	case 439: 
 	case 440: 
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -19230,7 +19224,7 @@ case 804:
 	case 565: 
 	case 566: 
 	case 567: 
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 376 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -19262,7 +19256,7 @@ case 804:
 	case 599: 
 	case 600: 
 	case 601: 
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 393 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
@@ -19275,7 +19269,7 @@ case 804:
 	break;
 	case 579: 
 	case 580: 
-#line 401 "src/vcf/vcf_v43.ragel"
+#line 399 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st799;}
@@ -19288,7 +19282,7 @@ case 804:
 	break;
 	case 581: 
 	case 582: 
-#line 407 "src/vcf/vcf_v43.ragel"
+#line 405 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st799;}
@@ -19301,7 +19295,7 @@ case 804:
 	break;
 	case 583: 
 	case 584: 
-#line 413 "src/vcf/vcf_v43.ragel"
+#line 411 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st799;}
@@ -19349,7 +19343,7 @@ case 804:
 	case 793: 
 	case 794: 
 	case 795: 
-#line 419 "src/vcf/vcf_v43.ragel"
+#line 417 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st799;}
@@ -19373,7 +19367,7 @@ case 804:
 	case 758: 
 	case 759: 
 	case 760: 
-#line 425 "src/vcf/vcf_v43.ragel"
+#line 423 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st799;}
@@ -19389,7 +19383,7 @@ case 804:
 	case 592: 
 	case 749: 
 	case 750: 
-#line 431 "src/vcf/vcf_v43.ragel"
+#line 429 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st799;}
@@ -19401,7 +19395,7 @@ case 804:
     }
 	break;
 	case 594: 
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -19414,7 +19408,7 @@ case 804:
 	break;
 	case 595: 
 	case 596: 
-#line 621 "src/vcf/vcf_v43.ragel"
+#line 619 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st799;}
@@ -19427,7 +19421,7 @@ case 804:
 	break;
 	case 598: 
 	case 603: 
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 625 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -19447,7 +19441,7 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 376 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -19478,13 +19472,13 @@ case 804:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 251 "src/vcf/vcf_v43.ragel"
+#line 249 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -19496,12 +19490,12 @@ case 804:
     }
 	break;
 	case 122: 
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19515,12 +19509,12 @@ case 804:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 281 "src/vcf/vcf_v43.ragel"
+#line 279 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19534,12 +19528,12 @@ case 804:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 297 "src/vcf/vcf_v43.ragel"
+#line 295 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19552,12 +19546,12 @@ case 804:
 	break;
 	case 199: 
 	case 200: 
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19570,12 +19564,12 @@ case 804:
 	break;
 	case 265: 
 	case 266: 
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 300 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19589,12 +19583,12 @@ case 804:
 	case 406: 
 	case 407: 
 	case 408: 
-#line 313 "src/vcf/vcf_v43.ragel"
+#line 311 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19611,12 +19605,12 @@ case 804:
 	case 384: 
 	case 385: 
 	case 386: 
-#line 318 "src/vcf/vcf_v43.ragel"
+#line 316 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19638,12 +19632,12 @@ case 804:
 	case 395: 
 	case 396: 
 	case 397: 
-#line 323 "src/vcf/vcf_v43.ragel"
+#line 321 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19656,12 +19650,12 @@ case 804:
 	break;
 	case 324: 
 	case 325: 
-#line 340 "src/vcf/vcf_v43.ragel"
+#line 338 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19679,12 +19673,12 @@ case 804:
 	case 335: 
 	case 336: 
 	case 337: 
-#line 345 "src/vcf/vcf_v43.ragel"
+#line 343 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19697,12 +19691,12 @@ case 804:
 	break;
 	case 347: 
 	case 350: 
-#line 350 "src/vcf/vcf_v43.ragel"
+#line 348 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19716,12 +19710,12 @@ case 804:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -19734,12 +19728,12 @@ case 804:
 	break;
 	case 478: 
 	case 479: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 262 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -19756,12 +19750,12 @@ case 804:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -19778,12 +19772,12 @@ case 804:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19800,12 +19794,12 @@ case 804:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19819,12 +19813,12 @@ case 804:
 	case 364: 
 	case 365: 
 	case 366: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19838,12 +19832,12 @@ case 804:
 	case 314: 
 	case 315: 
 	case 316: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19857,12 +19851,12 @@ case 804:
 	case 419: 
 	case 420: 
 	case 421: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -19887,12 +19881,12 @@ case 804:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -19917,12 +19911,12 @@ case 804:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -19947,12 +19941,12 @@ case 804:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19977,12 +19971,12 @@ case 804:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -20012,12 +20006,12 @@ case 804:
 	case 465: 
 	case 466: 
 	case 467: 
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 370 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -20049,12 +20043,12 @@ case 804:
 	case 528: 
 	case 529: 
 	case 530: 
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 370 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -20113,12 +20107,12 @@ case 804:
 	case 743: 
 	case 744: 
 	case 745: 
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20131,12 +20125,12 @@ case 804:
 	break;
 	case 613: 
 	case 614: 
-#line 447 "src/vcf/vcf_v43.ragel"
+#line 445 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20149,7 +20143,7 @@ case 804:
 	break;
 	case 620: 
 	case 621: 
-#line 452 "src/vcf/vcf_v43.ragel"
+#line 450 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20157,7 +20151,7 @@ case 804:
                 "AA"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20170,7 +20164,7 @@ case 804:
 	break;
 	case 623: 
 	case 624: 
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 458 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20178,7 +20172,7 @@ case 804:
                 "AC"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20191,7 +20185,7 @@ case 804:
 	break;
 	case 626: 
 	case 627: 
-#line 468 "src/vcf/vcf_v43.ragel"
+#line 466 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20199,7 +20193,7 @@ case 804:
                 "AD"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20212,7 +20206,7 @@ case 804:
 	break;
 	case 629: 
 	case 630: 
-#line 476 "src/vcf/vcf_v43.ragel"
+#line 474 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20220,7 +20214,7 @@ case 804:
                 "ADF"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20233,7 +20227,7 @@ case 804:
 	break;
 	case 632: 
 	case 633: 
-#line 484 "src/vcf/vcf_v43.ragel"
+#line 482 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20241,7 +20235,7 @@ case 804:
                 "ADR"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20265,7 +20259,7 @@ case 804:
 	case 645: 
 	case 646: 
 	case 647: 
-#line 492 "src/vcf/vcf_v43.ragel"
+#line 490 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20273,7 +20267,7 @@ case 804:
                 "AF"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20286,7 +20280,7 @@ case 804:
 	break;
 	case 649: 
 	case 650: 
-#line 500 "src/vcf/vcf_v43.ragel"
+#line 498 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20294,7 +20288,7 @@ case 804:
                 "AN"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20318,7 +20312,7 @@ case 804:
 	case 663: 
 	case 664: 
 	case 665: 
-#line 508 "src/vcf/vcf_v43.ragel"
+#line 506 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20326,7 +20320,7 @@ case 804:
                 "BQ"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20340,7 +20334,7 @@ case 804:
 	case 671: 
 	case 672: 
 	case 673: 
-#line 516 "src/vcf/vcf_v43.ragel"
+#line 514 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20348,7 +20342,7 @@ case 804:
                 "CIGAR"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20361,7 +20355,7 @@ case 804:
 	break;
 	case 676: 
 	case 677: 
-#line 524 "src/vcf/vcf_v43.ragel"
+#line 522 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20369,7 +20363,7 @@ case 804:
                 "DB"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20382,7 +20376,7 @@ case 804:
 	break;
 	case 679: 
 	case 680: 
-#line 532 "src/vcf/vcf_v43.ragel"
+#line 530 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20390,7 +20384,7 @@ case 804:
                 "DP"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20403,7 +20397,7 @@ case 804:
 	break;
 	case 684: 
 	case 685: 
-#line 540 "src/vcf/vcf_v43.ragel"
+#line 538 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20411,7 +20405,7 @@ case 804:
                 "END"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20424,7 +20418,7 @@ case 804:
 	break;
 	case 688: 
 	case 689: 
-#line 548 "src/vcf/vcf_v43.ragel"
+#line 546 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20432,7 +20426,7 @@ case 804:
                 "H2"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20445,7 +20439,7 @@ case 804:
 	break;
 	case 691: 
 	case 692: 
-#line 556 "src/vcf/vcf_v43.ragel"
+#line 554 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20453,7 +20447,7 @@ case 804:
                 "H3"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20477,7 +20471,7 @@ case 804:
 	case 708: 
 	case 709: 
 	case 710: 
-#line 564 "src/vcf/vcf_v43.ragel"
+#line 562 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20485,7 +20479,7 @@ case 804:
                 "MQ"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20498,7 +20492,7 @@ case 804:
 	break;
 	case 696: 
 	case 697: 
-#line 572 "src/vcf/vcf_v43.ragel"
+#line 570 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20506,7 +20500,7 @@ case 804:
                 "MQ0"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20519,7 +20513,7 @@ case 804:
 	break;
 	case 713: 
 	case 714: 
-#line 580 "src/vcf/vcf_v43.ragel"
+#line 578 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20527,7 +20521,7 @@ case 804:
                 "NS"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20551,7 +20545,7 @@ case 804:
 	case 727: 
 	case 728: 
 	case 729: 
-#line 588 "src/vcf/vcf_v43.ragel"
+#line 586 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20559,7 +20553,7 @@ case 804:
                 "SB"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20572,7 +20566,7 @@ case 804:
 	break;
 	case 736: 
 	case 737: 
-#line 596 "src/vcf/vcf_v43.ragel"
+#line 594 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20580,7 +20574,7 @@ case 804:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20593,7 +20587,7 @@ case 804:
 	break;
 	case 747: 
 	case 748: 
-#line 604 "src/vcf/vcf_v43.ragel"
+#line 602 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20601,7 +20595,7 @@ case 804:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20614,7 +20608,7 @@ case 804:
 	break;
 	case 616: 
 	case 617: 
-#line 612 "src/vcf/vcf_v43.ragel"
+#line 610 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20622,7 +20616,7 @@ case 804:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20637,14 +20631,14 @@ case 804:
 	case 604: 
 	case 605: 
 	case 606: 
-#line 634 "src/vcf/vcf_v43.ragel"
+#line 632 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 625 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -20668,7 +20662,7 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 376 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -20699,17 +20693,17 @@ case 804:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -20723,17 +20717,17 @@ case 804:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -20747,17 +20741,17 @@ case 804:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -20771,17 +20765,17 @@ case 804:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -20795,17 +20789,17 @@ case 804:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -20819,17 +20813,17 @@ case 804:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -20843,17 +20837,17 @@ case 804:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -20867,17 +20861,17 @@ case 804:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 365 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 360 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -20889,7 +20883,7 @@ case 804:
     }
 	break;
 	case 675: 
-#line 524 "src/vcf/vcf_v43.ragel"
+#line 522 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20897,12 +20891,12 @@ case 804:
                 "DB"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20914,7 +20908,7 @@ case 804:
     }
 	break;
 	case 687: 
-#line 548 "src/vcf/vcf_v43.ragel"
+#line 546 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20922,12 +20916,12 @@ case 804:
                 "H2"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20939,7 +20933,7 @@ case 804:
     }
 	break;
 	case 690: 
-#line 556 "src/vcf/vcf_v43.ragel"
+#line 554 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20947,12 +20941,12 @@ case 804:
                 "H3"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20964,7 +20958,7 @@ case 804:
     }
 	break;
 	case 735: 
-#line 596 "src/vcf/vcf_v43.ragel"
+#line 594 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20972,12 +20966,12 @@ case 804:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20989,7 +20983,7 @@ case 804:
     }
 	break;
 	case 746: 
-#line 604 "src/vcf/vcf_v43.ragel"
+#line 602 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20997,12 +20991,12 @@ case 804:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -21014,7 +21008,7 @@ case 804:
     }
 	break;
 	case 615: 
-#line 612 "src/vcf/vcf_v43.ragel"
+#line 610 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -21022,12 +21016,12 @@ case 804:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 440 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 435 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -21039,52 +21033,52 @@ case 804:
     }
 	break;
 	case 24: 
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 244 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 268 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 274 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 290 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 256 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 262 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 333 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 354 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 306 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 327 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -21095,14 +21089,14 @@ case 804:
         p--; {goto st798;}
     }
 	break;
-#line 21099 "inc/vcf/validator_detail_v43.hpp"
+#line 21093 "inc/vcf/validator_detail_v43.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 941 "src/vcf/vcf_v43.ragel"
+#line 937 "src/vcf/vcf_v43.ragel"
 
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,12 +172,12 @@ namespace
         while (ebi::util::readline(input, line)) {
             validator.parse(line);
 
-            for (auto &error : *validator.errors()) {
+            for (auto &error : validator.errors()) {
                 for (auto &output : outputs) {
                     output->write_error(*error);
                 }
             }
-            for (auto &error : *validator.warnings()) {
+            for (auto &error : validator.warnings()) {
                 for (auto &output : outputs) {
                     output->write_warning(*error);
                 }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -34,7 +34,7 @@ namespace ebi
             std::map<std::string, std::string> const & info,
             std::vector<std::string> const & format,
             std::vector<std::string> const & samples,
-            std::shared_ptr<Source> const & source)
+            std::shared_ptr<Source> source)
     : line(line),
         chromosome{chromosome},
         position{position},
@@ -441,7 +441,7 @@ namespace ebi
             }
         }
     }
-    
+
     bool is_record_subfield_in_header(std::string const & field_value,
                                       std::multimap<std::string, MetaEntry>::iterator begin,
                                       std::multimap<std::string, MetaEntry>::iterator end)

--- a/src/vcf/store_parse_policy.cpp
+++ b/src/vcf/store_parse_policy.cpp
@@ -48,7 +48,7 @@ namespace ebi
         m_line_tokens.clear();
     }
 
-    void StoreParsePolicy::handle_fileformat(ParsingState const & state)
+    void StoreParsePolicy::handle_fileformat(ParsingState & state)
     {
         Version fileformat_version = Version::v41;
 
@@ -80,7 +80,7 @@ namespace ebi
     }
 
     
-    void StoreParsePolicy::handle_meta_line(ParsingState const & state) 
+    void StoreParsePolicy::handle_meta_line(ParsingState & state)
     {
         // Put together m_line_typeid and m_grouped_tokens in a single MetaEntry object
         // Add MetaEntry to Source
@@ -109,7 +109,7 @@ namespace ebi
         m_grouped_tokens.push_back(m_current_token);
     }
 
-    void StoreParsePolicy::handle_header_line(ParsingState const & state) 
+    void StoreParsePolicy::handle_header_line(ParsingState & state)
     {
         state.set_samples(m_grouped_tokens);
     }
@@ -194,7 +194,7 @@ namespace ebi
         auto samples = m_line_tokens.find("SAMPLES") != m_line_tokens.end() ?
                        m_line_tokens["SAMPLES"] : std::vector<std::string>{};
 
-        state.add_record(Record{
+        state.set_record(std::unique_ptr<Record>{new Record{
                 state.n_lines,
                 m_line_tokens["CHROM"][0],
                 position,
@@ -207,7 +207,7 @@ namespace ebi
                 format,
                 samples,
                 state.source
-        });
+        }});
 
         check_sorted(state, position);
     }

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -200,16 +200,14 @@
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
                     ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -833,10 +831,8 @@ namespace ebi
   {
     
     template <typename Configuration>
-    ParserImpl_v41<Configuration>::ParserImpl_v41(std::shared_ptr<Source> const & source,
-                                                  std::shared_ptr<std::vector<Record>> const & records
-    )
-    : ParserImpl{source, records}
+    ParserImpl_v41<Configuration>::ParserImpl_v41(std::shared_ptr<Source> source)
+    : ParserImpl{source}
     {
       %%{
       write init;

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -200,16 +200,14 @@
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
-                    ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
+                ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -837,10 +835,8 @@ namespace ebi
   {
    
     template <typename Configuration>
-    ParserImpl_v42<Configuration>::ParserImpl_v42(std::shared_ptr<Source> const & source,
-                                                  std::shared_ptr<std::vector<Record>> const & records
-    )
-    : ParserImpl{source, records}
+    ParserImpl_v42<Configuration>::ParserImpl_v42(std::shared_ptr<Source> source)
+    : ParserImpl{source}
     {
       %%{
       write init;

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -212,16 +212,14 @@
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            for (auto & record : *(ParsingState::records)){
-                auto duplicated_errors = previous_records.check_duplicates(record);
-                for(auto &error_ptr : duplicated_errors) {
-                    ErrorPolicy::handle_error(*this, error_ptr.release());
-                }
+            auto duplicated_errors = previous_records.check_duplicates(*record);
+            for(auto &error_ptr : duplicated_errors) {
+                ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, ParsingState::records->back());
+                OptionalPolicy::optional_check_body_entry(*this, *record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -923,10 +921,8 @@ namespace ebi
   {
     
     template <typename Configuration>
-    ParserImpl_v43<Configuration>::ParserImpl_v43(std::shared_ptr<Source> const & source,
-                                                  std::shared_ptr<std::vector<Record>> const & records
-    )
-    : ParserImpl{source, records}
+    ParserImpl_v43<Configuration>::ParserImpl_v43(std::shared_ptr<Source> source)
+    : ParserImpl{source}
     {
       %%{
       write init;

--- a/test/vcf/debugulator_integration_test.cpp
+++ b/test/vcf/debugulator_integration_test.cpp
@@ -38,12 +38,12 @@ namespace ebi
       while (ebi::util::readline(input, line)) {
           validator.parse(line);
 
-          for (auto &error : *validator.errors()) {
+          for (auto &error : validator.errors()) {
               for (auto &output : outputs) {
                   output->write_error(*error);
               }
           }
-          for (auto &error : *validator.warnings()) {
+          for (auto &error : validator.warnings()) {
               for (auto &output : outputs) {
                   output->write_warning(*error);
               }

--- a/test/vcf/parser_v41_test.cpp
+++ b/test/vcf/parser_v41_test.cpp
@@ -22,12 +22,10 @@ namespace ebi
     bool is_valid_v41(std::string path)
     {
         std::ifstream input{path};
-        auto source = ebi::vcf::Source{path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v41};
-        auto records = std::vector<ebi::vcf::Record>{};
 
         auto validator = ebi::vcf::FullValidator_v41{
-            std::make_shared<ebi::vcf::Source>(source),
-            std::make_shared<std::vector<ebi::vcf::Record>>(records)};
+                std::make_shared<ebi::vcf::Source>(path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v41)
+        };
 
         std::vector<char> line;
         line.reserve(default_line_buffer_size);

--- a/test/vcf/parser_v42_test.cpp
+++ b/test/vcf/parser_v42_test.cpp
@@ -22,12 +22,10 @@ namespace ebi
     bool is_valid_v42(std::string path)
     {
         std::ifstream input{path};
-        auto source = ebi::vcf::Source{path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v42};
-        auto records = std::vector<ebi::vcf::Record>{};
 
         auto validator = ebi::vcf::FullValidator_v42{
-            std::make_shared<ebi::vcf::Source>(source),
-            std::make_shared<std::vector<ebi::vcf::Record>>(records)};
+                std::make_shared<ebi::vcf::Source>(path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v42)
+        };
 
         std::vector<char> line;
         line.reserve(default_line_buffer_size);

--- a/test/vcf/parser_v43_test.cpp
+++ b/test/vcf/parser_v43_test.cpp
@@ -22,12 +22,10 @@ namespace ebi
     bool is_valid_v43(std::string path)
     {
         std::ifstream input{path};
-        auto source = ebi::vcf::Source{path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v43};
-        auto records = std::vector<ebi::vcf::Record>{};
 
         auto validator = ebi::vcf::FullValidator_v43{
-            std::make_shared<ebi::vcf::Source>(source),
-            std::make_shared<std::vector<ebi::vcf::Record>>(records)};
+                std::make_shared<ebi::vcf::Source>(path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v43)
+        };
 
         std::vector<char> line;
         line.reserve(default_line_buffer_size);

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -56,22 +56,20 @@ namespace ebi
       if (!input) {
           throw std::runtime_error("file not found: " + path);
       }
-      auto source = ebi::vcf::Source{path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v41};
-      auto records = std::vector<ebi::vcf::Record>{};
 
       auto validator = ebi::vcf::FullValidator_v41{
-          std::make_shared<ebi::vcf::Source>(source),
-          std::make_shared<std::vector<ebi::vcf::Record>>(records)};
+              std::make_shared<ebi::vcf::Source>(path, ebi::vcf::InputFormat::VCF_FILE_VCF, ebi::vcf::Version::v41)
+      };
 
       std::vector<char> line;
       line.reserve(default_line_buffer_size);
 
       while (readline(input, line)) {
           validator.parse(line);
-          for (auto &error : *validator.errors()) {
+          for (auto &error : validator.errors()) {
               output.write_error(*error);
           }
-          for (auto &warn : *validator.warnings()) {
+          for (auto &warn : validator.warnings()) {
               output.write_warning(*warn);
           }
       }


### PR DESCRIPTION
in parsing state:
- `source` is still a shared pointer because it has to be shared with each record
- `record` is not a vector anymore, as there's only one at each moment. unique pointer now.
- `errors` and `warnings` are not pointers to vectors anymore, but plain vectors. (vectors to unique pointers to `Error`s)