### PR TITLE
EVA-407 Fixed high memory usage caused by 17ef05e

### DIFF
--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -141,6 +141,8 @@ namespace ebi
 
         std::shared_ptr<Source> source;
 
+        Record() { }
+        
         Record(size_t line,
                 std::string const & chromosome,
                 size_t position,

--- a/inc/vcf/parsing_state.hpp
+++ b/inc/vcf/parsing_state.hpp
@@ -41,9 +41,9 @@ namespace ebi
         bool m_is_valid;
         
         std::shared_ptr<Source> source;
-        std::unique_ptr<Record> record;
         std::vector<std::unique_ptr<Error>> errors;
         std::vector<std::unique_ptr<Error>> warnings;
+        Record record;
 
         std::multimap<std::string, std::string> defined_metadata;
         std::multimap<std::string, std::string> undefined_metadata;
@@ -54,14 +54,13 @@ namespace ebi
         
         void add_meta(MetaEntry const & meta);
 
-        void set_record(std::unique_ptr<Record> record);
-        void unset_record();
-
+        void set_record(Record record);
+        
         void add_error(std::unique_ptr<Error> error);
-        void clear_errors();
-
+        
         void add_warning(std::unique_ptr<Error> error);
-        void clear_warnings();
+        
+        void clear();
         
         std::vector<std::string> const & samples() const;
         

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -1,5 +1,5 @@
 
-#line 1 "src/vcf/vcf_v41.ragel"
+#line 1 "../src/vcf/vcf_v41.ragel"
 /**
  * Copyright 2014-2016 EMBL - European Bioinformatics Institute
  *
@@ -21,13 +21,13 @@
 #include "vcf/validator.hpp"
 
 
-#line 819 "src/vcf/vcf_v41.ragel"
+#line 819 "../src/vcf/vcf_v41.ragel"
 
 
 namespace
 {
   
-#line 31 "inc/vcf/validator_detail_v41.hpp"
+#line 31 "../inc/vcf/validator_detail_v41.hpp"
 static const int vcf_v41_start = 1;
 static const int vcf_v41_first_final = 654;
 static const int vcf_v41_error = 0;
@@ -39,7 +39,7 @@ static const int vcf_v41_en_meta_section_skip = 652;
 static const int vcf_v41_en_body_section_skip = 653;
 
 
-#line 825 "src/vcf/vcf_v41.ragel"
+#line 825 "../src/vcf/vcf_v41.ragel"
 
 }
 
@@ -53,12 +53,12 @@ namespace ebi
     : ParserImpl{source}
     {
       
-#line 57 "inc/vcf/validator_detail_v41.hpp"
+#line 57 "../inc/vcf/validator_detail_v41.hpp"
 	{
 	cs = vcf_v41_start;
 	}
 
-#line 839 "src/vcf/vcf_v41.ragel"
+#line 839 "../src/vcf/vcf_v41.ragel"
 
     }
 
@@ -66,7 +66,7 @@ namespace ebi
     void ParserImpl_v41<Configuration>::parse_buffer(char const * p, char const * pe, char const * eof)
     {
       
-#line 70 "inc/vcf/validator_detail_v41.hpp"
+#line 70 "../inc/vcf/validator_detail_v41.hpp"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -77,37 +77,37 @@ case 1:
 		goto st2;
 	goto tr0;
 tr0:
-#line 60 "src/vcf/vcf_v41.ragel"
+#line 60 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr14:
-#line 225 "src/vcf/vcf_v41.ragel"
+#line 225 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         p--; {goto st652;}
     }
-#line 60 "src/vcf/vcf_v41.ragel"
+#line 60 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr24:
-#line 60 "src/vcf/vcf_v41.ragel"
+#line 60 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 338 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -121,7 +121,7 @@ tr24:
         
         p--; {goto st653;}
     }
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -136,12 +136,12 @@ tr24:
     }
 	goto st0;
 tr26:
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 338 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -155,7 +155,7 @@ tr26:
         
         p--; {goto st653;}
     }
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -170,598 +170,598 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 244 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 250 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 294 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 300 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr39:
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr125:
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr133:
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 237 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr152:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr162:
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr165:
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr175:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr194:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr204:
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr214:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr227:
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 267 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr236:
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 288 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr253:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr264:
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr273:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr286:
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 283 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr295:
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 288 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr312:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr323:
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 294 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr333:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 294 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr345:
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr356:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr361:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 311 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr363:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 311 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr373:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 311 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 316 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr376:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 316 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr386:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 316 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr389:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr412:
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 244 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr421:
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 332 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 244 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr442:
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 250 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr453:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 250 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr491:
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 300 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr503:
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 332 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 300 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	goto st0;
 tr526:
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 338 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -775,7 +775,7 @@ tr526:
         
         p--; {goto st653;}
     }
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -790,7 +790,7 @@ tr526:
     }
 	goto st0;
 tr566:
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -805,179 +805,179 @@ tr566:
     }
 	goto st0;
 tr581:
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 355 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr584:
-#line 361 "src/vcf/vcf_v41.ragel"
+#line 361 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr588:
-#line 367 "src/vcf/vcf_v41.ragel"
+#line 367 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr593:
-#line 373 "src/vcf/vcf_v41.ragel"
+#line 373 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr597:
-#line 379 "src/vcf/vcf_v41.ragel"
+#line 379 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr606:
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 385 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr617:
-#line 391 "src/vcf/vcf_v41.ragel"
+#line 391 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr625:
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr647:
-#line 557 "src/vcf/vcf_v41.ragel"
+#line 557 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr652:
-#line 570 "src/vcf/vcf_v41.ragel"
+#line 570 "../src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 563 "../src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr656:
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 563 "../src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr663:
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr672:
-#line 407 "src/vcf/vcf_v41.ragel"
+#line 407 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr674:
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 548 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -985,24 +985,24 @@ tr674:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr676:
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 548 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1010,19 +1010,19 @@ tr676:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr683:
-#line 412 "src/vcf/vcf_v41.ragel"
+#line 412 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1030,19 +1030,19 @@ tr683:
                 "AA"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr686:
-#line 420 "src/vcf/vcf_v41.ragel"
+#line 420 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1050,19 +1050,19 @@ tr686:
                 "AC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr689:
-#line 428 "src/vcf/vcf_v41.ragel"
+#line 428 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1070,19 +1070,19 @@ tr689:
                 "AF"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr703:
-#line 436 "src/vcf/vcf_v41.ragel"
+#line 436 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1090,19 +1090,19 @@ tr703:
                 "AN"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr707:
-#line 444 "src/vcf/vcf_v41.ragel"
+#line 444 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1110,19 +1110,19 @@ tr707:
                 "BQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr725:
-#line 452 "src/vcf/vcf_v41.ragel"
+#line 452 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1130,19 +1130,19 @@ tr725:
                 "CIGAR"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr730:
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 460 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1150,24 +1150,24 @@ tr730:
                 "DB"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr732:
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 460 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1175,19 +1175,19 @@ tr732:
                 "DB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr735:
-#line 468 "src/vcf/vcf_v41.ragel"
+#line 468 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1195,19 +1195,19 @@ tr735:
                 "DP"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr740:
-#line 476 "src/vcf/vcf_v41.ragel"
+#line 476 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1215,19 +1215,19 @@ tr740:
                 "END"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr744:
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 484 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1235,24 +1235,24 @@ tr744:
                 "H2"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr746:
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 484 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1260,19 +1260,19 @@ tr746:
                 "H2"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr748:
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 492 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1280,24 +1280,24 @@ tr748:
                 "H3"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr750:
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 492 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1305,19 +1305,19 @@ tr750:
                 "H3"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr756:
-#line 508 "src/vcf/vcf_v41.ragel"
+#line 508 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1325,19 +1325,19 @@ tr756:
                 "MQ0"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr758:
-#line 500 "src/vcf/vcf_v41.ragel"
+#line 500 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1345,19 +1345,19 @@ tr758:
                 "MQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr773:
-#line 516 "src/vcf/vcf_v41.ragel"
+#line 516 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1365,19 +1365,19 @@ tr773:
                 "NS"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr778:
-#line 524 "src/vcf/vcf_v41.ragel"
+#line 524 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1385,19 +1385,19 @@ tr778:
                 "SB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr796:
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 532 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1405,24 +1405,24 @@ tr796:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr798:
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 532 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1430,19 +1430,19 @@ tr798:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr808:
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 540 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1450,24 +1450,24 @@ tr808:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr810:
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 540 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1475,19 +1475,19 @@ tr810:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
 tr859:
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -1500,18 +1500,18 @@ tr859:
         
         p--; {goto st653;}
     }
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 355 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	goto st0;
-#line 1515 "inc/vcf/validator_detail_v41.hpp"
+#line 1515 "../inc/vcf/validator_detail_v41.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1607,11 +1607,11 @@ case 14:
 		goto tr15;
 	goto tr14;
 tr15:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1620,12 +1620,12 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1624 "inc/vcf/validator_detail_v41.hpp"
+#line 1624 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
 tr16:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1634,12 +1634,12 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1638 "inc/vcf/validator_detail_v41.hpp"
+#line 1638 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
 tr17:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1648,12 +1648,12 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1652 "inc/vcf/validator_detail_v41.hpp"
+#line 1652 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
 tr18:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1662,12 +1662,12 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1666 "inc/vcf/validator_detail_v41.hpp"
+#line 1666 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
 tr19:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1676,12 +1676,12 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1680 "inc/vcf/validator_detail_v41.hpp"
+#line 1680 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
 tr20:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1690,12 +1690,12 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1694 "inc/vcf/validator_detail_v41.hpp"
+#line 1694 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 49 )
 		goto tr21;
 	goto tr14;
 tr21:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1704,14 +1704,14 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1708 "inc/vcf/validator_detail_v41.hpp"
+#line 1708 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
 	}
 	goto tr14;
 tr22:
-#line 99 "src/vcf/vcf_v41.ragel"
+#line 99 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
@@ -1720,7 +1720,7 @@ tr22:
           p--; {goto st652;}
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -1735,7 +1735,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1739 "inc/vcf/validator_detail_v41.hpp"
+#line 1739 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1769,17 +1769,17 @@ case 24:
 		goto tr30;
 	goto tr29;
 tr30:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st25;
 tr40:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1788,14 +1788,14 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1792 "inc/vcf/validator_detail_v41.hpp"
+#line 1792 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr40;
 	goto tr39;
 tr41:
-#line 168 "src/vcf/vcf_v41.ragel"
+#line 168 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this);
     }
@@ -1804,7 +1804,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1808 "inc/vcf/validator_detail_v41.hpp"
+#line 1808 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -1813,17 +1813,17 @@ case 26:
 		goto tr42;
 	goto tr39;
 tr42:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st27;
 tr47:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1832,7 +1832,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 1836 "inc/vcf/validator_detail_v41.hpp"
+#line 1836 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -1841,11 +1841,11 @@ case 27:
 		goto tr47;
 	goto tr39;
 tr45:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 176 "src/vcf/vcf_v41.ragel"
+#line 176 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -1853,7 +1853,7 @@ tr45:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -1865,7 +1865,7 @@ tr45:
     }
 	goto st28;
 tr55:
-#line 176 "src/vcf/vcf_v41.ragel"
+#line 176 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -1873,7 +1873,7 @@ tr55:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -1888,16 +1888,16 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 1892 "inc/vcf/validator_detail_v41.hpp"
+#line 1892 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
 tr46:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 176 "src/vcf/vcf_v41.ragel"
+#line 176 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -1905,7 +1905,7 @@ tr46:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -1917,7 +1917,7 @@ tr46:
     }
 	goto st29;
 tr56:
-#line 176 "src/vcf/vcf_v41.ragel"
+#line 176 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -1925,7 +1925,7 @@ tr56:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -1940,7 +1940,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 1944 "inc/vcf/validator_detail_v41.hpp"
+#line 1944 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -1956,17 +1956,17 @@ case 30:
 		goto tr49;
 	goto tr39;
 tr49:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st31;
 tr52:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1975,7 +1975,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 1979 "inc/vcf/validator_detail_v41.hpp"
+#line 1979 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -1984,17 +1984,17 @@ case 31:
 		goto tr52;
 	goto tr39;
 tr50:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st32;
 tr53:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2003,24 +2003,24 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2007 "inc/vcf/validator_detail_v41.hpp"
+#line 2007 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
 	}
 	goto tr39;
 tr51:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st33;
 tr54:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2029,7 +2029,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2033 "inc/vcf/validator_detail_v41.hpp"
+#line 2033 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2038,11 +2038,11 @@ case 33:
 		goto tr52;
 	goto tr39;
 tr57:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2051,7 +2051,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2055 "inc/vcf/validator_detail_v41.hpp"
+#line 2055 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2093,17 +2093,17 @@ case 36:
 		goto tr61;
 	goto tr39;
 tr61:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st37;
 tr64:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2112,7 +2112,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2116 "inc/vcf/validator_detail_v41.hpp"
+#line 2116 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2121,17 +2121,17 @@ case 37:
 		goto tr64;
 	goto tr39;
 tr62:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st38;
 tr65:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2140,22 +2140,22 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2144 "inc/vcf/validator_detail_v41.hpp"
+#line 2144 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
 tr63:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st39;
 tr66:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2164,7 +2164,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2168 "inc/vcf/validator_detail_v41.hpp"
+#line 2168 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2173,11 +2173,11 @@ case 39:
 		goto tr64;
 	goto tr39;
 tr68:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2186,7 +2186,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2190 "inc/vcf/validator_detail_v41.hpp"
+#line 2190 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2196,7 +2196,7 @@ case 40:
 		goto tr64;
 	goto tr39;
 tr69:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2205,7 +2205,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2209 "inc/vcf/validator_detail_v41.hpp"
+#line 2209 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2216,7 +2216,7 @@ case 41:
 		goto tr64;
 	goto tr39;
 tr59:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2225,7 +2225,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2229 "inc/vcf/validator_detail_v41.hpp"
+#line 2229 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2241,17 +2241,17 @@ case 42:
 		goto tr71;
 	goto tr39;
 tr60:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st43;
 tr71:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2260,7 +2260,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2264 "inc/vcf/validator_detail_v41.hpp"
+#line 2264 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2278,7 +2278,7 @@ case 43:
 		goto tr71;
 	goto tr39;
 tr72:
-#line 172 "src/vcf/vcf_v41.ragel"
+#line 172 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2287,7 +2287,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2291 "inc/vcf/validator_detail_v41.hpp"
+#line 2291 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2300,17 +2300,17 @@ case 44:
 		goto tr73;
 	goto tr39;
 tr73:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st45;
 tr75:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2319,7 +2319,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2323 "inc/vcf/validator_detail_v41.hpp"
+#line 2323 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2331,7 +2331,7 @@ case 45:
 		goto tr75;
 	goto tr39;
 tr76:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2340,7 +2340,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2344 "inc/vcf/validator_detail_v41.hpp"
+#line 2344 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2356,7 +2356,7 @@ case 46:
 		goto tr78;
 	goto tr39;
 tr77:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2365,7 +2365,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2369 "inc/vcf/validator_detail_v41.hpp"
+#line 2369 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2381,17 +2381,17 @@ case 47:
 		goto tr80;
 	goto tr39;
 tr78:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st48;
 tr80:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2400,7 +2400,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2404 "inc/vcf/validator_detail_v41.hpp"
+#line 2404 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2418,7 +2418,7 @@ case 48:
 		goto tr80;
 	goto tr39;
 tr81:
-#line 172 "src/vcf/vcf_v41.ragel"
+#line 172 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2427,7 +2427,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2431 "inc/vcf/validator_detail_v41.hpp"
+#line 2431 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2451,17 +2451,17 @@ case 50:
 		goto tr83;
 	goto tr39;
 tr83:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st51;
 tr86:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2470,7 +2470,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2474 "inc/vcf/validator_detail_v41.hpp"
+#line 2474 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2479,17 +2479,17 @@ case 51:
 		goto tr86;
 	goto tr39;
 tr84:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st52;
 tr87:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2498,24 +2498,24 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2502 "inc/vcf/validator_detail_v41.hpp"
+#line 2502 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
 	}
 	goto tr39;
 tr85:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st53;
 tr88:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2524,7 +2524,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2528 "inc/vcf/validator_detail_v41.hpp"
+#line 2528 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2533,11 +2533,11 @@ case 53:
 		goto tr86;
 	goto tr39;
 tr90:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2546,7 +2546,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2550 "inc/vcf/validator_detail_v41.hpp"
+#line 2550 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2557,27 +2557,27 @@ case 54:
 		goto tr86;
 	goto tr39;
 tr105:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st55;
 tr91:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st55;
 tr102:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2586,7 +2586,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2590 "inc/vcf/validator_detail_v41.hpp"
+#line 2590 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2618,17 +2618,17 @@ case 55:
 		goto tr86;
 	goto tr39;
 tr93:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st56;
 tr95:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2637,7 +2637,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2641 "inc/vcf/validator_detail_v41.hpp"
+#line 2641 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2669,17 +2669,17 @@ case 56:
 		goto tr86;
 	goto tr39;
 tr94:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st57;
 tr96:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2688,7 +2688,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2692 "inc/vcf/validator_detail_v41.hpp"
+#line 2692 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2718,11 +2718,11 @@ case 57:
 		goto tr96;
 	goto tr39;
 tr97:
-#line 172 "src/vcf/vcf_v41.ragel"
+#line 172 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2731,7 +2731,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2735 "inc/vcf/validator_detail_v41.hpp"
+#line 2735 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2742,17 +2742,17 @@ case 58:
 		goto tr98;
 	goto tr39;
 tr101:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st59;
 tr98:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2761,7 +2761,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2765 "inc/vcf/validator_detail_v41.hpp"
+#line 2765 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2772,27 +2772,27 @@ case 59:
 		goto tr101;
 	goto tr39;
 tr106:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st60;
 tr92:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st60;
 tr103:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2801,7 +2801,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2805 "inc/vcf/validator_detail_v41.hpp"
+#line 2805 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2812,17 +2812,17 @@ case 60:
 		goto tr86;
 	goto tr39;
 tr104:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st61;
 tr100:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2831,7 +2831,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 2835 "inc/vcf/validator_detail_v41.hpp"
+#line 2835 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -2842,7 +2842,7 @@ case 61:
 		goto tr101;
 	goto tr39;
 tr99:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2851,7 +2851,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 2855 "inc/vcf/validator_detail_v41.hpp"
+#line 2855 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -2873,17 +2873,17 @@ case 63:
 		goto tr107;
 	goto tr39;
 tr107:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st64;
 tr109:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2892,7 +2892,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 2896 "inc/vcf/validator_detail_v41.hpp"
+#line 2896 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -2901,17 +2901,17 @@ case 64:
 		goto tr109;
 	goto tr39;
 tr108:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st65;
 tr110:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2920,7 +2920,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 2924 "inc/vcf/validator_detail_v41.hpp"
+#line 2924 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -2929,11 +2929,11 @@ case 65:
 		goto tr109;
 	goto tr39;
 tr111:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2942,7 +2942,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 2946 "inc/vcf/validator_detail_v41.hpp"
+#line 2946 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -2953,17 +2953,17 @@ case 66:
 		goto tr109;
 	goto tr39;
 tr112:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st67;
 tr122:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2972,7 +2972,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 2976 "inc/vcf/validator_detail_v41.hpp"
+#line 2976 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3004,17 +3004,17 @@ case 67:
 		goto tr109;
 	goto tr39;
 tr116:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st68;
 tr114:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3023,7 +3023,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3027 "inc/vcf/validator_detail_v41.hpp"
+#line 3027 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3055,17 +3055,17 @@ case 68:
 		goto tr109;
 	goto tr39;
 tr117:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st69;
 tr115:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3074,7 +3074,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3078 "inc/vcf/validator_detail_v41.hpp"
+#line 3078 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3104,11 +3104,11 @@ case 69:
 		goto tr117;
 	goto tr39;
 tr118:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 172 "src/vcf/vcf_v41.ragel"
+#line 172 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3117,7 +3117,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3121 "inc/vcf/validator_detail_v41.hpp"
+#line 3121 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3128,17 +3128,17 @@ case 70:
 		goto tr119;
 	goto tr39;
 tr121:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st71;
 tr119:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3147,7 +3147,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3151 "inc/vcf/validator_detail_v41.hpp"
+#line 3151 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3158,17 +3158,17 @@ case 71:
 		goto tr121;
 	goto tr39;
 tr113:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st72;
 tr123:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3177,7 +3177,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3181 "inc/vcf/validator_detail_v41.hpp"
+#line 3181 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3188,17 +3188,17 @@ case 72:
 		goto tr109;
 	goto tr39;
 tr124:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st73;
 tr120:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3207,7 +3207,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3211 "inc/vcf/validator_detail_v41.hpp"
+#line 3211 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3218,11 +3218,11 @@ case 73:
 		goto tr121;
 	goto tr39;
 tr31:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3231,7 +3231,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3235 "inc/vcf/validator_detail_v41.hpp"
+#line 3235 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3240,7 +3240,7 @@ case 74:
 		goto tr40;
 	goto tr125;
 tr126:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3249,7 +3249,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3253 "inc/vcf/validator_detail_v41.hpp"
+#line 3253 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3267,7 +3267,7 @@ case 76:
 		goto tr40;
 	goto tr125;
 tr128:
-#line 108 "src/vcf/vcf_v41.ragel"
+#line 108 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "ALT");
     }
@@ -3276,7 +3276,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3280 "inc/vcf/validator_detail_v41.hpp"
+#line 3280 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3335,11 +3335,11 @@ case 81:
 		goto tr134;
 	goto tr133;
 tr134:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3348,7 +3348,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3352 "inc/vcf/validator_detail_v41.hpp"
+#line 3352 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3379,21 +3379,21 @@ case 82:
 		goto st82;
 	goto tr133;
 tr137:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st83;
 tr135:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3402,7 +3402,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3406 "inc/vcf/validator_detail_v41.hpp"
+#line 3406 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3414,7 +3414,7 @@ case 83:
 		goto tr137;
 	goto tr133;
 tr138:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3423,7 +3423,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3427 "inc/vcf/validator_detail_v41.hpp"
+#line 3427 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3512,7 +3512,7 @@ case 96:
 		goto tr151;
 	goto tr125;
 tr151:
-#line 156 "src/vcf/vcf_v41.ragel"
+#line 156 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -3521,7 +3521,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3525 "inc/vcf/validator_detail_v41.hpp"
+#line 3525 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3530,17 +3530,17 @@ case 97:
 		goto tr153;
 	goto tr152;
 tr153:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st98;
 tr156:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3549,7 +3549,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3553 "inc/vcf/validator_detail_v41.hpp"
+#line 3553 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3558,17 +3558,17 @@ case 98:
 		goto tr156;
 	goto tr152;
 tr154:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st99;
 tr157:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3577,7 +3577,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3581 "inc/vcf/validator_detail_v41.hpp"
+#line 3581 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st100;
 	goto tr152;
@@ -3591,17 +3591,17 @@ case 100:
 	}
 	goto tr125;
 tr155:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st101;
 tr158:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3610,7 +3610,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3614 "inc/vcf/validator_detail_v41.hpp"
+#line 3614 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr160;
 		case 92: goto tr158;
@@ -3619,11 +3619,11 @@ case 101:
 		goto tr156;
 	goto tr152;
 tr160:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3632,7 +3632,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3636 "inc/vcf/validator_detail_v41.hpp"
+#line 3636 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 62: goto tr161;
@@ -3642,7 +3642,7 @@ case 102:
 		goto tr156;
 	goto tr152;
 tr161:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3651,7 +3651,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3655 "inc/vcf/validator_detail_v41.hpp"
+#line 3655 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3662,11 +3662,11 @@ case 103:
 		goto tr156;
 	goto tr152;
 tr32:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3675,7 +3675,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3679 "inc/vcf/validator_detail_v41.hpp"
+#line 3679 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr163;
@@ -3685,7 +3685,7 @@ case 104:
 		goto tr40;
 	goto tr162;
 tr163:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3694,7 +3694,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3698 "inc/vcf/validator_detail_v41.hpp"
+#line 3698 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr166;
@@ -3703,7 +3703,7 @@ case 105:
 		goto tr40;
 	goto tr165;
 tr166:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3712,7 +3712,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3716 "inc/vcf/validator_detail_v41.hpp"
+#line 3716 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr167;
@@ -3721,7 +3721,7 @@ case 106:
 		goto tr40;
 	goto tr165;
 tr167:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3730,7 +3730,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3734 "inc/vcf/validator_detail_v41.hpp"
+#line 3734 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr168;
@@ -3739,7 +3739,7 @@ case 107:
 		goto tr40;
 	goto tr165;
 tr168:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3748,7 +3748,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3752 "inc/vcf/validator_detail_v41.hpp"
+#line 3752 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st109;
@@ -3766,7 +3766,7 @@ case 109:
 		goto tr40;
 	goto tr165;
 tr170:
-#line 120 "src/vcf/vcf_v41.ragel"
+#line 120 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "FILTER");
     }
@@ -3775,7 +3775,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 3779 "inc/vcf/validator_detail_v41.hpp"
+#line 3779 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st111;
 	goto tr165;
@@ -3819,11 +3819,11 @@ case 114:
 		goto tr177;
 	goto tr175;
 tr176:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3832,7 +3832,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 3836 "inc/vcf/validator_detail_v41.hpp"
+#line 3836 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st115;
 	if ( (*p) < 48 ) {
@@ -3848,21 +3848,21 @@ case 115:
 		goto tr179;
 	goto tr175;
 tr179:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st116;
 tr177:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3871,7 +3871,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 3875 "inc/vcf/validator_detail_v41.hpp"
+#line 3875 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr180;
 		case 95: goto tr179;
@@ -3889,7 +3889,7 @@ case 116:
 		goto tr179;
 	goto tr175;
 tr180:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3898,7 +3898,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 3902 "inc/vcf/validator_detail_v41.hpp"
+#line 3902 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st118;
 	goto tr165;
@@ -3987,7 +3987,7 @@ case 129:
 		goto tr193;
 	goto tr165;
 tr193:
-#line 156 "src/vcf/vcf_v41.ragel"
+#line 156 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -3996,7 +3996,7 @@ st130:
 	if ( ++p == pe )
 		goto _test_eof130;
 case 130:
-#line 4000 "inc/vcf/validator_detail_v41.hpp"
+#line 4000 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr196;
 		case 92: goto tr197;
@@ -4005,17 +4005,17 @@ case 130:
 		goto tr195;
 	goto tr194;
 tr195:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st131;
 tr198:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4024,7 +4024,7 @@ st131:
 	if ( ++p == pe )
 		goto _test_eof131;
 case 131:
-#line 4028 "inc/vcf/validator_detail_v41.hpp"
+#line 4028 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 92: goto tr200;
@@ -4033,17 +4033,17 @@ case 131:
 		goto tr198;
 	goto tr194;
 tr196:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st132;
 tr199:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4052,7 +4052,7 @@ st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 4056 "inc/vcf/validator_detail_v41.hpp"
+#line 4056 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st133;
 	goto tr194;
@@ -4066,17 +4066,17 @@ case 133:
 	}
 	goto tr165;
 tr197:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st134;
 tr200:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4085,7 +4085,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4089 "inc/vcf/validator_detail_v41.hpp"
+#line 4089 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr202;
 		case 92: goto tr200;
@@ -4094,11 +4094,11 @@ case 134:
 		goto tr198;
 	goto tr194;
 tr202:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4107,7 +4107,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4111 "inc/vcf/validator_detail_v41.hpp"
+#line 4111 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 62: goto tr203;
@@ -4117,7 +4117,7 @@ case 135:
 		goto tr198;
 	goto tr194;
 tr203:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4126,7 +4126,7 @@ st136:
 	if ( ++p == pe )
 		goto _test_eof136;
 case 136:
-#line 4130 "inc/vcf/validator_detail_v41.hpp"
+#line 4130 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4137,7 +4137,7 @@ case 136:
 		goto tr198;
 	goto tr194;
 tr164:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4146,7 +4146,7 @@ st137:
 	if ( ++p == pe )
 		goto _test_eof137;
 case 137:
-#line 4150 "inc/vcf/validator_detail_v41.hpp"
+#line 4150 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr205;
@@ -4155,7 +4155,7 @@ case 137:
 		goto tr40;
 	goto tr204;
 tr205:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4164,7 +4164,7 @@ st138:
 	if ( ++p == pe )
 		goto _test_eof138;
 case 138:
-#line 4168 "inc/vcf/validator_detail_v41.hpp"
+#line 4168 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr206;
@@ -4173,7 +4173,7 @@ case 138:
 		goto tr40;
 	goto tr204;
 tr206:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4182,7 +4182,7 @@ st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 4186 "inc/vcf/validator_detail_v41.hpp"
+#line 4186 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr207;
@@ -4191,7 +4191,7 @@ case 139:
 		goto tr40;
 	goto tr204;
 tr207:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4200,7 +4200,7 @@ st140:
 	if ( ++p == pe )
 		goto _test_eof140;
 case 140:
-#line 4204 "inc/vcf/validator_detail_v41.hpp"
+#line 4204 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st141;
@@ -4218,7 +4218,7 @@ case 141:
 		goto tr40;
 	goto tr204;
 tr209:
-#line 124 "src/vcf/vcf_v41.ragel"
+#line 124 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "FORMAT");
     }
@@ -4227,7 +4227,7 @@ st142:
 	if ( ++p == pe )
 		goto _test_eof142;
 case 142:
-#line 4231 "inc/vcf/validator_detail_v41.hpp"
+#line 4231 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st143;
 	goto tr204;
@@ -4271,11 +4271,11 @@ case 146:
 		goto tr216;
 	goto tr214;
 tr215:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4284,7 +4284,7 @@ st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 4288 "inc/vcf/validator_detail_v41.hpp"
+#line 4288 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st147;
 	if ( (*p) < 48 ) {
@@ -4300,21 +4300,21 @@ case 147:
 		goto tr218;
 	goto tr214;
 tr218:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st148;
 tr216:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4323,7 +4323,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4327 "inc/vcf/validator_detail_v41.hpp"
+#line 4327 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr219;
 		case 95: goto tr218;
@@ -4341,7 +4341,7 @@ case 148:
 		goto tr218;
 	goto tr214;
 tr219:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4350,7 +4350,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4354 "inc/vcf/validator_detail_v41.hpp"
+#line 4354 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st150;
 	goto tr204;
@@ -4409,15 +4409,15 @@ case 156:
 		goto tr229;
 	goto tr227;
 tr228:
-#line 148 "src/vcf/vcf_v41.ragel"
+#line 148 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4426,12 +4426,12 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4430 "inc/vcf/validator_detail_v41.hpp"
+#line 4430 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	goto tr227;
 tr230:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4440,7 +4440,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 4444 "inc/vcf/validator_detail_v41.hpp"
+#line 4444 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st159;
 	goto tr204;
@@ -4483,21 +4483,21 @@ case 163:
 		goto tr237;
 	goto tr236;
 tr239:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st164;
 tr237:
-#line 152 "src/vcf/vcf_v41.ragel"
+#line 152 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Type");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4506,7 +4506,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 4510 "inc/vcf/validator_detail_v41.hpp"
+#line 4510 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr238;
 	if ( (*p) > 90 ) {
@@ -4516,7 +4516,7 @@ case 164:
 		goto tr239;
 	goto tr236;
 tr238:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4525,7 +4525,7 @@ st165:
 	if ( ++p == pe )
 		goto _test_eof165;
 case 165:
-#line 4529 "inc/vcf/validator_detail_v41.hpp"
+#line 4529 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st166;
 	goto tr204;
@@ -4614,7 +4614,7 @@ case 177:
 		goto tr252;
 	goto tr204;
 tr252:
-#line 156 "src/vcf/vcf_v41.ragel"
+#line 156 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -4623,7 +4623,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 4627 "inc/vcf/validator_detail_v41.hpp"
+#line 4627 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr255;
 		case 92: goto tr256;
@@ -4632,17 +4632,17 @@ case 178:
 		goto tr254;
 	goto tr253;
 tr254:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st179;
 tr257:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4651,7 +4651,7 @@ st179:
 	if ( ++p == pe )
 		goto _test_eof179;
 case 179:
-#line 4655 "inc/vcf/validator_detail_v41.hpp"
+#line 4655 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 92: goto tr259;
@@ -4660,17 +4660,17 @@ case 179:
 		goto tr257;
 	goto tr253;
 tr255:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st180;
 tr258:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4679,7 +4679,7 @@ st180:
 	if ( ++p == pe )
 		goto _test_eof180;
 case 180:
-#line 4683 "inc/vcf/validator_detail_v41.hpp"
+#line 4683 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st181;
 	goto tr253;
@@ -4693,17 +4693,17 @@ case 181:
 	}
 	goto tr204;
 tr256:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st182;
 tr259:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4712,7 +4712,7 @@ st182:
 	if ( ++p == pe )
 		goto _test_eof182;
 case 182:
-#line 4716 "inc/vcf/validator_detail_v41.hpp"
+#line 4716 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr261;
 		case 92: goto tr259;
@@ -4721,11 +4721,11 @@ case 182:
 		goto tr257;
 	goto tr253;
 tr261:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4734,7 +4734,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 4738 "inc/vcf/validator_detail_v41.hpp"
+#line 4738 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 62: goto tr262;
@@ -4744,7 +4744,7 @@ case 183:
 		goto tr257;
 	goto tr253;
 tr262:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4753,7 +4753,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 4757 "inc/vcf/validator_detail_v41.hpp"
+#line 4757 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4764,21 +4764,21 @@ case 184:
 		goto tr257;
 	goto tr253;
 tr263:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st185;
 tr229:
-#line 148 "src/vcf/vcf_v41.ragel"
+#line 148 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4787,18 +4787,18 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 4791 "inc/vcf/validator_detail_v41.hpp"
+#line 4791 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr263;
 	goto tr227;
 tr33:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4807,7 +4807,7 @@ st186:
 	if ( ++p == pe )
 		goto _test_eof186;
 case 186:
-#line 4811 "inc/vcf/validator_detail_v41.hpp"
+#line 4811 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr265;
@@ -4816,7 +4816,7 @@ case 186:
 		goto tr40;
 	goto tr264;
 tr265:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4825,7 +4825,7 @@ st187:
 	if ( ++p == pe )
 		goto _test_eof187;
 case 187:
-#line 4829 "inc/vcf/validator_detail_v41.hpp"
+#line 4829 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr266;
@@ -4834,7 +4834,7 @@ case 187:
 		goto tr40;
 	goto tr264;
 tr266:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4843,7 +4843,7 @@ st188:
 	if ( ++p == pe )
 		goto _test_eof188;
 case 188:
-#line 4847 "inc/vcf/validator_detail_v41.hpp"
+#line 4847 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st189;
@@ -4861,7 +4861,7 @@ case 189:
 		goto tr40;
 	goto tr264;
 tr268:
-#line 128 "src/vcf/vcf_v41.ragel"
+#line 128 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "INFO");
     }
@@ -4870,7 +4870,7 @@ st190:
 	if ( ++p == pe )
 		goto _test_eof190;
 case 190:
-#line 4874 "inc/vcf/validator_detail_v41.hpp"
+#line 4874 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st191;
 	goto tr264;
@@ -4914,11 +4914,11 @@ case 194:
 		goto tr275;
 	goto tr273;
 tr274:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4927,7 +4927,7 @@ st195:
 	if ( ++p == pe )
 		goto _test_eof195;
 case 195:
-#line 4931 "inc/vcf/validator_detail_v41.hpp"
+#line 4931 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st195;
 	if ( (*p) < 48 ) {
@@ -4943,21 +4943,21 @@ case 195:
 		goto tr277;
 	goto tr273;
 tr277:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st196;
 tr275:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4966,7 +4966,7 @@ st196:
 	if ( ++p == pe )
 		goto _test_eof196;
 case 196:
-#line 4970 "inc/vcf/validator_detail_v41.hpp"
+#line 4970 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr278;
 		case 95: goto tr277;
@@ -4984,7 +4984,7 @@ case 196:
 		goto tr277;
 	goto tr273;
 tr278:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4993,7 +4993,7 @@ st197:
 	if ( ++p == pe )
 		goto _test_eof197;
 case 197:
-#line 4997 "inc/vcf/validator_detail_v41.hpp"
+#line 4997 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st198;
 	goto tr264;
@@ -5052,15 +5052,15 @@ case 204:
 		goto tr288;
 	goto tr286;
 tr287:
-#line 148 "src/vcf/vcf_v41.ragel"
+#line 148 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5069,12 +5069,12 @@ st205:
 	if ( ++p == pe )
 		goto _test_eof205;
 case 205:
-#line 5073 "inc/vcf/validator_detail_v41.hpp"
+#line 5073 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	goto tr286;
 tr289:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5083,7 +5083,7 @@ st206:
 	if ( ++p == pe )
 		goto _test_eof206;
 case 206:
-#line 5087 "inc/vcf/validator_detail_v41.hpp"
+#line 5087 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st207;
 	goto tr264;
@@ -5126,21 +5126,21 @@ case 211:
 		goto tr296;
 	goto tr295;
 tr298:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st212;
 tr296:
-#line 152 "src/vcf/vcf_v41.ragel"
+#line 152 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Type");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5149,7 +5149,7 @@ st212:
 	if ( ++p == pe )
 		goto _test_eof212;
 case 212:
-#line 5153 "inc/vcf/validator_detail_v41.hpp"
+#line 5153 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr297;
 	if ( (*p) > 90 ) {
@@ -5159,7 +5159,7 @@ case 212:
 		goto tr298;
 	goto tr295;
 tr297:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5168,7 +5168,7 @@ st213:
 	if ( ++p == pe )
 		goto _test_eof213;
 case 213:
-#line 5172 "inc/vcf/validator_detail_v41.hpp"
+#line 5172 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st214;
 	goto tr264;
@@ -5257,7 +5257,7 @@ case 225:
 		goto tr311;
 	goto tr264;
 tr311:
-#line 156 "src/vcf/vcf_v41.ragel"
+#line 156 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -5266,7 +5266,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 5270 "inc/vcf/validator_detail_v41.hpp"
+#line 5270 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr314;
 		case 92: goto tr315;
@@ -5275,17 +5275,17 @@ case 226:
 		goto tr313;
 	goto tr312;
 tr313:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st227;
 tr316:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5294,7 +5294,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 5298 "inc/vcf/validator_detail_v41.hpp"
+#line 5298 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -5303,17 +5303,17 @@ case 227:
 		goto tr316;
 	goto tr312;
 tr314:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st228;
 tr317:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5322,7 +5322,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 5326 "inc/vcf/validator_detail_v41.hpp"
+#line 5326 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st229;
 	goto tr312;
@@ -5336,17 +5336,17 @@ case 229:
 	}
 	goto tr264;
 tr315:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st230;
 tr318:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5355,7 +5355,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 5359 "inc/vcf/validator_detail_v41.hpp"
+#line 5359 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr318;
@@ -5364,11 +5364,11 @@ case 230:
 		goto tr316;
 	goto tr312;
 tr320:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5377,7 +5377,7 @@ st231:
 	if ( ++p == pe )
 		goto _test_eof231;
 case 231:
-#line 5381 "inc/vcf/validator_detail_v41.hpp"
+#line 5381 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 62: goto tr321;
@@ -5387,7 +5387,7 @@ case 231:
 		goto tr316;
 	goto tr312;
 tr321:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5396,7 +5396,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 5400 "inc/vcf/validator_detail_v41.hpp"
+#line 5400 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5407,21 +5407,21 @@ case 232:
 		goto tr316;
 	goto tr312;
 tr322:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st233;
 tr288:
-#line 148 "src/vcf/vcf_v41.ragel"
+#line 148 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5430,18 +5430,18 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 5434 "inc/vcf/validator_detail_v41.hpp"
+#line 5434 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr322;
 	goto tr286;
 tr34:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5450,7 +5450,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 5454 "inc/vcf/validator_detail_v41.hpp"
+#line 5454 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr324;
@@ -5459,7 +5459,7 @@ case 234:
 		goto tr40;
 	goto tr323;
 tr324:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5468,7 +5468,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 5472 "inc/vcf/validator_detail_v41.hpp"
+#line 5472 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr325;
@@ -5477,7 +5477,7 @@ case 235:
 		goto tr40;
 	goto tr323;
 tr325:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5486,7 +5486,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 5490 "inc/vcf/validator_detail_v41.hpp"
+#line 5490 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr326;
@@ -5495,7 +5495,7 @@ case 236:
 		goto tr40;
 	goto tr323;
 tr326:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5504,7 +5504,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 5508 "inc/vcf/validator_detail_v41.hpp"
+#line 5508 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr327;
@@ -5513,7 +5513,7 @@ case 237:
 		goto tr40;
 	goto tr323;
 tr327:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5522,7 +5522,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 5526 "inc/vcf/validator_detail_v41.hpp"
+#line 5526 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr328;
@@ -5531,7 +5531,7 @@ case 238:
 		goto tr40;
 	goto tr323;
 tr328:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5540,7 +5540,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 5544 "inc/vcf/validator_detail_v41.hpp"
+#line 5544 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr329;
@@ -5549,7 +5549,7 @@ case 239:
 		goto tr40;
 	goto tr323;
 tr329:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5558,7 +5558,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 5562 "inc/vcf/validator_detail_v41.hpp"
+#line 5562 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st241;
@@ -5576,7 +5576,7 @@ case 241:
 		goto tr40;
 	goto tr323;
 tr331:
-#line 132 "src/vcf/vcf_v41.ragel"
+#line 132 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "PEDIGREE");
     }
@@ -5585,12 +5585,12 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 5589 "inc/vcf/validator_detail_v41.hpp"
+#line 5589 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st243;
 	goto tr323;
 tr343:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5599,7 +5599,7 @@ st243:
 	if ( ++p == pe )
 		goto _test_eof243;
 case 243:
-#line 5603 "inc/vcf/validator_detail_v41.hpp"
+#line 5603 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr334;
 	if ( (*p) < 48 ) {
@@ -5615,7 +5615,7 @@ case 243:
 		goto tr335;
 	goto tr333;
 tr334:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5624,7 +5624,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 5628 "inc/vcf/validator_detail_v41.hpp"
+#line 5628 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st244;
 	if ( (*p) < 48 ) {
@@ -5640,17 +5640,17 @@ case 244:
 		goto tr337;
 	goto tr333;
 tr335:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st245;
 tr337:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5659,7 +5659,7 @@ st245:
 	if ( ++p == pe )
 		goto _test_eof245;
 case 245:
-#line 5663 "inc/vcf/validator_detail_v41.hpp"
+#line 5663 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr338;
 		case 95: goto tr337;
@@ -5677,7 +5677,7 @@ case 245:
 		goto tr337;
 	goto tr333;
 tr338:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5686,7 +5686,7 @@ st246:
 	if ( ++p == pe )
 		goto _test_eof246;
 case 246:
-#line 5690 "inc/vcf/validator_detail_v41.hpp"
+#line 5690 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr339;
 	if ( (*p) < 48 ) {
@@ -5702,7 +5702,7 @@ case 246:
 		goto tr340;
 	goto tr333;
 tr339:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5711,7 +5711,7 @@ st247:
 	if ( ++p == pe )
 		goto _test_eof247;
 case 247:
-#line 5715 "inc/vcf/validator_detail_v41.hpp"
+#line 5715 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st247;
 	if ( (*p) < 48 ) {
@@ -5727,17 +5727,17 @@ case 247:
 		goto tr342;
 	goto tr333;
 tr340:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st248;
 tr342:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5746,7 +5746,7 @@ st248:
 	if ( ++p == pe )
 		goto _test_eof248;
 case 248:
-#line 5750 "inc/vcf/validator_detail_v41.hpp"
+#line 5750 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr343;
 		case 62: goto tr344;
@@ -5765,7 +5765,7 @@ case 248:
 		goto tr342;
 	goto tr333;
 tr344:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5774,18 +5774,18 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 5778 "inc/vcf/validator_detail_v41.hpp"
+#line 5778 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
 	}
 	goto tr323;
 tr35:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5794,7 +5794,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 5798 "inc/vcf/validator_detail_v41.hpp"
+#line 5798 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr346;
@@ -5803,7 +5803,7 @@ case 250:
 		goto tr40;
 	goto tr345;
 tr346:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5812,7 +5812,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 5816 "inc/vcf/validator_detail_v41.hpp"
+#line 5816 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr347;
@@ -5821,7 +5821,7 @@ case 251:
 		goto tr40;
 	goto tr345;
 tr347:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5830,7 +5830,7 @@ st252:
 	if ( ++p == pe )
 		goto _test_eof252;
 case 252:
-#line 5834 "inc/vcf/validator_detail_v41.hpp"
+#line 5834 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr348;
@@ -5839,7 +5839,7 @@ case 252:
 		goto tr40;
 	goto tr345;
 tr348:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5848,7 +5848,7 @@ st253:
 	if ( ++p == pe )
 		goto _test_eof253;
 case 253:
-#line 5852 "inc/vcf/validator_detail_v41.hpp"
+#line 5852 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr349;
@@ -5857,7 +5857,7 @@ case 253:
 		goto tr40;
 	goto tr345;
 tr349:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5866,7 +5866,7 @@ st254:
 	if ( ++p == pe )
 		goto _test_eof254;
 case 254:
-#line 5870 "inc/vcf/validator_detail_v41.hpp"
+#line 5870 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st255;
@@ -5884,7 +5884,7 @@ case 255:
 		goto tr40;
 	goto tr345;
 tr351:
-#line 140 "src/vcf/vcf_v41.ragel"
+#line 140 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "SAMPLE");
     }
@@ -5893,7 +5893,7 @@ st256:
 	if ( ++p == pe )
 		goto _test_eof256;
 case 256:
-#line 5897 "inc/vcf/validator_detail_v41.hpp"
+#line 5897 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st257;
 	goto tr345;
@@ -5937,11 +5937,11 @@ case 260:
 		goto tr358;
 	goto tr356;
 tr357:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5950,7 +5950,7 @@ st261:
 	if ( ++p == pe )
 		goto _test_eof261;
 case 261:
-#line 5954 "inc/vcf/validator_detail_v41.hpp"
+#line 5954 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st261;
 	if ( (*p) < 48 ) {
@@ -5966,21 +5966,21 @@ case 261:
 		goto tr360;
 	goto tr356;
 tr360:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st262;
 tr358:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5989,7 +5989,7 @@ st262:
 	if ( ++p == pe )
 		goto _test_eof262;
 case 262:
-#line 5993 "inc/vcf/validator_detail_v41.hpp"
+#line 5993 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr362;
 		case 95: goto tr360;
@@ -6007,7 +6007,7 @@ case 262:
 		goto tr360;
 	goto tr361;
 tr362:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6016,7 +6016,7 @@ st263:
 	if ( ++p == pe )
 		goto _test_eof263;
 case 263:
-#line 6020 "inc/vcf/validator_detail_v41.hpp"
+#line 6020 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 71 )
 		goto st264;
 	goto tr363;
@@ -6086,21 +6086,21 @@ case 271:
 		goto tr372;
 	goto tr363;
 tr374:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st272;
 tr372:
-#line 160 "src/vcf/vcf_v41.ragel"
+#line 160 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Genomes");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6109,7 +6109,7 @@ st272:
 	if ( ++p == pe )
 		goto _test_eof272;
 case 272:
-#line 6113 "inc/vcf/validator_detail_v41.hpp"
+#line 6113 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr375;
 	if ( (*p) < 35 ) {
@@ -6122,7 +6122,7 @@ case 272:
 		goto tr374;
 	goto tr373;
 tr375:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6131,7 +6131,7 @@ st273:
 	if ( ++p == pe )
 		goto _test_eof273;
 case 273:
-#line 6135 "inc/vcf/validator_detail_v41.hpp"
+#line 6135 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 77 )
 		goto st274;
 	goto tr376;
@@ -6201,21 +6201,21 @@ case 281:
 		goto tr385;
 	goto tr376;
 tr387:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st282;
 tr385:
-#line 164 "src/vcf/vcf_v41.ragel"
+#line 164 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Mixture");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6224,7 +6224,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 6228 "inc/vcf/validator_detail_v41.hpp"
+#line 6228 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) < 35 ) {
@@ -6237,7 +6237,7 @@ case 282:
 		goto tr387;
 	goto tr386;
 tr388:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6246,7 +6246,7 @@ st283:
 	if ( ++p == pe )
 		goto _test_eof283;
 case 283:
-#line 6250 "inc/vcf/validator_detail_v41.hpp"
+#line 6250 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st284;
 	goto tr389;
@@ -6335,7 +6335,7 @@ case 295:
 		goto tr402;
 	goto tr389;
 tr402:
-#line 156 "src/vcf/vcf_v41.ragel"
+#line 156 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -6344,7 +6344,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 6348 "inc/vcf/validator_detail_v41.hpp"
+#line 6348 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 92: goto tr405;
@@ -6353,17 +6353,17 @@ case 296:
 		goto tr403;
 	goto tr389;
 tr403:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st297;
 tr406:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6372,7 +6372,7 @@ st297:
 	if ( ++p == pe )
 		goto _test_eof297;
 case 297:
-#line 6376 "inc/vcf/validator_detail_v41.hpp"
+#line 6376 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 92: goto tr408;
@@ -6381,17 +6381,17 @@ case 297:
 		goto tr406;
 	goto tr389;
 tr404:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st298;
 tr407:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6400,7 +6400,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 6404 "inc/vcf/validator_detail_v41.hpp"
+#line 6404 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st299;
 	goto tr389;
@@ -6414,17 +6414,17 @@ case 299:
 	}
 	goto tr345;
 tr405:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st300;
 tr408:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6433,7 +6433,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 6437 "inc/vcf/validator_detail_v41.hpp"
+#line 6437 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr410;
 		case 92: goto tr408;
@@ -6442,11 +6442,11 @@ case 300:
 		goto tr406;
 	goto tr389;
 tr410:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6455,7 +6455,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 6459 "inc/vcf/validator_detail_v41.hpp"
+#line 6459 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 62: goto tr411;
@@ -6465,7 +6465,7 @@ case 301:
 		goto tr406;
 	goto tr389;
 tr411:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6474,7 +6474,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 6478 "inc/vcf/validator_detail_v41.hpp"
+#line 6478 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6485,11 +6485,11 @@ case 302:
 		goto tr406;
 	goto tr389;
 tr36:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6498,7 +6498,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 6502 "inc/vcf/validator_detail_v41.hpp"
+#line 6502 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr413;
@@ -6507,7 +6507,7 @@ case 303:
 		goto tr40;
 	goto tr412;
 tr413:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6516,7 +6516,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 6520 "inc/vcf/validator_detail_v41.hpp"
+#line 6520 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr414;
@@ -6525,7 +6525,7 @@ case 304:
 		goto tr40;
 	goto tr412;
 tr414:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6534,7 +6534,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 6538 "inc/vcf/validator_detail_v41.hpp"
+#line 6538 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr415;
@@ -6543,7 +6543,7 @@ case 305:
 		goto tr40;
 	goto tr412;
 tr415:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6552,7 +6552,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 6556 "inc/vcf/validator_detail_v41.hpp"
+#line 6556 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr416;
@@ -6561,7 +6561,7 @@ case 306:
 		goto tr40;
 	goto tr412;
 tr416:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6570,7 +6570,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 6574 "inc/vcf/validator_detail_v41.hpp"
+#line 6574 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr417;
@@ -6579,7 +6579,7 @@ case 307:
 		goto tr40;
 	goto tr412;
 tr417:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6588,7 +6588,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 6592 "inc/vcf/validator_detail_v41.hpp"
+#line 6592 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr418;
@@ -6597,7 +6597,7 @@ case 308:
 		goto tr40;
 	goto tr412;
 tr418:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6606,7 +6606,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 6610 "inc/vcf/validator_detail_v41.hpp"
+#line 6610 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st310;
@@ -6624,7 +6624,7 @@ case 310:
 		goto tr40;
 	goto tr412;
 tr420:
-#line 112 "src/vcf/vcf_v41.ragel"
+#line 112 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "assembly");
     }
@@ -6633,7 +6633,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 6637 "inc/vcf/validator_detail_v41.hpp"
+#line 6637 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr422;
@@ -6641,7 +6641,7 @@ case 311:
 		goto tr422;
 	goto tr421;
 tr422:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6650,7 +6650,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 6654 "inc/vcf/validator_detail_v41.hpp"
+#line 6654 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6661,7 +6661,7 @@ case 312:
 	}
 	goto st313;
 tr424:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -6676,7 +6676,7 @@ st313:
 	if ( ++p == pe )
 		goto _test_eof313;
 case 313:
-#line 6680 "inc/vcf/validator_detail_v41.hpp"
+#line 6680 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6762,13 +6762,13 @@ case 322:
 		goto tr429;
 	goto tr421;
 tr429:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st323;
 tr438:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -6778,15 +6778,15 @@ tr438:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 176 "src/vcf/vcf_v41.ragel"
+#line 176 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -6799,7 +6799,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 6803 "inc/vcf/validator_detail_v41.hpp"
+#line 6803 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr438;
@@ -6854,11 +6854,11 @@ case 329:
 		goto st318;
 	goto tr421;
 tr37:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6867,7 +6867,7 @@ st330:
 	if ( ++p == pe )
 		goto _test_eof330;
 case 330:
-#line 6871 "inc/vcf/validator_detail_v41.hpp"
+#line 6871 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr443;
@@ -6876,7 +6876,7 @@ case 330:
 		goto tr40;
 	goto tr442;
 tr443:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6885,7 +6885,7 @@ st331:
 	if ( ++p == pe )
 		goto _test_eof331;
 case 331:
-#line 6889 "inc/vcf/validator_detail_v41.hpp"
+#line 6889 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr444;
@@ -6894,7 +6894,7 @@ case 331:
 		goto tr40;
 	goto tr442;
 tr444:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6903,7 +6903,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 6907 "inc/vcf/validator_detail_v41.hpp"
+#line 6907 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr445;
@@ -6912,7 +6912,7 @@ case 332:
 		goto tr40;
 	goto tr442;
 tr445:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6921,7 +6921,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 6925 "inc/vcf/validator_detail_v41.hpp"
+#line 6925 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr446;
@@ -6930,7 +6930,7 @@ case 333:
 		goto tr40;
 	goto tr442;
 tr446:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6939,7 +6939,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 6943 "inc/vcf/validator_detail_v41.hpp"
+#line 6943 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st335;
@@ -6957,7 +6957,7 @@ case 335:
 		goto tr40;
 	goto tr442;
 tr448:
-#line 116 "src/vcf/vcf_v41.ragel"
+#line 116 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "contig");
     }
@@ -6966,7 +6966,7 @@ st336:
 	if ( ++p == pe )
 		goto _test_eof336;
 case 336:
-#line 6970 "inc/vcf/validator_detail_v41.hpp"
+#line 6970 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st337;
 	goto tr442;
@@ -7005,21 +7005,21 @@ case 340:
 		goto tr454;
 	goto tr453;
 tr455:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st341;
 tr454:
-#line 144 "src/vcf/vcf_v41.ragel"
+#line 144 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7028,7 +7028,7 @@ st341:
 	if ( ++p == pe )
 		goto _test_eof341;
 case 341:
-#line 7032 "inc/vcf/validator_detail_v41.hpp"
+#line 7032 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 59: goto tr455;
@@ -7041,7 +7041,7 @@ case 341:
 		goto tr455;
 	goto tr453;
 tr456:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7050,7 +7050,7 @@ st342:
 	if ( ++p == pe )
 		goto _test_eof342;
 case 342:
-#line 7054 "inc/vcf/validator_detail_v41.hpp"
+#line 7054 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr458;
 	if ( (*p) < 48 ) {
@@ -7066,7 +7066,7 @@ case 342:
 		goto tr459;
 	goto tr442;
 tr458:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7075,7 +7075,7 @@ st343:
 	if ( ++p == pe )
 		goto _test_eof343;
 case 343:
-#line 7079 "inc/vcf/validator_detail_v41.hpp"
+#line 7079 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st343;
 	if ( (*p) < 48 ) {
@@ -7091,17 +7091,17 @@ case 343:
 		goto tr461;
 	goto tr442;
 tr459:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st344;
 tr461:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7110,7 +7110,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 7114 "inc/vcf/validator_detail_v41.hpp"
+#line 7114 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr462;
 		case 95: goto tr461;
@@ -7128,7 +7128,7 @@ case 344:
 		goto tr461;
 	goto tr442;
 tr462:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7137,7 +7137,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 7141 "inc/vcf/validator_detail_v41.hpp"
+#line 7141 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st348;
 	if ( (*p) < 45 ) {
@@ -7150,17 +7150,17 @@ case 345:
 		goto tr463;
 	goto tr442;
 tr463:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st346;
 tr465:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7169,7 +7169,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 7173 "inc/vcf/validator_detail_v41.hpp"
+#line 7173 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 62: goto tr457;
@@ -7181,7 +7181,7 @@ case 346:
 		goto tr465;
 	goto tr442;
 tr457:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7190,7 +7190,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 7194 "inc/vcf/validator_detail_v41.hpp"
+#line 7194 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7208,17 +7208,17 @@ case 348:
 		goto tr466;
 	goto tr442;
 tr466:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st349;
 tr469:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7227,7 +7227,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 7231 "inc/vcf/validator_detail_v41.hpp"
+#line 7231 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 92: goto tr471;
@@ -7236,17 +7236,17 @@ case 349:
 		goto tr469;
 	goto tr442;
 tr467:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st350;
 tr470:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7255,24 +7255,24 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 7259 "inc/vcf/validator_detail_v41.hpp"
+#line 7259 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st342;
 		case 62: goto st347;
 	}
 	goto tr442;
 tr468:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st351;
 tr471:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7281,7 +7281,7 @@ st351:
 	if ( ++p == pe )
 		goto _test_eof351;
 case 351:
-#line 7285 "inc/vcf/validator_detail_v41.hpp"
+#line 7285 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 92: goto tr471;
@@ -7290,11 +7290,11 @@ case 351:
 		goto tr469;
 	goto tr442;
 tr474:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7303,7 +7303,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 7307 "inc/vcf/validator_detail_v41.hpp"
+#line 7307 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr475;
@@ -7314,27 +7314,27 @@ case 352:
 		goto tr469;
 	goto tr442;
 tr489:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st353;
 tr475:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st353;
 tr486:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7343,7 +7343,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 7347 "inc/vcf/validator_detail_v41.hpp"
+#line 7347 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7375,17 +7375,17 @@ case 353:
 		goto tr469;
 	goto tr442;
 tr477:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st354;
 tr479:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7394,7 +7394,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 7398 "inc/vcf/validator_detail_v41.hpp"
+#line 7398 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7426,17 +7426,17 @@ case 354:
 		goto tr469;
 	goto tr442;
 tr478:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st355;
 tr480:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7445,7 +7445,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 7449 "inc/vcf/validator_detail_v41.hpp"
+#line 7449 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7475,11 +7475,11 @@ case 355:
 		goto tr480;
 	goto tr442;
 tr481:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7488,7 +7488,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 7492 "inc/vcf/validator_detail_v41.hpp"
+#line 7492 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr483;
 		case 44: goto tr469;
@@ -7499,17 +7499,17 @@ case 356:
 		goto tr482;
 	goto tr442;
 tr485:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st357;
 tr482:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7518,7 +7518,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 7522 "inc/vcf/validator_detail_v41.hpp"
+#line 7522 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr486;
@@ -7529,27 +7529,27 @@ case 357:
 		goto tr485;
 	goto tr442;
 tr490:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st358;
 tr476:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st358;
 tr487:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7558,7 +7558,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 7562 "inc/vcf/validator_detail_v41.hpp"
+#line 7562 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7569,17 +7569,17 @@ case 358:
 		goto tr469;
 	goto tr442;
 tr488:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st359;
 tr484:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7588,7 +7588,7 @@ st359:
 	if ( ++p == pe )
 		goto _test_eof359;
 case 359:
-#line 7592 "inc/vcf/validator_detail_v41.hpp"
+#line 7592 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 44: goto tr486;
@@ -7599,7 +7599,7 @@ case 359:
 		goto tr485;
 	goto tr442;
 tr483:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7608,7 +7608,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 7612 "inc/vcf/validator_detail_v41.hpp"
+#line 7612 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr467;
 		case 44: goto tr489;
@@ -7619,11 +7619,11 @@ case 360:
 		goto tr466;
 	goto tr442;
 tr38:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7632,7 +7632,7 @@ st361:
 	if ( ++p == pe )
 		goto _test_eof361;
 case 361:
-#line 7636 "inc/vcf/validator_detail_v41.hpp"
+#line 7636 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr492;
@@ -7641,7 +7641,7 @@ case 361:
 		goto tr40;
 	goto tr491;
 tr492:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7650,7 +7650,7 @@ st362:
 	if ( ++p == pe )
 		goto _test_eof362;
 case 362:
-#line 7654 "inc/vcf/validator_detail_v41.hpp"
+#line 7654 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr493;
@@ -7659,7 +7659,7 @@ case 362:
 		goto tr40;
 	goto tr491;
 tr493:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7668,7 +7668,7 @@ st363:
 	if ( ++p == pe )
 		goto _test_eof363;
 case 363:
-#line 7672 "inc/vcf/validator_detail_v41.hpp"
+#line 7672 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr494;
@@ -7677,7 +7677,7 @@ case 363:
 		goto tr40;
 	goto tr491;
 tr494:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7686,7 +7686,7 @@ st364:
 	if ( ++p == pe )
 		goto _test_eof364;
 case 364:
-#line 7690 "inc/vcf/validator_detail_v41.hpp"
+#line 7690 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr495;
@@ -7695,7 +7695,7 @@ case 364:
 		goto tr40;
 	goto tr491;
 tr495:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7704,7 +7704,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 7708 "inc/vcf/validator_detail_v41.hpp"
+#line 7708 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr496;
@@ -7713,7 +7713,7 @@ case 365:
 		goto tr40;
 	goto tr491;
 tr496:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7722,7 +7722,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 7726 "inc/vcf/validator_detail_v41.hpp"
+#line 7726 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr497;
@@ -7731,7 +7731,7 @@ case 366:
 		goto tr40;
 	goto tr491;
 tr497:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7740,7 +7740,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 7744 "inc/vcf/validator_detail_v41.hpp"
+#line 7744 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr498;
@@ -7749,7 +7749,7 @@ case 367:
 		goto tr40;
 	goto tr491;
 tr498:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7758,7 +7758,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 7762 "inc/vcf/validator_detail_v41.hpp"
+#line 7762 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr499;
@@ -7767,7 +7767,7 @@ case 368:
 		goto tr40;
 	goto tr491;
 tr499:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7776,7 +7776,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 7780 "inc/vcf/validator_detail_v41.hpp"
+#line 7780 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st370;
@@ -7794,7 +7794,7 @@ case 370:
 		goto tr40;
 	goto tr491;
 tr501:
-#line 136 "src/vcf/vcf_v41.ragel"
+#line 136 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "pedigreeDB");
     }
@@ -7803,7 +7803,7 @@ st371:
 	if ( ++p == pe )
 		goto _test_eof371;
 case 371:
-#line 7807 "inc/vcf/validator_detail_v41.hpp"
+#line 7807 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st372;
 	goto tr491;
@@ -7818,7 +7818,7 @@ case 372:
 		goto tr504;
 	goto tr503;
 tr504:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7827,7 +7827,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 7831 "inc/vcf/validator_detail_v41.hpp"
+#line 7831 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7838,7 +7838,7 @@ case 373:
 	}
 	goto st374;
 tr506:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -7853,7 +7853,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 7857 "inc/vcf/validator_detail_v41.hpp"
+#line 7857 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7939,13 +7939,13 @@ case 383:
 		goto tr511;
 	goto tr503;
 tr511:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st384;
 tr520:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -7955,7 +7955,7 @@ tr520:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7964,7 +7964,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 7968 "inc/vcf/validator_detail_v41.hpp"
+#line 7968 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr520;
@@ -7972,11 +7972,11 @@ case 384:
 	}
 	goto tr511;
 tr521:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7985,7 +7985,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 7989 "inc/vcf/validator_detail_v41.hpp"
+#line 7989 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr522;
@@ -7993,7 +7993,7 @@ case 385:
 	}
 	goto tr511;
 tr522:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -8003,11 +8003,11 @@ tr522:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 176 "src/vcf/vcf_v41.ragel"
+#line 176 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -8020,7 +8020,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 8024 "inc/vcf/validator_detail_v41.hpp"
+#line 8024 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr520;
@@ -8111,7 +8111,7 @@ case 397:
 		goto tr531;
 	goto tr526;
 tr531:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8120,7 +8120,7 @@ st398:
 	if ( ++p == pe )
 		goto _test_eof398;
 case 398:
-#line 8124 "inc/vcf/validator_detail_v41.hpp"
+#line 8124 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 80 )
 		goto st399;
 	goto tr526;
@@ -8146,7 +8146,7 @@ case 401:
 		goto tr535;
 	goto tr526;
 tr535:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8155,7 +8155,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 8159 "inc/vcf/validator_detail_v41.hpp"
+#line 8159 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st403;
 	goto tr526;
@@ -8174,7 +8174,7 @@ case 404:
 		goto tr538;
 	goto tr526;
 tr538:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8183,7 +8183,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 8187 "inc/vcf/validator_detail_v41.hpp"
+#line 8187 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 82 )
 		goto st406;
 	goto tr526;
@@ -8209,7 +8209,7 @@ case 408:
 		goto tr542;
 	goto tr526;
 tr542:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8218,7 +8218,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 8222 "inc/vcf/validator_detail_v41.hpp"
+#line 8222 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 65 )
 		goto st410;
 	goto tr526;
@@ -8244,7 +8244,7 @@ case 412:
 		goto tr546;
 	goto tr526;
 tr546:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8253,7 +8253,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 8257 "inc/vcf/validator_detail_v41.hpp"
+#line 8257 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 81 )
 		goto st414;
 	goto tr526;
@@ -8286,7 +8286,7 @@ case 417:
 		goto tr551;
 	goto tr526;
 tr551:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8295,7 +8295,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 8299 "inc/vcf/validator_detail_v41.hpp"
+#line 8299 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st419;
 	goto tr526;
@@ -8342,7 +8342,7 @@ case 424:
 		goto tr558;
 	goto tr526;
 tr558:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8351,7 +8351,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 8355 "inc/vcf/validator_detail_v41.hpp"
+#line 8355 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st426;
 	goto tr526;
@@ -8387,7 +8387,7 @@ case 429:
 	}
 	goto tr526;
 tr563:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8396,7 +8396,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 8400 "inc/vcf/validator_detail_v41.hpp"
+#line 8400 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st431;
 	goto tr566;
@@ -8443,17 +8443,17 @@ case 436:
 		goto tr573;
 	goto tr566;
 tr573:
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
 	goto st437;
 tr575:
-#line 184 "src/vcf/vcf_v41.ragel"
+#line 184 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8462,22 +8462,22 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 8466 "inc/vcf/validator_detail_v41.hpp"
+#line 8466 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr574;
 	goto tr566;
 tr574:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st438;
 tr578:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8486,7 +8486,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 8490 "inc/vcf/validator_detail_v41.hpp"
+#line 8490 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr575;
 		case 10: goto tr576;
@@ -8496,11 +8496,11 @@ case 438:
 		goto tr578;
 	goto tr566;
 tr564:
-#line 188 "src/vcf/vcf_v41.ragel"
+#line 188 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -8512,15 +8512,15 @@ tr564:
     }
 	goto st654;
 tr576:
-#line 184 "src/vcf/vcf_v41.ragel"
+#line 184 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 188 "src/vcf/vcf_v41.ragel"
+#line 188 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -8535,7 +8535,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 8539 "inc/vcf/validator_detail_v41.hpp"
+#line 8539 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr860;
 		case 13: goto tr861;
@@ -8551,7 +8551,7 @@ case 654:
 		goto tr862;
 	goto tr859;
 tr864:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -8563,7 +8563,7 @@ tr864:
     }
 	goto st655;
 tr860:
-#line 70 "src/vcf/vcf_v41.ragel"
+#line 70 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -8571,7 +8571,7 @@ tr860:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -8586,14 +8586,14 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 8590 "inc/vcf/validator_detail_v41.hpp"
+#line 8590 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr864;
 		case 13: goto tr865;
 	}
 	goto st0;
 tr865:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -8605,7 +8605,7 @@ tr865:
     }
 	goto st439;
 tr861:
-#line 70 "src/vcf/vcf_v41.ragel"
+#line 70 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -8613,7 +8613,7 @@ tr861:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -8628,28 +8628,28 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 8632 "inc/vcf/validator_detail_v41.hpp"
+#line 8632 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st655;
 	goto st0;
 tr866:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st440;
 tr583:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st440;
 tr862:
-#line 70 "src/vcf/vcf_v41.ragel"
+#line 70 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -8657,11 +8657,11 @@ tr862:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8670,7 +8670,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 8674 "inc/vcf/validator_detail_v41.hpp"
+#line 8674 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr582;
 		case 59: goto tr583;
@@ -8686,25 +8686,25 @@ case 440:
 		goto tr583;
 	goto tr581;
 tr582:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
 	goto st441;
 tr662:
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8713,22 +8713,22 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 8717 "inc/vcf/validator_detail_v41.hpp"
+#line 8717 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr585;
 	goto tr584;
 tr585:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st442;
 tr587:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8737,28 +8737,28 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 8741 "inc/vcf/validator_detail_v41.hpp"
+#line 8741 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr586;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr587;
 	goto tr584;
 tr592:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st443;
 tr586:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8767,7 +8767,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 8771 "inc/vcf/validator_detail_v41.hpp"
+#line 8771 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr589;
@@ -8775,17 +8775,17 @@ case 443:
 		goto tr589;
 	goto tr588;
 tr589:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st444;
 tr591:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8794,7 +8794,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 8798 "inc/vcf/validator_detail_v41.hpp"
+#line 8798 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr590;
 		case 59: goto tr592;
@@ -8803,15 +8803,15 @@ case 444:
 		goto tr591;
 	goto tr588;
 tr590:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8820,7 +8820,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 8824 "inc/vcf/validator_detail_v41.hpp"
+#line 8824 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr594;
 		case 67: goto tr594;
@@ -8835,17 +8835,17 @@ case 445:
 	}
 	goto tr593;
 tr594:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st446;
 tr596:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8854,7 +8854,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 8858 "inc/vcf/validator_detail_v41.hpp"
+#line 8858 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr595;
 		case 65: goto tr596;
@@ -8870,15 +8870,15 @@ case 446:
 	}
 	goto tr593;
 tr595:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8887,7 +8887,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 8891 "inc/vcf/validator_detail_v41.hpp"
+#line 8891 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr599;
@@ -8907,17 +8907,17 @@ case 447:
 	}
 	goto tr597;
 tr598:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st448;
 tr822:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8926,22 +8926,22 @@ st448:
 	if ( ++p == pe )
 		goto _test_eof448;
 case 448:
-#line 8930 "inc/vcf/validator_detail_v41.hpp"
+#line 8930 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
 	}
 	goto tr597;
 tr604:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -8950,7 +8950,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 8954 "inc/vcf/validator_detail_v41.hpp"
+#line 8954 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr607;
 		case 45: goto tr607;
@@ -8962,11 +8962,11 @@ case 449:
 		goto tr609;
 	goto tr606;
 tr607:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8975,24 +8975,24 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 8979 "inc/vcf/validator_detail_v41.hpp"
+#line 8979 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr613;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr612;
 	goto tr606;
 tr609:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st451;
 tr612:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9001,7 +9001,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 9005 "inc/vcf/validator_detail_v41.hpp"
+#line 9005 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 46: goto tr615;
@@ -9012,15 +9012,15 @@ case 451:
 		goto tr612;
 	goto tr606;
 tr614:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -9029,7 +9029,7 @@ st452:
 	if ( ++p == pe )
 		goto _test_eof452;
 case 452:
-#line 9033 "inc/vcf/validator_detail_v41.hpp"
+#line 9033 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr619;
 		case 58: goto tr618;
@@ -9056,7 +9056,7 @@ case 452:
 		goto tr620;
 	goto tr617;
 tr618:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9065,7 +9065,7 @@ st453:
 	if ( ++p == pe )
 		goto _test_eof453;
 case 453:
-#line 9069 "inc/vcf/validator_detail_v41.hpp"
+#line 9069 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto st453;
 	if ( (*p) < 65 ) {
@@ -9090,17 +9090,17 @@ case 453:
 		goto tr622;
 	goto tr617;
 tr620:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st454;
 tr622:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9109,7 +9109,7 @@ st454:
 	if ( ++p == pe )
 		goto _test_eof454;
 case 454:
-#line 9113 "inc/vcf/validator_detail_v41.hpp"
+#line 9113 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 59: goto tr624;
@@ -9118,15 +9118,15 @@ case 454:
 		goto tr622;
 	goto tr617;
 tr623:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -9135,7 +9135,7 @@ st455:
 	if ( ++p == pe )
 		goto _test_eof455;
 case 455:
-#line 9139 "inc/vcf/validator_detail_v41.hpp"
+#line 9139 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr627;
 		case 49: goto tr629;
@@ -9174,17 +9174,17 @@ case 455:
 		goto tr628;
 	goto tr625;
 tr626:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st456;
 tr640:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9193,7 +9193,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 9197 "inc/vcf/validator_detail_v41.hpp"
+#line 9197 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr640;
 		case 60: goto tr640;
@@ -9220,17 +9220,17 @@ case 456:
 		goto tr641;
 	goto tr625;
 tr628:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st457;
 tr641:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9239,7 +9239,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 9243 "inc/vcf/validator_detail_v41.hpp"
+#line 9243 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9251,21 +9251,21 @@ case 457:
 		goto tr641;
 	goto tr625;
 tr651:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st458;
 tr642:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -9274,7 +9274,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 9278 "inc/vcf/validator_detail_v41.hpp"
+#line 9278 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr648;
@@ -9285,17 +9285,17 @@ case 458:
 		goto tr648;
 	goto tr647;
 tr648:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st459;
 tr650:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9304,7 +9304,7 @@ st459:
 	if ( ++p == pe )
 		goto _test_eof459;
 case 459:
-#line 9308 "inc/vcf/validator_detail_v41.hpp"
+#line 9308 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 58: goto tr651;
@@ -9319,15 +9319,15 @@ case 459:
 		goto tr650;
 	goto tr647;
 tr649:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v41.ragel"
+#line 53 "../src/vcf/vcf_v41.ragel"
 	{
         ++n_columns;
     }
@@ -9336,7 +9336,7 @@ st460:
 	if ( ++p == pe )
 		goto _test_eof460;
 case 460:
-#line 9340 "inc/vcf/validator_detail_v41.hpp"
+#line 9340 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr654;
 	if ( (*p) < 48 ) {
@@ -9349,17 +9349,17 @@ case 460:
 		goto tr655;
 	goto tr652;
 tr653:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st461;
 tr657:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9368,7 +9368,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 9372 "inc/vcf/validator_detail_v41.hpp"
+#line 9372 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9379,28 +9379,28 @@ case 461:
 		goto tr657;
 	goto tr656;
 tr643:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 198 "src/vcf/vcf_v41.ragel"
+#line 198 "../src/vcf/vcf_v41.ragel"
 	{
         try {
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                     ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -9410,7 +9410,7 @@ tr643:
             ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -9425,7 +9425,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 9429 "inc/vcf/validator_detail_v41.hpp"
+#line 9429 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr864;
 		case 13: goto tr865;
@@ -9441,7 +9441,7 @@ case 656:
 		goto tr866;
 	goto tr581;
 tr863:
-#line 70 "src/vcf/vcf_v41.ragel"
+#line 70 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -9454,7 +9454,7 @@ st462:
 	if ( ++p == pe )
 		goto _test_eof462;
 case 462:
-#line 9458 "inc/vcf/validator_detail_v41.hpp"
+#line 9458 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr659;
@@ -9465,17 +9465,17 @@ case 462:
 		goto tr659;
 	goto tr581;
 tr659:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st463;
 tr660:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9484,7 +9484,7 @@ st463:
 	if ( ++p == pe )
 		goto _test_eof463;
 case 463:
-#line 9488 "inc/vcf/validator_detail_v41.hpp"
+#line 9488 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr660;
 		case 62: goto tr661;
@@ -9499,7 +9499,7 @@ case 463:
 		goto tr660;
 	goto tr581;
 tr661:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9508,33 +9508,33 @@ st464:
 	if ( ++p == pe )
 		goto _test_eof464;
 case 464:
-#line 9512 "inc/vcf/validator_detail_v41.hpp"
+#line 9512 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr662;
 	goto tr581;
 tr644:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v41.ragel"
+#line 194 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 198 "src/vcf/vcf_v41.ragel"
+#line 198 "../src/vcf/vcf_v41.ragel"
 	{
         try {
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                     ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -9544,7 +9544,7 @@ tr644:
             ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -9559,12 +9559,12 @@ st465:
 	if ( ++p == pe )
 		goto _test_eof465;
 case 465:
-#line 9563 "inc/vcf/validator_detail_v41.hpp"
+#line 9563 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st656;
 	goto tr663;
 tr658:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9573,7 +9573,7 @@ st466:
 	if ( ++p == pe )
 		goto _test_eof466;
 case 466:
-#line 9577 "inc/vcf/validator_detail_v41.hpp"
+#line 9577 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr657;
@@ -9581,17 +9581,17 @@ case 466:
 		goto tr657;
 	goto tr656;
 tr654:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st467;
 tr666:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9600,7 +9600,7 @@ st467:
 	if ( ++p == pe )
 		goto _test_eof467;
 case 467:
-#line 9604 "inc/vcf/validator_detail_v41.hpp"
+#line 9604 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9613,7 +9613,7 @@ case 467:
 		goto tr657;
 	goto tr652;
 tr665:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9622,7 +9622,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 9626 "inc/vcf/validator_detail_v41.hpp"
+#line 9626 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9640,17 +9640,17 @@ case 468:
 		goto tr667;
 	goto tr652;
 tr655:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st469;
 tr667:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9659,7 +9659,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 9663 "inc/vcf/validator_detail_v41.hpp"
+#line 9663 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9678,7 +9678,7 @@ case 469:
 		goto tr667;
 	goto tr652;
 tr645:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9687,7 +9687,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 9691 "inc/vcf/validator_detail_v41.hpp"
+#line 9691 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 49: goto tr629;
 		case 58: goto tr626;
@@ -9725,11 +9725,11 @@ case 470:
 		goto tr628;
 	goto tr625;
 tr629:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9738,7 +9738,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 9742 "inc/vcf/validator_detail_v41.hpp"
+#line 9742 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9751,7 +9751,7 @@ case 471:
 		goto tr641;
 	goto tr625;
 tr668:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9760,7 +9760,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 9764 "inc/vcf/validator_detail_v41.hpp"
+#line 9764 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9773,7 +9773,7 @@ case 472:
 		goto tr641;
 	goto tr625;
 tr669:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9782,7 +9782,7 @@ st473:
 	if ( ++p == pe )
 		goto _test_eof473;
 case 473:
-#line 9786 "inc/vcf/validator_detail_v41.hpp"
+#line 9786 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9795,7 +9795,7 @@ case 473:
 		goto tr641;
 	goto tr625;
 tr670:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9804,7 +9804,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 9808 "inc/vcf/validator_detail_v41.hpp"
+#line 9808 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9817,7 +9817,7 @@ case 474:
 		goto tr641;
 	goto tr625;
 tr646:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9826,7 +9826,7 @@ st475:
 	if ( ++p == pe )
 		goto _test_eof475;
 case 475:
-#line 9830 "inc/vcf/validator_detail_v41.hpp"
+#line 9830 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr673;
@@ -9834,7 +9834,7 @@ case 475:
 		goto tr673;
 	goto tr672;
 tr673:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9843,7 +9843,7 @@ st476:
 	if ( ++p == pe )
 		goto _test_eof476;
 case 476:
-#line 9847 "inc/vcf/validator_detail_v41.hpp"
+#line 9847 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9854,7 +9854,7 @@ case 476:
 		goto tr673;
 	goto tr672;
 tr671:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9863,7 +9863,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 9867 "inc/vcf/validator_detail_v41.hpp"
+#line 9867 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9875,7 +9875,7 @@ case 477:
 		goto tr641;
 	goto tr674;
 tr675:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9884,12 +9884,12 @@ st478:
 	if ( ++p == pe )
 		goto _test_eof478;
 case 478:
-#line 9888 "inc/vcf/validator_detail_v41.hpp"
+#line 9888 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr677;
 	goto tr676;
 tr677:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9898,7 +9898,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 9902 "inc/vcf/validator_detail_v41.hpp"
+#line 9902 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9907,11 +9907,11 @@ case 479:
 	}
 	goto tr676;
 tr630:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9920,7 +9920,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 9924 "inc/vcf/validator_detail_v41.hpp"
+#line 9924 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9936,7 +9936,7 @@ case 480:
 		goto tr641;
 	goto tr625;
 tr678:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9945,7 +9945,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 9949 "inc/vcf/validator_detail_v41.hpp"
+#line 9949 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr682;
 	if ( (*p) > 58 ) {
@@ -9955,7 +9955,7 @@ case 481:
 		goto tr641;
 	goto tr625;
 tr682:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9964,7 +9964,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 9968 "inc/vcf/validator_detail_v41.hpp"
+#line 9968 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr684;
 	if ( (*p) < 45 ) {
@@ -9977,7 +9977,7 @@ case 482:
 		goto tr684;
 	goto tr683;
 tr684:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9986,7 +9986,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 9990 "inc/vcf/validator_detail_v41.hpp"
+#line 9990 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10003,7 +10003,7 @@ case 483:
 		goto tr684;
 	goto tr683;
 tr679:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10012,7 +10012,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10016 "inc/vcf/validator_detail_v41.hpp"
+#line 10016 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr685;
 	if ( (*p) > 58 ) {
@@ -10022,7 +10022,7 @@ case 484:
 		goto tr641;
 	goto tr625;
 tr685:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10031,12 +10031,12 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10035 "inc/vcf/validator_detail_v41.hpp"
+#line 10035 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr687;
 	goto tr686;
 tr687:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10045,7 +10045,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 10049 "inc/vcf/validator_detail_v41.hpp"
+#line 10049 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10057,7 +10057,7 @@ case 486:
 		goto tr687;
 	goto tr686;
 tr680:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10066,7 +10066,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 10070 "inc/vcf/validator_detail_v41.hpp"
+#line 10070 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr688;
 	if ( (*p) > 58 ) {
@@ -10076,7 +10076,7 @@ case 487:
 		goto tr641;
 	goto tr625;
 tr688:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10085,7 +10085,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 10089 "inc/vcf/validator_detail_v41.hpp"
+#line 10089 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr690;
 		case 45: goto tr690;
@@ -10096,7 +10096,7 @@ case 488:
 		goto tr691;
 	goto tr689;
 tr690:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10105,14 +10105,14 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 10109 "inc/vcf/validator_detail_v41.hpp"
+#line 10109 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr692;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr691;
 	goto tr689;
 tr691:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10121,7 +10121,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10125 "inc/vcf/validator_detail_v41.hpp"
+#line 10125 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10136,7 +10136,7 @@ case 490:
 		goto tr691;
 	goto tr689;
 tr694:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10145,12 +10145,12 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 10149 "inc/vcf/validator_detail_v41.hpp"
+#line 10149 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr696;
 	goto tr689;
 tr696:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10159,7 +10159,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 10163 "inc/vcf/validator_detail_v41.hpp"
+#line 10163 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10173,7 +10173,7 @@ case 492:
 		goto tr696;
 	goto tr689;
 tr695:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10182,7 +10182,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 10186 "inc/vcf/validator_detail_v41.hpp"
+#line 10186 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr697;
 		case 45: goto tr697;
@@ -10191,7 +10191,7 @@ case 493:
 		goto tr698;
 	goto tr689;
 tr697:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10200,12 +10200,12 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 10204 "inc/vcf/validator_detail_v41.hpp"
+#line 10204 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr698;
 	goto tr689;
 tr698:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10214,7 +10214,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10218 "inc/vcf/validator_detail_v41.hpp"
+#line 10218 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10226,7 +10226,7 @@ case 495:
 		goto tr698;
 	goto tr689;
 tr692:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10235,12 +10235,12 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10239 "inc/vcf/validator_detail_v41.hpp"
+#line 10239 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr699;
 	goto tr689;
 tr699:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10249,12 +10249,12 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10253 "inc/vcf/validator_detail_v41.hpp"
+#line 10253 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr700;
 	goto tr689;
 tr700:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10263,7 +10263,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10267 "inc/vcf/validator_detail_v41.hpp"
+#line 10267 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10273,7 +10273,7 @@ case 498:
 	}
 	goto tr689;
 tr693:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10282,12 +10282,12 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10286 "inc/vcf/validator_detail_v41.hpp"
+#line 10286 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr701;
 	goto tr689;
 tr701:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10296,12 +10296,12 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10300 "inc/vcf/validator_detail_v41.hpp"
+#line 10300 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr700;
 	goto tr689;
 tr681:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10310,7 +10310,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 10314 "inc/vcf/validator_detail_v41.hpp"
+#line 10314 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr702;
 	if ( (*p) > 58 ) {
@@ -10320,7 +10320,7 @@ case 501:
 		goto tr641;
 	goto tr625;
 tr702:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10329,12 +10329,12 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10333 "inc/vcf/validator_detail_v41.hpp"
+#line 10333 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr704;
 	goto tr703;
 tr704:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10343,7 +10343,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 10347 "inc/vcf/validator_detail_v41.hpp"
+#line 10347 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10354,11 +10354,11 @@ case 503:
 		goto tr704;
 	goto tr703;
 tr631:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10367,7 +10367,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 10371 "inc/vcf/validator_detail_v41.hpp"
+#line 10371 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10380,7 +10380,7 @@ case 504:
 		goto tr641;
 	goto tr625;
 tr705:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10389,7 +10389,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 10393 "inc/vcf/validator_detail_v41.hpp"
+#line 10393 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr706;
 	if ( (*p) > 58 ) {
@@ -10399,7 +10399,7 @@ case 505:
 		goto tr641;
 	goto tr625;
 tr706:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10408,7 +10408,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 10412 "inc/vcf/validator_detail_v41.hpp"
+#line 10412 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr708;
 		case 45: goto tr708;
@@ -10419,7 +10419,7 @@ case 506:
 		goto tr709;
 	goto tr707;
 tr708:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10428,14 +10428,14 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 10432 "inc/vcf/validator_detail_v41.hpp"
+#line 10432 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr710;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr709;
 	goto tr707;
 tr709:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10444,7 +10444,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 10448 "inc/vcf/validator_detail_v41.hpp"
+#line 10448 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10458,7 +10458,7 @@ case 508:
 		goto tr709;
 	goto tr707;
 tr712:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10467,12 +10467,12 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10471 "inc/vcf/validator_detail_v41.hpp"
+#line 10471 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr714;
 	goto tr707;
 tr714:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10481,7 +10481,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10485 "inc/vcf/validator_detail_v41.hpp"
+#line 10485 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10494,7 +10494,7 @@ case 510:
 		goto tr714;
 	goto tr707;
 tr713:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10503,7 +10503,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 10507 "inc/vcf/validator_detail_v41.hpp"
+#line 10507 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr715;
 		case 45: goto tr715;
@@ -10512,7 +10512,7 @@ case 511:
 		goto tr716;
 	goto tr707;
 tr715:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10521,12 +10521,12 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 10525 "inc/vcf/validator_detail_v41.hpp"
+#line 10525 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr716;
 	goto tr707;
 tr716:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10535,7 +10535,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 10539 "inc/vcf/validator_detail_v41.hpp"
+#line 10539 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10546,7 +10546,7 @@ case 513:
 		goto tr716;
 	goto tr707;
 tr710:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10555,12 +10555,12 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 10559 "inc/vcf/validator_detail_v41.hpp"
+#line 10559 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr717;
 	goto tr707;
 tr717:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10569,12 +10569,12 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 10573 "inc/vcf/validator_detail_v41.hpp"
+#line 10573 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr718;
 	goto tr707;
 tr718:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10583,7 +10583,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 10587 "inc/vcf/validator_detail_v41.hpp"
+#line 10587 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10592,7 +10592,7 @@ case 516:
 	}
 	goto tr707;
 tr711:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10601,12 +10601,12 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 10605 "inc/vcf/validator_detail_v41.hpp"
+#line 10605 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr719;
 	goto tr707;
 tr719:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10615,16 +10615,16 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 10619 "inc/vcf/validator_detail_v41.hpp"
+#line 10619 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr718;
 	goto tr707;
 tr632:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10633,7 +10633,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 10637 "inc/vcf/validator_detail_v41.hpp"
+#line 10637 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10646,7 +10646,7 @@ case 519:
 		goto tr641;
 	goto tr625;
 tr720:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10655,7 +10655,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 10659 "inc/vcf/validator_detail_v41.hpp"
+#line 10659 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10668,7 +10668,7 @@ case 520:
 		goto tr641;
 	goto tr625;
 tr721:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10677,7 +10677,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 10681 "inc/vcf/validator_detail_v41.hpp"
+#line 10681 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10690,7 +10690,7 @@ case 521:
 		goto tr641;
 	goto tr625;
 tr722:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10699,7 +10699,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 10703 "inc/vcf/validator_detail_v41.hpp"
+#line 10703 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10712,7 +10712,7 @@ case 522:
 		goto tr641;
 	goto tr625;
 tr723:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10721,7 +10721,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 10725 "inc/vcf/validator_detail_v41.hpp"
+#line 10725 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr724;
 	if ( (*p) > 58 ) {
@@ -10731,7 +10731,7 @@ case 523:
 		goto tr641;
 	goto tr625;
 tr724:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10740,12 +10740,12 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 10744 "inc/vcf/validator_detail_v41.hpp"
+#line 10744 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr726;
 	goto tr725;
 tr726:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10754,7 +10754,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 10758 "inc/vcf/validator_detail_v41.hpp"
+#line 10758 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 68: goto tr727;
 		case 80: goto tr727;
@@ -10771,7 +10771,7 @@ case 525:
 		goto tr727;
 	goto tr725;
 tr727:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10780,7 +10780,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 10784 "inc/vcf/validator_detail_v41.hpp"
+#line 10784 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10791,11 +10791,11 @@ case 526:
 		goto tr726;
 	goto tr725;
 tr633:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10804,7 +10804,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 10808 "inc/vcf/validator_detail_v41.hpp"
+#line 10808 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10818,7 +10818,7 @@ case 527:
 		goto tr641;
 	goto tr625;
 tr728:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10827,7 +10827,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 10831 "inc/vcf/validator_detail_v41.hpp"
+#line 10831 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10839,7 +10839,7 @@ case 528:
 		goto tr641;
 	goto tr730;
 tr731:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10848,12 +10848,12 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 10852 "inc/vcf/validator_detail_v41.hpp"
+#line 10852 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr733;
 	goto tr732;
 tr733:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10862,7 +10862,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 10866 "inc/vcf/validator_detail_v41.hpp"
+#line 10866 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10871,7 +10871,7 @@ case 530:
 	}
 	goto tr732;
 tr729:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10880,7 +10880,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 10884 "inc/vcf/validator_detail_v41.hpp"
+#line 10884 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr734;
 	if ( (*p) > 58 ) {
@@ -10890,7 +10890,7 @@ case 531:
 		goto tr641;
 	goto tr625;
 tr734:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10899,12 +10899,12 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 10903 "inc/vcf/validator_detail_v41.hpp"
+#line 10903 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr736;
 	goto tr735;
 tr736:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10913,7 +10913,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 10917 "inc/vcf/validator_detail_v41.hpp"
+#line 10917 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10924,11 +10924,11 @@ case 533:
 		goto tr736;
 	goto tr735;
 tr634:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10937,7 +10937,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 10941 "inc/vcf/validator_detail_v41.hpp"
+#line 10941 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10950,7 +10950,7 @@ case 534:
 		goto tr641;
 	goto tr625;
 tr737:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10959,7 +10959,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 10963 "inc/vcf/validator_detail_v41.hpp"
+#line 10963 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10972,7 +10972,7 @@ case 535:
 		goto tr641;
 	goto tr625;
 tr738:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10981,7 +10981,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 10985 "inc/vcf/validator_detail_v41.hpp"
+#line 10985 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr739;
 	if ( (*p) > 58 ) {
@@ -10991,7 +10991,7 @@ case 536:
 		goto tr641;
 	goto tr625;
 tr739:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11000,12 +11000,12 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 11004 "inc/vcf/validator_detail_v41.hpp"
+#line 11004 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr741;
 	goto tr740;
 tr741:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11014,7 +11014,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 11018 "inc/vcf/validator_detail_v41.hpp"
+#line 11018 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11025,11 +11025,11 @@ case 538:
 		goto tr741;
 	goto tr740;
 tr635:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11038,7 +11038,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 11042 "inc/vcf/validator_detail_v41.hpp"
+#line 11042 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11052,7 +11052,7 @@ case 539:
 		goto tr641;
 	goto tr625;
 tr742:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11061,7 +11061,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 11065 "inc/vcf/validator_detail_v41.hpp"
+#line 11065 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11073,7 +11073,7 @@ case 540:
 		goto tr641;
 	goto tr744;
 tr745:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11082,12 +11082,12 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 11086 "inc/vcf/validator_detail_v41.hpp"
+#line 11086 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr747;
 	goto tr746;
 tr747:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11096,7 +11096,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 11100 "inc/vcf/validator_detail_v41.hpp"
+#line 11100 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11105,7 +11105,7 @@ case 542:
 	}
 	goto tr746;
 tr743:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11114,7 +11114,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 11118 "inc/vcf/validator_detail_v41.hpp"
+#line 11118 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11126,7 +11126,7 @@ case 543:
 		goto tr641;
 	goto tr748;
 tr749:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11135,12 +11135,12 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 11139 "inc/vcf/validator_detail_v41.hpp"
+#line 11139 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr751;
 	goto tr750;
 tr751:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11149,7 +11149,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 11153 "inc/vcf/validator_detail_v41.hpp"
+#line 11153 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11158,11 +11158,11 @@ case 545:
 	}
 	goto tr750;
 tr636:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11171,7 +11171,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 11175 "inc/vcf/validator_detail_v41.hpp"
+#line 11175 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11184,7 +11184,7 @@ case 546:
 		goto tr641;
 	goto tr625;
 tr752:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11193,7 +11193,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 11197 "inc/vcf/validator_detail_v41.hpp"
+#line 11197 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 48: goto tr753;
 		case 61: goto tr754;
@@ -11205,7 +11205,7 @@ case 547:
 		goto tr641;
 	goto tr625;
 tr753:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11214,7 +11214,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 11218 "inc/vcf/validator_detail_v41.hpp"
+#line 11218 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr755;
 	if ( (*p) > 58 ) {
@@ -11224,7 +11224,7 @@ case 548:
 		goto tr641;
 	goto tr625;
 tr755:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11233,12 +11233,12 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 11237 "inc/vcf/validator_detail_v41.hpp"
+#line 11237 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr757;
 	goto tr756;
 tr757:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11247,7 +11247,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 11251 "inc/vcf/validator_detail_v41.hpp"
+#line 11251 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11258,7 +11258,7 @@ case 550:
 		goto tr757;
 	goto tr756;
 tr754:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11267,7 +11267,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 11271 "inc/vcf/validator_detail_v41.hpp"
+#line 11271 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr759;
 		case 45: goto tr759;
@@ -11278,7 +11278,7 @@ case 551:
 		goto tr760;
 	goto tr758;
 tr759:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11287,14 +11287,14 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 11291 "inc/vcf/validator_detail_v41.hpp"
+#line 11291 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr761;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr760;
 	goto tr758;
 tr760:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11303,7 +11303,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 11307 "inc/vcf/validator_detail_v41.hpp"
+#line 11307 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11317,7 +11317,7 @@ case 553:
 		goto tr760;
 	goto tr758;
 tr763:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11326,12 +11326,12 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 11330 "inc/vcf/validator_detail_v41.hpp"
+#line 11330 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr765;
 	goto tr758;
 tr765:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11340,7 +11340,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 11344 "inc/vcf/validator_detail_v41.hpp"
+#line 11344 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11353,7 +11353,7 @@ case 555:
 		goto tr765;
 	goto tr758;
 tr764:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11362,7 +11362,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 11366 "inc/vcf/validator_detail_v41.hpp"
+#line 11366 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr766;
 		case 45: goto tr766;
@@ -11371,7 +11371,7 @@ case 556:
 		goto tr767;
 	goto tr758;
 tr766:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11380,12 +11380,12 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 11384 "inc/vcf/validator_detail_v41.hpp"
+#line 11384 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr767;
 	goto tr758;
 tr767:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11394,7 +11394,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 11398 "inc/vcf/validator_detail_v41.hpp"
+#line 11398 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11405,7 +11405,7 @@ case 558:
 		goto tr767;
 	goto tr758;
 tr761:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11414,12 +11414,12 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 11418 "inc/vcf/validator_detail_v41.hpp"
+#line 11418 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr768;
 	goto tr758;
 tr768:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11428,12 +11428,12 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 11432 "inc/vcf/validator_detail_v41.hpp"
+#line 11432 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr769;
 	goto tr758;
 tr769:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11442,7 +11442,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 11446 "inc/vcf/validator_detail_v41.hpp"
+#line 11446 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11451,7 +11451,7 @@ case 561:
 	}
 	goto tr758;
 tr762:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11460,12 +11460,12 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 11464 "inc/vcf/validator_detail_v41.hpp"
+#line 11464 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr770;
 	goto tr758;
 tr770:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11474,16 +11474,16 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 11478 "inc/vcf/validator_detail_v41.hpp"
+#line 11478 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr769;
 	goto tr758;
 tr637:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11492,7 +11492,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 11496 "inc/vcf/validator_detail_v41.hpp"
+#line 11496 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11505,7 +11505,7 @@ case 564:
 		goto tr641;
 	goto tr625;
 tr771:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11514,7 +11514,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 11518 "inc/vcf/validator_detail_v41.hpp"
+#line 11518 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr772;
 	if ( (*p) > 58 ) {
@@ -11524,7 +11524,7 @@ case 565:
 		goto tr641;
 	goto tr625;
 tr772:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11533,12 +11533,12 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 11537 "inc/vcf/validator_detail_v41.hpp"
+#line 11537 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr774;
 	goto tr773;
 tr774:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11547,7 +11547,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 11551 "inc/vcf/validator_detail_v41.hpp"
+#line 11551 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11558,11 +11558,11 @@ case 567:
 		goto tr774;
 	goto tr773;
 tr638:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11571,7 +11571,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 11575 "inc/vcf/validator_detail_v41.hpp"
+#line 11575 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11585,7 +11585,7 @@ case 568:
 		goto tr641;
 	goto tr625;
 tr775:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11594,7 +11594,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 11598 "inc/vcf/validator_detail_v41.hpp"
+#line 11598 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr777;
 	if ( (*p) > 58 ) {
@@ -11604,7 +11604,7 @@ case 569:
 		goto tr641;
 	goto tr625;
 tr777:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11613,7 +11613,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 11617 "inc/vcf/validator_detail_v41.hpp"
+#line 11617 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr779;
 		case 45: goto tr779;
@@ -11624,7 +11624,7 @@ case 570:
 		goto tr780;
 	goto tr778;
 tr779:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11633,14 +11633,14 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 11637 "inc/vcf/validator_detail_v41.hpp"
+#line 11637 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr781;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr780;
 	goto tr778;
 tr780:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11649,7 +11649,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 11653 "inc/vcf/validator_detail_v41.hpp"
+#line 11653 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11663,7 +11663,7 @@ case 572:
 		goto tr780;
 	goto tr778;
 tr783:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11672,12 +11672,12 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 11676 "inc/vcf/validator_detail_v41.hpp"
+#line 11676 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr785;
 	goto tr778;
 tr785:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11686,7 +11686,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 11690 "inc/vcf/validator_detail_v41.hpp"
+#line 11690 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11699,7 +11699,7 @@ case 574:
 		goto tr785;
 	goto tr778;
 tr784:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11708,7 +11708,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 11712 "inc/vcf/validator_detail_v41.hpp"
+#line 11712 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr786;
 		case 45: goto tr786;
@@ -11717,7 +11717,7 @@ case 575:
 		goto tr787;
 	goto tr778;
 tr786:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11726,12 +11726,12 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 11730 "inc/vcf/validator_detail_v41.hpp"
+#line 11730 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr787;
 	goto tr778;
 tr787:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11740,7 +11740,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 11744 "inc/vcf/validator_detail_v41.hpp"
+#line 11744 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11751,7 +11751,7 @@ case 577:
 		goto tr787;
 	goto tr778;
 tr781:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11760,12 +11760,12 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 11764 "inc/vcf/validator_detail_v41.hpp"
+#line 11764 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr788;
 	goto tr778;
 tr788:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11774,12 +11774,12 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 11778 "inc/vcf/validator_detail_v41.hpp"
+#line 11778 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr789;
 	goto tr778;
 tr789:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11788,7 +11788,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 11792 "inc/vcf/validator_detail_v41.hpp"
+#line 11792 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11797,7 +11797,7 @@ case 580:
 	}
 	goto tr778;
 tr782:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11806,12 +11806,12 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 11810 "inc/vcf/validator_detail_v41.hpp"
+#line 11810 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr790;
 	goto tr778;
 tr790:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11820,12 +11820,12 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 11824 "inc/vcf/validator_detail_v41.hpp"
+#line 11824 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr789;
 	goto tr778;
 tr776:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11834,7 +11834,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 11838 "inc/vcf/validator_detail_v41.hpp"
+#line 11838 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11847,7 +11847,7 @@ case 583:
 		goto tr641;
 	goto tr625;
 tr791:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11856,7 +11856,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 11860 "inc/vcf/validator_detail_v41.hpp"
+#line 11860 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11869,7 +11869,7 @@ case 584:
 		goto tr641;
 	goto tr625;
 tr792:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11878,7 +11878,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 11882 "inc/vcf/validator_detail_v41.hpp"
+#line 11882 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11891,7 +11891,7 @@ case 585:
 		goto tr641;
 	goto tr625;
 tr793:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11900,7 +11900,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 11904 "inc/vcf/validator_detail_v41.hpp"
+#line 11904 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11913,7 +11913,7 @@ case 586:
 		goto tr641;
 	goto tr625;
 tr794:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11922,7 +11922,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 11926 "inc/vcf/validator_detail_v41.hpp"
+#line 11926 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11935,7 +11935,7 @@ case 587:
 		goto tr641;
 	goto tr625;
 tr795:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11944,7 +11944,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 11948 "inc/vcf/validator_detail_v41.hpp"
+#line 11948 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11956,7 +11956,7 @@ case 588:
 		goto tr641;
 	goto tr796;
 tr797:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11965,12 +11965,12 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 11969 "inc/vcf/validator_detail_v41.hpp"
+#line 11969 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr799;
 	goto tr798;
 tr799:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11979,7 +11979,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 11983 "inc/vcf/validator_detail_v41.hpp"
+#line 11983 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11988,11 +11988,11 @@ case 590:
 	}
 	goto tr798;
 tr639:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12001,7 +12001,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12005 "inc/vcf/validator_detail_v41.hpp"
+#line 12005 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12014,7 +12014,7 @@ case 591:
 		goto tr641;
 	goto tr625;
 tr800:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12023,7 +12023,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12027 "inc/vcf/validator_detail_v41.hpp"
+#line 12027 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12036,7 +12036,7 @@ case 592:
 		goto tr641;
 	goto tr625;
 tr801:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12045,7 +12045,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12049 "inc/vcf/validator_detail_v41.hpp"
+#line 12049 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12058,7 +12058,7 @@ case 593:
 		goto tr641;
 	goto tr625;
 tr802:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12067,7 +12067,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 12071 "inc/vcf/validator_detail_v41.hpp"
+#line 12071 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12080,7 +12080,7 @@ case 594:
 		goto tr641;
 	goto tr625;
 tr803:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12089,7 +12089,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 12093 "inc/vcf/validator_detail_v41.hpp"
+#line 12093 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12102,7 +12102,7 @@ case 595:
 		goto tr641;
 	goto tr625;
 tr804:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12111,7 +12111,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 12115 "inc/vcf/validator_detail_v41.hpp"
+#line 12115 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12124,7 +12124,7 @@ case 596:
 		goto tr641;
 	goto tr625;
 tr805:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12133,7 +12133,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 12137 "inc/vcf/validator_detail_v41.hpp"
+#line 12137 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12146,7 +12146,7 @@ case 597:
 		goto tr641;
 	goto tr625;
 tr806:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12155,7 +12155,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 12159 "inc/vcf/validator_detail_v41.hpp"
+#line 12159 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12168,7 +12168,7 @@ case 598:
 		goto tr641;
 	goto tr625;
 tr807:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12177,7 +12177,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 12181 "inc/vcf/validator_detail_v41.hpp"
+#line 12181 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12189,7 +12189,7 @@ case 599:
 		goto tr641;
 	goto tr808;
 tr809:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12198,12 +12198,12 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 12202 "inc/vcf/validator_detail_v41.hpp"
+#line 12202 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr811;
 	goto tr810;
 tr811:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12212,7 +12212,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 12216 "inc/vcf/validator_detail_v41.hpp"
+#line 12216 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12221,11 +12221,11 @@ case 601:
 	}
 	goto tr810;
 tr627:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12234,7 +12234,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 12238 "inc/vcf/validator_detail_v41.hpp"
+#line 12238 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12264,7 +12264,7 @@ case 602:
 		goto tr641;
 	goto tr625;
 tr624:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -12273,7 +12273,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 12277 "inc/vcf/validator_detail_v41.hpp"
+#line 12277 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr618;
 	if ( (*p) < 65 ) {
@@ -12298,11 +12298,11 @@ case 603:
 		goto tr620;
 	goto tr617;
 tr619:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12311,7 +12311,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 12315 "inc/vcf/validator_detail_v41.hpp"
+#line 12315 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 58: goto st453;
@@ -12338,7 +12338,7 @@ case 604:
 		goto tr622;
 	goto tr617;
 tr615:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12347,12 +12347,12 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 12351 "inc/vcf/validator_detail_v41.hpp"
+#line 12351 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr812;
 	goto tr606;
 tr812:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12361,7 +12361,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 12365 "inc/vcf/validator_detail_v41.hpp"
+#line 12365 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 69: goto tr616;
@@ -12371,7 +12371,7 @@ case 606:
 		goto tr812;
 	goto tr606;
 tr616:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12380,7 +12380,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 12384 "inc/vcf/validator_detail_v41.hpp"
+#line 12384 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr813;
 		case 45: goto tr813;
@@ -12389,7 +12389,7 @@ case 607:
 		goto tr814;
 	goto tr606;
 tr813:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12398,12 +12398,12 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 12402 "inc/vcf/validator_detail_v41.hpp"
+#line 12402 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr814;
 	goto tr606;
 tr814:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12412,24 +12412,24 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 12416 "inc/vcf/validator_detail_v41.hpp"
+#line 12416 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr814;
 	goto tr606;
 tr610:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st610;
 tr613:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12438,12 +12438,12 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 12442 "inc/vcf/validator_detail_v41.hpp"
+#line 12442 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr815;
 	goto tr606;
 tr815:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12452,22 +12452,22 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 12456 "inc/vcf/validator_detail_v41.hpp"
+#line 12456 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr816;
 	goto tr606;
 tr608:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st612;
 tr816:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12476,16 +12476,16 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 12480 "inc/vcf/validator_detail_v41.hpp"
+#line 12480 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	goto tr606;
 tr611:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12494,12 +12494,12 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 12498 "inc/vcf/validator_detail_v41.hpp"
+#line 12498 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr817;
 	goto tr606;
 tr817:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12508,12 +12508,12 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 12512 "inc/vcf/validator_detail_v41.hpp"
+#line 12512 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr816;
 	goto tr606;
 tr605:
-#line 39 "src/vcf/vcf_v41.ragel"
+#line 39 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -12522,7 +12522,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 12526 "inc/vcf/validator_detail_v41.hpp"
+#line 12526 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr818;
@@ -12542,17 +12542,17 @@ case 615:
 	}
 	goto tr597;
 tr818:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st616;
 tr842:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12561,7 +12561,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 12565 "inc/vcf/validator_detail_v41.hpp"
+#line 12565 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr819;
 		case 67: goto tr819;
@@ -12576,7 +12576,7 @@ case 616:
 	}
 	goto tr597;
 tr819:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12585,7 +12585,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 12589 "inc/vcf/validator_detail_v41.hpp"
+#line 12589 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12602,17 +12602,17 @@ case 617:
 	}
 	goto tr597;
 tr600:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st618;
 tr820:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12621,7 +12621,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 12625 "inc/vcf/validator_detail_v41.hpp"
+#line 12625 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr820;
 	if ( (*p) < 63 ) {
@@ -12652,7 +12652,7 @@ case 618:
 		goto tr820;
 	goto tr597;
 tr821:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12661,7 +12661,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 12665 "inc/vcf/validator_detail_v41.hpp"
+#line 12665 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto tr822;
 	if ( (*p) < 45 ) {
@@ -12674,17 +12674,17 @@ case 619:
 		goto tr821;
 	goto tr597;
 tr601:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st620;
 tr823:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12693,7 +12693,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 12697 "inc/vcf/validator_detail_v41.hpp"
+#line 12697 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12713,7 +12713,7 @@ case 620:
 	}
 	goto tr597;
 tr824:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12722,7 +12722,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 12726 "inc/vcf/validator_detail_v41.hpp"
+#line 12726 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr827;
 	if ( (*p) < 65 ) {
@@ -12735,7 +12735,7 @@ case 621:
 		goto tr826;
 	goto tr597;
 tr826:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12744,7 +12744,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 12748 "inc/vcf/validator_detail_v41.hpp"
+#line 12748 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr828;
 		case 61: goto tr826;
@@ -12759,7 +12759,7 @@ case 622:
 		goto tr826;
 	goto tr597;
 tr828:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12768,12 +12768,12 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 12772 "inc/vcf/validator_detail_v41.hpp"
+#line 12772 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr829;
 	goto tr597;
 tr829:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12782,14 +12782,14 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 12786 "inc/vcf/validator_detail_v41.hpp"
+#line 12786 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr829;
 	goto tr597;
 tr827:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12798,7 +12798,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 12802 "inc/vcf/validator_detail_v41.hpp"
+#line 12802 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr830;
@@ -12809,7 +12809,7 @@ case 625:
 		goto tr830;
 	goto tr597;
 tr830:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12818,7 +12818,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 12822 "inc/vcf/validator_detail_v41.hpp"
+#line 12822 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr830;
 		case 62: goto tr831;
@@ -12833,7 +12833,7 @@ case 626:
 		goto tr830;
 	goto tr597;
 tr831:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12842,12 +12842,12 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 12846 "inc/vcf/validator_detail_v41.hpp"
+#line 12846 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr828;
 	goto tr597;
 tr825:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12856,7 +12856,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 12860 "inc/vcf/validator_detail_v41.hpp"
+#line 12860 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr833;
 	if ( (*p) < 65 ) {
@@ -12869,7 +12869,7 @@ case 628:
 		goto tr832;
 	goto tr597;
 tr832:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12878,7 +12878,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 12882 "inc/vcf/validator_detail_v41.hpp"
+#line 12882 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr834;
 		case 61: goto tr832;
@@ -12893,7 +12893,7 @@ case 629:
 		goto tr832;
 	goto tr597;
 tr834:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12902,12 +12902,12 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 12906 "inc/vcf/validator_detail_v41.hpp"
+#line 12906 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr597;
 tr835:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12916,14 +12916,14 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 12920 "inc/vcf/validator_detail_v41.hpp"
+#line 12920 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr597;
 tr833:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12932,7 +12932,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 12936 "inc/vcf/validator_detail_v41.hpp"
+#line 12936 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr836;
@@ -12943,7 +12943,7 @@ case 632:
 		goto tr836;
 	goto tr597;
 tr836:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12952,7 +12952,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 12956 "inc/vcf/validator_detail_v41.hpp"
+#line 12956 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr836;
 		case 62: goto tr837;
@@ -12967,7 +12967,7 @@ case 633:
 		goto tr836;
 	goto tr597;
 tr837:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12976,16 +12976,16 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 12980 "inc/vcf/validator_detail_v41.hpp"
+#line 12980 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr834;
 	goto tr597;
 tr602:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12994,7 +12994,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 12998 "inc/vcf/validator_detail_v41.hpp"
+#line 12998 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr839;
 	if ( (*p) < 65 ) {
@@ -13007,7 +13007,7 @@ case 635:
 		goto tr838;
 	goto tr597;
 tr838:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13016,7 +13016,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13020 "inc/vcf/validator_detail_v41.hpp"
+#line 13020 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr840;
 		case 61: goto tr838;
@@ -13031,7 +13031,7 @@ case 636:
 		goto tr838;
 	goto tr597;
 tr840:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13040,12 +13040,12 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 13044 "inc/vcf/validator_detail_v41.hpp"
+#line 13044 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr841;
 	goto tr597;
 tr841:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13054,14 +13054,14 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 13058 "inc/vcf/validator_detail_v41.hpp"
+#line 13058 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr842;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr841;
 	goto tr597;
 tr839:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13070,7 +13070,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 13074 "inc/vcf/validator_detail_v41.hpp"
+#line 13074 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr843;
@@ -13081,7 +13081,7 @@ case 639:
 		goto tr843;
 	goto tr597;
 tr843:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13090,7 +13090,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 13094 "inc/vcf/validator_detail_v41.hpp"
+#line 13094 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr843;
 		case 62: goto tr844;
@@ -13105,7 +13105,7 @@ case 640:
 		goto tr843;
 	goto tr597;
 tr844:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13114,16 +13114,16 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 13118 "inc/vcf/validator_detail_v41.hpp"
+#line 13118 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr840;
 	goto tr597;
 tr603:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13132,7 +13132,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 13136 "inc/vcf/validator_detail_v41.hpp"
+#line 13136 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr846;
 	if ( (*p) < 65 ) {
@@ -13145,7 +13145,7 @@ case 642:
 		goto tr845;
 	goto tr597;
 tr845:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13154,7 +13154,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 13158 "inc/vcf/validator_detail_v41.hpp"
+#line 13158 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr847;
 		case 61: goto tr845;
@@ -13169,7 +13169,7 @@ case 643:
 		goto tr845;
 	goto tr597;
 tr847:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13178,12 +13178,12 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 13182 "inc/vcf/validator_detail_v41.hpp"
+#line 13182 "../inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr848;
 	goto tr597;
 tr848:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13192,14 +13192,14 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 13196 "inc/vcf/validator_detail_v41.hpp"
+#line 13196 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr842;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr848;
 	goto tr597;
 tr846:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13208,7 +13208,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 13212 "inc/vcf/validator_detail_v41.hpp"
+#line 13212 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr849;
@@ -13219,7 +13219,7 @@ case 646:
 		goto tr849;
 	goto tr597;
 tr849:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13228,7 +13228,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 13232 "inc/vcf/validator_detail_v41.hpp"
+#line 13232 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr849;
 		case 62: goto tr850;
@@ -13243,7 +13243,7 @@ case 647:
 		goto tr849;
 	goto tr597;
 tr850:
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13252,16 +13252,16 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 13256 "inc/vcf/validator_detail_v41.hpp"
+#line 13256 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr847;
 	goto tr597;
 tr599:
-#line 31 "src/vcf/vcf_v41.ragel"
+#line 31 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v41.ragel"
+#line 35 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13270,7 +13270,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 13274 "inc/vcf/validator_detail_v41.hpp"
+#line 13274 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 65: goto tr819;
@@ -13286,11 +13286,11 @@ case 649:
 	}
 	goto tr597;
 tr565:
-#line 188 "src/vcf/vcf_v41.ragel"
+#line 188 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13302,15 +13302,15 @@ tr565:
     }
 	goto st650;
 tr577:
-#line 184 "src/vcf/vcf_v41.ragel"
+#line 184 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 188 "src/vcf/vcf_v41.ragel"
+#line 188 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13325,12 +13325,12 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 13329 "inc/vcf/validator_detail_v41.hpp"
+#line 13329 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st654;
 	goto tr566;
 tr23:
-#line 99 "src/vcf/vcf_v41.ragel"
+#line 99 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
@@ -13339,7 +13339,7 @@ tr23:
           p--; {goto st652;}
         }
     }
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13354,12 +13354,12 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 13358 "inc/vcf/validator_detail_v41.hpp"
+#line 13358 "../inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
 tr855:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13374,14 +13374,14 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 13378 "inc/vcf/validator_detail_v41.hpp"
+#line 13378 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr854;
 		case 13: goto tr855;
 	}
 	goto st652;
 tr854:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13391,17 +13391,17 @@ tr854:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 817 "src/vcf/vcf_v41.ragel"
+#line 817 "../src/vcf/vcf_v41.ragel"
 	{ {goto st28;} }
 	goto st657;
 st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 13402 "inc/vcf/validator_detail_v41.hpp"
+#line 13402 "../inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 tr858:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13416,14 +13416,14 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 13420 "inc/vcf/validator_detail_v41.hpp"
+#line 13420 "../inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr857;
 		case 13: goto tr858;
 	}
 	goto st653;
 tr857:
-#line 43 "src/vcf/vcf_v41.ragel"
+#line 43 "../src/vcf/vcf_v41.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13433,14 +13433,14 @@ tr857:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 818 "src/vcf/vcf_v41.ragel"
+#line 818 "../src/vcf/vcf_v41.ragel"
 	{ {goto st656;} }
 	goto st658;
 st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 13444 "inc/vcf/validator_detail_v41.hpp"
+#line 13444 "../inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -14119,7 +14119,7 @@ case 658:
 	case 12: 
 	case 13: 
 	case 651: 
-#line 60 "src/vcf/vcf_v41.ragel"
+#line 60 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st652;}
@@ -14173,14 +14173,14 @@ case 658:
 	case 71: 
 	case 72: 
 	case 73: 
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	break;
 	case 654: 
-#line 70 "src/vcf/vcf_v41.ragel"
+#line 70 "../src/vcf/vcf_v41.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -14199,7 +14199,7 @@ case 658:
 	case 437: 
 	case 438: 
 	case 650: 
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -14214,7 +14214,7 @@ case 658:
     }
 	break;
 	case 465: 
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14228,13 +14228,13 @@ case 658:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 225 "src/vcf/vcf_v41.ragel"
+#line 225 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         p--; {goto st652;}
     }
-#line 60 "src/vcf/vcf_v41.ragel"
+#line 60 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st652;}
@@ -14261,12 +14261,12 @@ case 658:
 	case 95: 
 	case 96: 
 	case 100: 
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14280,12 +14280,12 @@ case 658:
 	case 308: 
 	case 309: 
 	case 310: 
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 244 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14320,12 +14320,12 @@ case 658:
 	case 358: 
 	case 359: 
 	case 360: 
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 250 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14354,12 +14354,12 @@ case 658:
 	case 128: 
 	case 129: 
 	case 133: 
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14400,12 +14400,12 @@ case 658:
 	case 176: 
 	case 177: 
 	case 181: 
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14445,12 +14445,12 @@ case 658:
 	case 224: 
 	case 225: 
 	case 229: 
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14466,12 +14466,12 @@ case 658:
 	case 241: 
 	case 242: 
 	case 249: 
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 294 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14488,12 +14488,12 @@ case 658:
 	case 369: 
 	case 370: 
 	case 371: 
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 300 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14510,12 +14510,12 @@ case 658:
 	case 258: 
 	case 259: 
 	case 299: 
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14558,7 +14558,7 @@ case 658:
 	case 427: 
 	case 428: 
 	case 429: 
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 338 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14572,7 +14572,7 @@ case 658:
         
         p--; {goto st653;}
     }
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -14590,12 +14590,12 @@ case 658:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 355 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14603,12 +14603,12 @@ case 658:
 	break;
 	case 441: 
 	case 442: 
-#line 361 "src/vcf/vcf_v41.ragel"
+#line 361 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14616,12 +14616,12 @@ case 658:
 	break;
 	case 443: 
 	case 444: 
-#line 367 "src/vcf/vcf_v41.ragel"
+#line 367 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14629,12 +14629,12 @@ case 658:
 	break;
 	case 445: 
 	case 446: 
-#line 373 "src/vcf/vcf_v41.ragel"
+#line 373 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14677,12 +14677,12 @@ case 658:
 	case 647: 
 	case 648: 
 	case 649: 
-#line 379 "src/vcf/vcf_v41.ragel"
+#line 379 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14701,12 +14701,12 @@ case 658:
 	case 612: 
 	case 613: 
 	case 614: 
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 385 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14717,12 +14717,12 @@ case 658:
 	case 454: 
 	case 603: 
 	case 604: 
-#line 391 "src/vcf/vcf_v41.ragel"
+#line 391 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14730,12 +14730,12 @@ case 658:
 	break;
 	case 458: 
 	case 459: 
-#line 557 "src/vcf/vcf_v41.ragel"
+#line 557 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14743,14 +14743,14 @@ case 658:
 	break;
 	case 461: 
 	case 466: 
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 563 "../src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -14758,12 +14758,12 @@ case 658:
 	break;
 	case 23: 
 	case 28: 
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 338 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14777,7 +14777,7 @@ case 658:
         
         p--; {goto st653;}
     }
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -14794,35 +14794,35 @@ case 658:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 237 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	break;
 	case 104: 
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14831,17 +14831,17 @@ case 658:
 	case 156: 
 	case 157: 
 	case 185: 
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 267 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14850,17 +14850,17 @@ case 658:
 	case 204: 
 	case 205: 
 	case 233: 
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 283 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14868,17 +14868,17 @@ case 658:
 	break;
 	case 163: 
 	case 164: 
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 288 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14886,17 +14886,17 @@ case 658:
 	break;
 	case 211: 
 	case 212: 
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 288 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14911,17 +14911,17 @@ case 658:
 	case 269: 
 	case 270: 
 	case 271: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 311 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14936,17 +14936,17 @@ case 658:
 	case 279: 
 	case 280: 
 	case 281: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 316 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14954,17 +14954,17 @@ case 658:
 	break;
 	case 340: 
 	case 341: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 250 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14973,17 +14973,17 @@ case 658:
 	case 114: 
 	case 115: 
 	case 116: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -14992,17 +14992,17 @@ case 658:
 	case 146: 
 	case 147: 
 	case 148: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15011,17 +15011,17 @@ case 658:
 	case 194: 
 	case 195: 
 	case 196: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15033,17 +15033,17 @@ case 658:
 	case 246: 
 	case 247: 
 	case 248: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 294 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15051,17 +15051,17 @@ case 658:
 	break;
 	case 260: 
 	case 261: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15073,17 +15073,17 @@ case 658:
 	case 101: 
 	case 102: 
 	case 103: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15095,17 +15095,17 @@ case 658:
 	case 134: 
 	case 135: 
 	case 136: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15117,17 +15117,17 @@ case 658:
 	case 182: 
 	case 183: 
 	case 184: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15139,17 +15139,17 @@ case 658:
 	case 230: 
 	case 231: 
 	case 232: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15174,17 +15174,17 @@ case 658:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15209,17 +15209,17 @@ case 658:
 	case 327: 
 	case 328: 
 	case 329: 
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 332 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 244 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15246,17 +15246,17 @@ case 658:
 	case 390: 
 	case 391: 
 	case 392: 
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 332 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 300 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
@@ -15309,17 +15309,17 @@ case 658:
 	case 597: 
 	case 598: 
 	case 602: 
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15327,17 +15327,17 @@ case 658:
 	break;
 	case 475: 
 	case 476: 
-#line 407 "src/vcf/vcf_v41.ragel"
+#line 407 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15345,7 +15345,7 @@ case 658:
 	break;
 	case 482: 
 	case 483: 
-#line 412 "src/vcf/vcf_v41.ragel"
+#line 412 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15353,12 +15353,12 @@ case 658:
                 "AA"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15366,7 +15366,7 @@ case 658:
 	break;
 	case 485: 
 	case 486: 
-#line 420 "src/vcf/vcf_v41.ragel"
+#line 420 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15374,12 +15374,12 @@ case 658:
                 "AC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15398,7 +15398,7 @@ case 658:
 	case 498: 
 	case 499: 
 	case 500: 
-#line 428 "src/vcf/vcf_v41.ragel"
+#line 428 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15406,12 +15406,12 @@ case 658:
                 "AF"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15419,7 +15419,7 @@ case 658:
 	break;
 	case 502: 
 	case 503: 
-#line 436 "src/vcf/vcf_v41.ragel"
+#line 436 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15427,12 +15427,12 @@ case 658:
                 "AN"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15451,7 +15451,7 @@ case 658:
 	case 516: 
 	case 517: 
 	case 518: 
-#line 444 "src/vcf/vcf_v41.ragel"
+#line 444 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15459,12 +15459,12 @@ case 658:
                 "BQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15473,7 +15473,7 @@ case 658:
 	case 524: 
 	case 525: 
 	case 526: 
-#line 452 "src/vcf/vcf_v41.ragel"
+#line 452 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15481,12 +15481,12 @@ case 658:
                 "CIGAR"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15494,7 +15494,7 @@ case 658:
 	break;
 	case 529: 
 	case 530: 
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 460 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15502,12 +15502,12 @@ case 658:
                 "DB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15515,7 +15515,7 @@ case 658:
 	break;
 	case 532: 
 	case 533: 
-#line 468 "src/vcf/vcf_v41.ragel"
+#line 468 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15523,12 +15523,12 @@ case 658:
                 "DP"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15536,7 +15536,7 @@ case 658:
 	break;
 	case 537: 
 	case 538: 
-#line 476 "src/vcf/vcf_v41.ragel"
+#line 476 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15544,12 +15544,12 @@ case 658:
                 "END"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15557,7 +15557,7 @@ case 658:
 	break;
 	case 541: 
 	case 542: 
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 484 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15565,12 +15565,12 @@ case 658:
                 "H2"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15578,7 +15578,7 @@ case 658:
 	break;
 	case 544: 
 	case 545: 
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 492 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15586,12 +15586,12 @@ case 658:
                 "H3"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15610,7 +15610,7 @@ case 658:
 	case 561: 
 	case 562: 
 	case 563: 
-#line 500 "src/vcf/vcf_v41.ragel"
+#line 500 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15618,12 +15618,12 @@ case 658:
                 "MQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15631,7 +15631,7 @@ case 658:
 	break;
 	case 549: 
 	case 550: 
-#line 508 "src/vcf/vcf_v41.ragel"
+#line 508 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15639,12 +15639,12 @@ case 658:
                 "MQ0"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15652,7 +15652,7 @@ case 658:
 	break;
 	case 566: 
 	case 567: 
-#line 516 "src/vcf/vcf_v41.ragel"
+#line 516 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15660,12 +15660,12 @@ case 658:
                 "NS"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15684,7 +15684,7 @@ case 658:
 	case 580: 
 	case 581: 
 	case 582: 
-#line 524 "src/vcf/vcf_v41.ragel"
+#line 524 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15692,12 +15692,12 @@ case 658:
                 "SB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15705,7 +15705,7 @@ case 658:
 	break;
 	case 589: 
 	case 590: 
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 532 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15713,12 +15713,12 @@ case 658:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15726,7 +15726,7 @@ case 658:
 	break;
 	case 600: 
 	case 601: 
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 540 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15734,12 +15734,12 @@ case 658:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15747,7 +15747,7 @@ case 658:
 	break;
 	case 478: 
 	case 479: 
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 548 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15755,12 +15755,12 @@ case 658:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
@@ -15770,38 +15770,38 @@ case 658:
 	case 467: 
 	case 468: 
 	case 469: 
-#line 570 "src/vcf/vcf_v41.ragel"
+#line 570 "../src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 563 "../src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	break;
 	case 22: 
-#line 60 "src/vcf/vcf_v41.ragel"
+#line 60 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 338 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -15815,7 +15815,7 @@ case 658:
         
         p--; {goto st653;}
     }
-#line 78 "src/vcf/vcf_v41.ragel"
+#line 78 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -15830,73 +15830,73 @@ case 658:
     }
 	break;
 	case 272: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 311 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 316 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	break;
 	case 282: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 316 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 327 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	break;
 	case 262: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 322 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 311 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	break;
 	case 528: 
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 460 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15904,24 +15904,24 @@ case 658:
                 "DB"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	break;
 	case 540: 
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 484 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15929,24 +15929,24 @@ case 658:
                 "H2"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	break;
 	case 543: 
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 492 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15954,24 +15954,24 @@ case 658:
                 "H3"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	break;
 	case 588: 
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 532 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15979,24 +15979,24 @@ case 658:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	break;
 	case 599: 
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 540 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -16004,24 +16004,24 @@ case 658:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	break;
 	case 477: 
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 548 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -16029,82 +16029,82 @@ case 658:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 402 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 397 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
     }
-#line 91 "src/vcf/vcf_v41.ragel"
+#line 91 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st653;}
     }
 	break;
 	case 24: 
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 232 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 256 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 262 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 278 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 244 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 250 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 306 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 294 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 300 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
     }
-#line 65 "src/vcf/vcf_v41.ragel"
+#line 65 "../src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
 	break;
-#line 16101 "inc/vcf/validator_detail_v41.hpp"
+#line 16101 "../inc/vcf/validator_detail_v41.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 847 "src/vcf/vcf_v41.ragel"
+#line 847 "../src/vcf/vcf_v41.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -1,5 +1,5 @@
 
-#line 1 "src/vcf/vcf_v42.ragel"
+#line 1 "../src/vcf/vcf_v42.ragel"
 /**
  * Copyright 2014-2016 EMBL - European Bioinformatics Institute
  *
@@ -21,13 +21,13 @@
 #include "vcf/validator.hpp"
 
 
-#line 823 "src/vcf/vcf_v42.ragel"
+#line 823 "../src/vcf/vcf_v42.ragel"
 
 
 namespace
 {
   
-#line 31 "inc/vcf/validator_detail_v42.hpp"
+#line 31 "../inc/vcf/validator_detail_v42.hpp"
 static const int vcf_v42_start = 1;
 static const int vcf_v42_first_final = 726;
 static const int vcf_v42_error = 0;
@@ -39,7 +39,7 @@ static const int vcf_v42_en_meta_section_skip = 724;
 static const int vcf_v42_en_body_section_skip = 725;
 
 
-#line 829 "src/vcf/vcf_v42.ragel"
+#line 829 "../src/vcf/vcf_v42.ragel"
 
 }
 
@@ -53,12 +53,12 @@ namespace ebi
     : ParserImpl{source}
     {
       
-#line 57 "inc/vcf/validator_detail_v42.hpp"
+#line 57 "../inc/vcf/validator_detail_v42.hpp"
 	{
 	cs = vcf_v42_start;
 	}
 
-#line 843 "src/vcf/vcf_v42.ragel"
+#line 843 "../src/vcf/vcf_v42.ragel"
 
     }
 
@@ -66,7 +66,7 @@ namespace ebi
     void ParserImpl_v42<Configuration>::parse_buffer(char const * p, char const * pe, char const * eof)
     {
       
-#line 70 "inc/vcf/validator_detail_v42.hpp"
+#line 70 "../inc/vcf/validator_detail_v42.hpp"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -77,37 +77,37 @@ case 1:
 		goto st2;
 	goto tr0;
 tr0:
-#line 60 "src/vcf/vcf_v42.ragel"
+#line 60 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr14:
-#line 225 "src/vcf/vcf_v42.ragel"
+#line 225 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         p--; {goto st724;}
     }
-#line 60 "src/vcf/vcf_v42.ragel"
+#line 60 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr24:
-#line 60 "src/vcf/vcf_v42.ragel"
+#line 60 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 338 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -121,7 +121,7 @@ tr24:
         
         p--; {goto st725;}
     }
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -136,12 +136,12 @@ tr24:
     }
 	goto st0;
 tr26:
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 338 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -155,7 +155,7 @@ tr26:
         
         p--; {goto st725;}
     }
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -170,791 +170,791 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 244 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 250 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 294 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 300 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr39:
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr125:
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr133:
-#line 237 "src/vcf/vcf_v42.ragel"
+#line 237 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr152:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr161:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr175:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr187:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr193:
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr196:
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr206:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr225:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr247:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr259:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr265:
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr275:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr288:
-#line 267 "src/vcf/vcf_v42.ragel"
+#line 267 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr297:
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 288 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr314:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr336:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr348:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr355:
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr364:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr377:
-#line 283 "src/vcf/vcf_v42.ragel"
+#line 283 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr386:
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 288 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr403:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr425:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr437:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr444:
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 294 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr454:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 294 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr466:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr477:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr482:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 311 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr484:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 311 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr494:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 311 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 316 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr497:
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 316 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr507:
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 316 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr510:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr533:
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 244 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr542:
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 332 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 244 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr563:
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 250 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr574:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 250 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr612:
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 300 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr624:
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 332 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 300 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	goto st0;
 tr647:
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 338 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -968,7 +968,7 @@ tr647:
         
         p--; {goto st725;}
     }
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -983,7 +983,7 @@ tr647:
     }
 	goto st0;
 tr687:
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -998,179 +998,179 @@ tr687:
     }
 	goto st0;
 tr702:
-#line 355 "src/vcf/vcf_v42.ragel"
+#line 355 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr705:
-#line 361 "src/vcf/vcf_v42.ragel"
+#line 361 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr709:
-#line 367 "src/vcf/vcf_v42.ragel"
+#line 367 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr714:
-#line 373 "src/vcf/vcf_v42.ragel"
+#line 373 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr718:
-#line 379 "src/vcf/vcf_v42.ragel"
+#line 379 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr727:
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 385 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr738:
-#line 391 "src/vcf/vcf_v42.ragel"
+#line 391 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr746:
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr768:
-#line 557 "src/vcf/vcf_v42.ragel"
+#line 557 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr773:
-#line 570 "src/vcf/vcf_v42.ragel"
+#line 570 "../src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 563 "../src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr777:
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 563 "../src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr784:
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr793:
-#line 407 "src/vcf/vcf_v42.ragel"
+#line 407 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr795:
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 548 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1178,24 +1178,24 @@ tr795:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr797:
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 548 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1203,19 +1203,19 @@ tr797:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr804:
-#line 412 "src/vcf/vcf_v42.ragel"
+#line 412 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1223,19 +1223,19 @@ tr804:
                 "AA"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr807:
-#line 420 "src/vcf/vcf_v42.ragel"
+#line 420 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1243,19 +1243,19 @@ tr807:
                 "AC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr810:
-#line 428 "src/vcf/vcf_v42.ragel"
+#line 428 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1263,19 +1263,19 @@ tr810:
                 "AF"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr824:
-#line 436 "src/vcf/vcf_v42.ragel"
+#line 436 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1283,19 +1283,19 @@ tr824:
                 "AN"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr828:
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 444 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1303,19 +1303,19 @@ tr828:
                 "BQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr846:
-#line 452 "src/vcf/vcf_v42.ragel"
+#line 452 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1323,19 +1323,19 @@ tr846:
                 "CIGAR"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr851:
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 460 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1343,24 +1343,24 @@ tr851:
                 "DB"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr853:
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 460 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1368,19 +1368,19 @@ tr853:
                 "DB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr856:
-#line 468 "src/vcf/vcf_v42.ragel"
+#line 468 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1388,19 +1388,19 @@ tr856:
                 "DP"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr861:
-#line 476 "src/vcf/vcf_v42.ragel"
+#line 476 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1408,19 +1408,19 @@ tr861:
                 "END"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr865:
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 484 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1428,24 +1428,24 @@ tr865:
                 "H2"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr867:
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 484 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1453,19 +1453,19 @@ tr867:
                 "H2"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr869:
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 492 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1473,24 +1473,24 @@ tr869:
                 "H3"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr871:
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 492 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1498,19 +1498,19 @@ tr871:
                 "H3"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr877:
-#line 508 "src/vcf/vcf_v42.ragel"
+#line 508 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1518,19 +1518,19 @@ tr877:
                 "MQ0"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr879:
-#line 500 "src/vcf/vcf_v42.ragel"
+#line 500 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1538,19 +1538,19 @@ tr879:
                 "MQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr894:
-#line 516 "src/vcf/vcf_v42.ragel"
+#line 516 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1558,19 +1558,19 @@ tr894:
                 "NS"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr899:
-#line 524 "src/vcf/vcf_v42.ragel"
+#line 524 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1578,19 +1578,19 @@ tr899:
                 "SB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr917:
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 532 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1598,24 +1598,24 @@ tr917:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr919:
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 532 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1623,19 +1623,19 @@ tr919:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr929:
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 540 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1643,24 +1643,24 @@ tr929:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr931:
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 540 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1668,19 +1668,19 @@ tr931:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
 tr980:
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -1693,18 +1693,18 @@ tr980:
         
         p--; {goto st725;}
     }
-#line 355 "src/vcf/vcf_v42.ragel"
+#line 355 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	goto st0;
-#line 1708 "inc/vcf/validator_detail_v42.hpp"
+#line 1708 "../inc/vcf/validator_detail_v42.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1800,11 +1800,11 @@ case 14:
 		goto tr15;
 	goto tr14;
 tr15:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1813,12 +1813,12 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1817 "inc/vcf/validator_detail_v42.hpp"
+#line 1817 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
 tr16:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1827,12 +1827,12 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1831 "inc/vcf/validator_detail_v42.hpp"
+#line 1831 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
 tr17:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1841,12 +1841,12 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1845 "inc/vcf/validator_detail_v42.hpp"
+#line 1845 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
 tr18:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1855,12 +1855,12 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1859 "inc/vcf/validator_detail_v42.hpp"
+#line 1859 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
 tr19:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1869,12 +1869,12 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1873 "inc/vcf/validator_detail_v42.hpp"
+#line 1873 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
 tr20:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1883,12 +1883,12 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1887 "inc/vcf/validator_detail_v42.hpp"
+#line 1887 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 50 )
 		goto tr21;
 	goto tr14;
 tr21:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1897,14 +1897,14 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1901 "inc/vcf/validator_detail_v42.hpp"
+#line 1901 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
 	}
 	goto tr14;
 tr22:
-#line 99 "src/vcf/vcf_v42.ragel"
+#line 99 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
@@ -1913,7 +1913,7 @@ tr22:
           p--; {goto st724;}
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -1928,7 +1928,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1932 "inc/vcf/validator_detail_v42.hpp"
+#line 1932 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1962,17 +1962,17 @@ case 24:
 		goto tr30;
 	goto tr29;
 tr30:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st25;
 tr40:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1981,14 +1981,14 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1985 "inc/vcf/validator_detail_v42.hpp"
+#line 1985 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr40;
 	goto tr39;
 tr41:
-#line 168 "src/vcf/vcf_v42.ragel"
+#line 168 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this);
     }
@@ -1997,7 +1997,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2001 "inc/vcf/validator_detail_v42.hpp"
+#line 2001 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2006,17 +2006,17 @@ case 26:
 		goto tr42;
 	goto tr39;
 tr42:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st27;
 tr47:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2025,7 +2025,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2029 "inc/vcf/validator_detail_v42.hpp"
+#line 2029 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -2034,11 +2034,11 @@ case 27:
 		goto tr47;
 	goto tr39;
 tr45:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 176 "src/vcf/vcf_v42.ragel"
+#line 176 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2046,7 +2046,7 @@ tr45:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2058,7 +2058,7 @@ tr45:
     }
 	goto st28;
 tr55:
-#line 176 "src/vcf/vcf_v42.ragel"
+#line 176 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2066,7 +2066,7 @@ tr55:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2081,16 +2081,16 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2085 "inc/vcf/validator_detail_v42.hpp"
+#line 2085 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
 tr46:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 176 "src/vcf/vcf_v42.ragel"
+#line 176 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2098,7 +2098,7 @@ tr46:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2110,7 +2110,7 @@ tr46:
     }
 	goto st29;
 tr56:
-#line 176 "src/vcf/vcf_v42.ragel"
+#line 176 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2118,7 +2118,7 @@ tr56:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2133,7 +2133,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2137 "inc/vcf/validator_detail_v42.hpp"
+#line 2137 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -2149,17 +2149,17 @@ case 30:
 		goto tr49;
 	goto tr39;
 tr49:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st31;
 tr52:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2168,7 +2168,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2172 "inc/vcf/validator_detail_v42.hpp"
+#line 2172 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2177,17 +2177,17 @@ case 31:
 		goto tr52;
 	goto tr39;
 tr50:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st32;
 tr53:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2196,24 +2196,24 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2200 "inc/vcf/validator_detail_v42.hpp"
+#line 2200 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
 	}
 	goto tr39;
 tr51:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st33;
 tr54:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2222,7 +2222,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2226 "inc/vcf/validator_detail_v42.hpp"
+#line 2226 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2231,11 +2231,11 @@ case 33:
 		goto tr52;
 	goto tr39;
 tr57:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2244,7 +2244,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2248 "inc/vcf/validator_detail_v42.hpp"
+#line 2248 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2286,17 +2286,17 @@ case 36:
 		goto tr61;
 	goto tr39;
 tr61:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st37;
 tr64:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2305,7 +2305,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2309 "inc/vcf/validator_detail_v42.hpp"
+#line 2309 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2314,17 +2314,17 @@ case 37:
 		goto tr64;
 	goto tr39;
 tr62:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st38;
 tr65:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2333,22 +2333,22 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2337 "inc/vcf/validator_detail_v42.hpp"
+#line 2337 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
 tr63:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st39;
 tr66:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2357,7 +2357,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2361 "inc/vcf/validator_detail_v42.hpp"
+#line 2361 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2366,11 +2366,11 @@ case 39:
 		goto tr64;
 	goto tr39;
 tr68:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2379,7 +2379,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2383 "inc/vcf/validator_detail_v42.hpp"
+#line 2383 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2389,7 +2389,7 @@ case 40:
 		goto tr64;
 	goto tr39;
 tr69:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2398,7 +2398,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2402 "inc/vcf/validator_detail_v42.hpp"
+#line 2402 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2409,7 +2409,7 @@ case 41:
 		goto tr64;
 	goto tr39;
 tr59:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2418,7 +2418,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2422 "inc/vcf/validator_detail_v42.hpp"
+#line 2422 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2434,17 +2434,17 @@ case 42:
 		goto tr71;
 	goto tr39;
 tr60:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st43;
 tr71:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2453,7 +2453,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2457 "inc/vcf/validator_detail_v42.hpp"
+#line 2457 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2471,7 +2471,7 @@ case 43:
 		goto tr71;
 	goto tr39;
 tr72:
-#line 172 "src/vcf/vcf_v42.ragel"
+#line 172 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2480,7 +2480,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2484 "inc/vcf/validator_detail_v42.hpp"
+#line 2484 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2493,17 +2493,17 @@ case 44:
 		goto tr73;
 	goto tr39;
 tr73:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st45;
 tr75:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2512,7 +2512,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2516 "inc/vcf/validator_detail_v42.hpp"
+#line 2516 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2524,7 +2524,7 @@ case 45:
 		goto tr75;
 	goto tr39;
 tr76:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2533,7 +2533,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2537 "inc/vcf/validator_detail_v42.hpp"
+#line 2537 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2549,7 +2549,7 @@ case 46:
 		goto tr78;
 	goto tr39;
 tr77:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2558,7 +2558,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2562 "inc/vcf/validator_detail_v42.hpp"
+#line 2562 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2574,17 +2574,17 @@ case 47:
 		goto tr80;
 	goto tr39;
 tr78:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st48;
 tr80:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2593,7 +2593,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2597 "inc/vcf/validator_detail_v42.hpp"
+#line 2597 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2611,7 +2611,7 @@ case 48:
 		goto tr80;
 	goto tr39;
 tr81:
-#line 172 "src/vcf/vcf_v42.ragel"
+#line 172 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2620,7 +2620,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2624 "inc/vcf/validator_detail_v42.hpp"
+#line 2624 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2644,17 +2644,17 @@ case 50:
 		goto tr83;
 	goto tr39;
 tr83:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st51;
 tr86:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2663,7 +2663,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2667 "inc/vcf/validator_detail_v42.hpp"
+#line 2667 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2672,17 +2672,17 @@ case 51:
 		goto tr86;
 	goto tr39;
 tr84:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st52;
 tr87:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2691,24 +2691,24 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2695 "inc/vcf/validator_detail_v42.hpp"
+#line 2695 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
 	}
 	goto tr39;
 tr85:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st53;
 tr88:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2717,7 +2717,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2721 "inc/vcf/validator_detail_v42.hpp"
+#line 2721 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2726,11 +2726,11 @@ case 53:
 		goto tr86;
 	goto tr39;
 tr90:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2739,7 +2739,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2743 "inc/vcf/validator_detail_v42.hpp"
+#line 2743 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2750,27 +2750,27 @@ case 54:
 		goto tr86;
 	goto tr39;
 tr105:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st55;
 tr91:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st55;
 tr102:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2779,7 +2779,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2783 "inc/vcf/validator_detail_v42.hpp"
+#line 2783 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2811,17 +2811,17 @@ case 55:
 		goto tr86;
 	goto tr39;
 tr93:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st56;
 tr95:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2830,7 +2830,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2834 "inc/vcf/validator_detail_v42.hpp"
+#line 2834 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2862,17 +2862,17 @@ case 56:
 		goto tr86;
 	goto tr39;
 tr94:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st57;
 tr96:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2881,7 +2881,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2885 "inc/vcf/validator_detail_v42.hpp"
+#line 2885 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2911,11 +2911,11 @@ case 57:
 		goto tr96;
 	goto tr39;
 tr97:
-#line 172 "src/vcf/vcf_v42.ragel"
+#line 172 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2924,7 +2924,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2928 "inc/vcf/validator_detail_v42.hpp"
+#line 2928 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2935,17 +2935,17 @@ case 58:
 		goto tr98;
 	goto tr39;
 tr101:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st59;
 tr98:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2954,7 +2954,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2958 "inc/vcf/validator_detail_v42.hpp"
+#line 2958 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2965,27 +2965,27 @@ case 59:
 		goto tr101;
 	goto tr39;
 tr106:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st60;
 tr92:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st60;
 tr103:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2994,7 +2994,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2998 "inc/vcf/validator_detail_v42.hpp"
+#line 2998 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3005,17 +3005,17 @@ case 60:
 		goto tr86;
 	goto tr39;
 tr104:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st61;
 tr100:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3024,7 +3024,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3028 "inc/vcf/validator_detail_v42.hpp"
+#line 3028 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -3035,7 +3035,7 @@ case 61:
 		goto tr101;
 	goto tr39;
 tr99:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3044,7 +3044,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3048 "inc/vcf/validator_detail_v42.hpp"
+#line 3048 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -3066,17 +3066,17 @@ case 63:
 		goto tr107;
 	goto tr39;
 tr107:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st64;
 tr109:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3085,7 +3085,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3089 "inc/vcf/validator_detail_v42.hpp"
+#line 3089 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -3094,17 +3094,17 @@ case 64:
 		goto tr109;
 	goto tr39;
 tr108:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st65;
 tr110:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3113,7 +3113,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3117 "inc/vcf/validator_detail_v42.hpp"
+#line 3117 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -3122,11 +3122,11 @@ case 65:
 		goto tr109;
 	goto tr39;
 tr111:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3135,7 +3135,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3139 "inc/vcf/validator_detail_v42.hpp"
+#line 3139 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -3146,17 +3146,17 @@ case 66:
 		goto tr109;
 	goto tr39;
 tr112:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st67;
 tr122:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3165,7 +3165,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3169 "inc/vcf/validator_detail_v42.hpp"
+#line 3169 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3197,17 +3197,17 @@ case 67:
 		goto tr109;
 	goto tr39;
 tr116:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st68;
 tr114:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3216,7 +3216,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3220 "inc/vcf/validator_detail_v42.hpp"
+#line 3220 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3248,17 +3248,17 @@ case 68:
 		goto tr109;
 	goto tr39;
 tr117:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st69;
 tr115:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3267,7 +3267,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3271 "inc/vcf/validator_detail_v42.hpp"
+#line 3271 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3297,11 +3297,11 @@ case 69:
 		goto tr117;
 	goto tr39;
 tr118:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 172 "src/vcf/vcf_v42.ragel"
+#line 172 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3310,7 +3310,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3314 "inc/vcf/validator_detail_v42.hpp"
+#line 3314 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3321,17 +3321,17 @@ case 70:
 		goto tr119;
 	goto tr39;
 tr121:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st71;
 tr119:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3340,7 +3340,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3344 "inc/vcf/validator_detail_v42.hpp"
+#line 3344 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3351,17 +3351,17 @@ case 71:
 		goto tr121;
 	goto tr39;
 tr113:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st72;
 tr123:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3370,7 +3370,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3374 "inc/vcf/validator_detail_v42.hpp"
+#line 3374 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3381,17 +3381,17 @@ case 72:
 		goto tr109;
 	goto tr39;
 tr124:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st73;
 tr120:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3400,7 +3400,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3404 "inc/vcf/validator_detail_v42.hpp"
+#line 3404 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3411,11 +3411,11 @@ case 73:
 		goto tr121;
 	goto tr39;
 tr31:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3424,7 +3424,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3428 "inc/vcf/validator_detail_v42.hpp"
+#line 3428 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3433,7 +3433,7 @@ case 74:
 		goto tr40;
 	goto tr125;
 tr126:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3442,7 +3442,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3446 "inc/vcf/validator_detail_v42.hpp"
+#line 3446 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3460,7 +3460,7 @@ case 76:
 		goto tr40;
 	goto tr125;
 tr128:
-#line 108 "src/vcf/vcf_v42.ragel"
+#line 108 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "ALT");
     }
@@ -3469,7 +3469,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3473 "inc/vcf/validator_detail_v42.hpp"
+#line 3473 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3528,11 +3528,11 @@ case 81:
 		goto tr134;
 	goto tr133;
 tr134:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3541,7 +3541,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3545 "inc/vcf/validator_detail_v42.hpp"
+#line 3545 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3572,21 +3572,21 @@ case 82:
 		goto st82;
 	goto tr133;
 tr137:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st83;
 tr135:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3595,7 +3595,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3599 "inc/vcf/validator_detail_v42.hpp"
+#line 3599 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3607,7 +3607,7 @@ case 83:
 		goto tr137;
 	goto tr133;
 tr138:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3616,7 +3616,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3620 "inc/vcf/validator_detail_v42.hpp"
+#line 3620 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3705,7 +3705,7 @@ case 96:
 		goto tr151;
 	goto tr125;
 tr151:
-#line 156 "src/vcf/vcf_v42.ragel"
+#line 156 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -3714,7 +3714,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3718 "inc/vcf/validator_detail_v42.hpp"
+#line 3718 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3723,17 +3723,17 @@ case 97:
 		goto tr153;
 	goto tr152;
 tr153:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st98;
 tr156:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3742,7 +3742,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3746 "inc/vcf/validator_detail_v42.hpp"
+#line 3746 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3751,17 +3751,17 @@ case 98:
 		goto tr156;
 	goto tr152;
 tr154:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st99;
 tr157:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3770,7 +3770,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3774 "inc/vcf/validator_detail_v42.hpp"
+#line 3774 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3795,7 +3795,7 @@ case 100:
 		goto tr163;
 	goto tr161;
 tr162:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3804,7 +3804,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3808 "inc/vcf/validator_detail_v42.hpp"
+#line 3808 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3820,17 +3820,17 @@ case 101:
 		goto tr165;
 	goto tr161;
 tr163:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st102;
 tr165:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3839,7 +3839,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3843 "inc/vcf/validator_detail_v42.hpp"
+#line 3843 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr166;
 		case 95: goto tr165;
@@ -3857,7 +3857,7 @@ case 102:
 		goto tr165;
 	goto tr161;
 tr166:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3866,7 +3866,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3870 "inc/vcf/validator_detail_v42.hpp"
+#line 3870 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr125;
@@ -3882,17 +3882,17 @@ case 104:
 		goto tr168;
 	goto tr152;
 tr168:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st105;
 tr170:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3901,7 +3901,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3905 "inc/vcf/validator_detail_v42.hpp"
+#line 3905 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr171;
@@ -3910,17 +3910,17 @@ case 105:
 		goto tr170;
 	goto tr152;
 tr169:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st106;
 tr171:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3929,7 +3929,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3933 "inc/vcf/validator_detail_v42.hpp"
+#line 3933 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr172;
 		case 92: goto tr171;
@@ -3938,11 +3938,11 @@ case 106:
 		goto tr170;
 	goto tr152;
 tr172:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3951,7 +3951,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3955 "inc/vcf/validator_detail_v42.hpp"
+#line 3955 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr173;
@@ -3962,17 +3962,17 @@ case 107:
 		goto tr170;
 	goto tr152;
 tr182:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st108;
 tr173:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3981,7 +3981,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3985 "inc/vcf/validator_detail_v42.hpp"
+#line 3985 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4013,17 +4013,17 @@ case 108:
 		goto tr170;
 	goto tr175;
 tr176:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st109;
 tr178:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4032,7 +4032,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4036 "inc/vcf/validator_detail_v42.hpp"
+#line 4036 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4064,17 +4064,17 @@ case 109:
 		goto tr170;
 	goto tr175;
 tr177:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st110;
 tr179:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4083,7 +4083,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4087 "inc/vcf/validator_detail_v42.hpp"
+#line 4087 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4113,11 +4113,11 @@ case 110:
 		goto tr179;
 	goto tr175;
 tr180:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4126,7 +4126,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4130 "inc/vcf/validator_detail_v42.hpp"
+#line 4130 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr171;
@@ -4135,7 +4135,7 @@ case 111:
 		goto tr170;
 	goto tr152;
 tr181:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4144,7 +4144,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4148 "inc/vcf/validator_detail_v42.hpp"
+#line 4148 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 44: goto tr182;
@@ -4155,17 +4155,17 @@ case 112:
 		goto tr168;
 	goto tr152;
 tr183:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st113;
 tr174:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4174,7 +4174,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4178 "inc/vcf/validator_detail_v42.hpp"
+#line 4178 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4194,17 +4194,17 @@ case 114:
 	}
 	goto tr125;
 tr155:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st115;
 tr158:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4213,7 +4213,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4217 "inc/vcf/validator_detail_v42.hpp"
+#line 4217 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr184;
 		case 92: goto tr158;
@@ -4222,11 +4222,11 @@ case 115:
 		goto tr156;
 	goto tr152;
 tr184:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4235,7 +4235,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4239 "inc/vcf/validator_detail_v42.hpp"
+#line 4239 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr185;
@@ -4246,7 +4246,7 @@ case 116:
 		goto tr156;
 	goto tr152;
 tr185:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4255,7 +4255,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4259 "inc/vcf/validator_detail_v42.hpp"
+#line 4259 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4287,17 +4287,17 @@ case 117:
 		goto tr156;
 	goto tr187;
 tr190:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st118;
 tr188:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4306,7 +4306,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4310 "inc/vcf/validator_detail_v42.hpp"
+#line 4310 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4338,17 +4338,17 @@ case 118:
 		goto tr156;
 	goto tr187;
 tr191:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st119;
 tr189:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4357,7 +4357,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4361 "inc/vcf/validator_detail_v42.hpp"
+#line 4361 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4387,11 +4387,11 @@ case 119:
 		goto tr191;
 	goto tr187;
 tr192:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4400,7 +4400,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4404 "inc/vcf/validator_detail_v42.hpp"
+#line 4404 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr158;
@@ -4409,7 +4409,7 @@ case 120:
 		goto tr156;
 	goto tr152;
 tr186:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4418,7 +4418,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4422 "inc/vcf/validator_detail_v42.hpp"
+#line 4422 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4429,11 +4429,11 @@ case 121:
 		goto tr156;
 	goto tr152;
 tr32:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4442,7 +4442,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4446 "inc/vcf/validator_detail_v42.hpp"
+#line 4446 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr194;
@@ -4452,7 +4452,7 @@ case 122:
 		goto tr40;
 	goto tr193;
 tr194:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4461,7 +4461,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4465 "inc/vcf/validator_detail_v42.hpp"
+#line 4465 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr197;
@@ -4470,7 +4470,7 @@ case 123:
 		goto tr40;
 	goto tr196;
 tr197:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4479,7 +4479,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4483 "inc/vcf/validator_detail_v42.hpp"
+#line 4483 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr198;
@@ -4488,7 +4488,7 @@ case 124:
 		goto tr40;
 	goto tr196;
 tr198:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4497,7 +4497,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4501 "inc/vcf/validator_detail_v42.hpp"
+#line 4501 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr199;
@@ -4506,7 +4506,7 @@ case 125:
 		goto tr40;
 	goto tr196;
 tr199:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4515,7 +4515,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4519 "inc/vcf/validator_detail_v42.hpp"
+#line 4519 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st127;
@@ -4533,7 +4533,7 @@ case 127:
 		goto tr40;
 	goto tr196;
 tr201:
-#line 120 "src/vcf/vcf_v42.ragel"
+#line 120 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "FILTER");
     }
@@ -4542,7 +4542,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4546 "inc/vcf/validator_detail_v42.hpp"
+#line 4546 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr196;
@@ -4586,11 +4586,11 @@ case 132:
 		goto tr208;
 	goto tr206;
 tr207:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4599,7 +4599,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4603 "inc/vcf/validator_detail_v42.hpp"
+#line 4603 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4615,21 +4615,21 @@ case 133:
 		goto tr210;
 	goto tr206;
 tr210:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st134;
 tr208:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4638,7 +4638,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4642 "inc/vcf/validator_detail_v42.hpp"
+#line 4642 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr211;
 		case 95: goto tr210;
@@ -4656,7 +4656,7 @@ case 134:
 		goto tr210;
 	goto tr206;
 tr211:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4665,7 +4665,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4669 "inc/vcf/validator_detail_v42.hpp"
+#line 4669 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr196;
@@ -4754,7 +4754,7 @@ case 147:
 		goto tr224;
 	goto tr196;
 tr224:
-#line 156 "src/vcf/vcf_v42.ragel"
+#line 156 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -4763,7 +4763,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4767 "inc/vcf/validator_detail_v42.hpp"
+#line 4767 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 92: goto tr228;
@@ -4772,17 +4772,17 @@ case 148:
 		goto tr226;
 	goto tr225;
 tr226:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st149;
 tr229:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4791,7 +4791,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4795 "inc/vcf/validator_detail_v42.hpp"
+#line 4795 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr231;
@@ -4800,17 +4800,17 @@ case 149:
 		goto tr229;
 	goto tr225;
 tr227:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st150;
 tr230:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4819,7 +4819,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4823 "inc/vcf/validator_detail_v42.hpp"
+#line 4823 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4844,7 +4844,7 @@ case 151:
 		goto tr235;
 	goto tr206;
 tr234:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4853,7 +4853,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4857 "inc/vcf/validator_detail_v42.hpp"
+#line 4857 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4869,17 +4869,17 @@ case 152:
 		goto tr237;
 	goto tr206;
 tr235:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st153;
 tr237:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4888,7 +4888,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4892 "inc/vcf/validator_detail_v42.hpp"
+#line 4892 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr238;
 		case 95: goto tr237;
@@ -4906,7 +4906,7 @@ case 153:
 		goto tr237;
 	goto tr206;
 tr238:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4915,7 +4915,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 4919 "inc/vcf/validator_detail_v42.hpp"
+#line 4919 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr196;
@@ -4931,17 +4931,17 @@ case 155:
 		goto tr240;
 	goto tr225;
 tr240:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st156;
 tr242:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4950,7 +4950,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 4954 "inc/vcf/validator_detail_v42.hpp"
+#line 4954 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr243;
@@ -4959,17 +4959,17 @@ case 156:
 		goto tr242;
 	goto tr225;
 tr241:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st157;
 tr243:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4978,7 +4978,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4982 "inc/vcf/validator_detail_v42.hpp"
+#line 4982 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr244;
 		case 92: goto tr243;
@@ -4987,11 +4987,11 @@ case 157:
 		goto tr242;
 	goto tr225;
 tr244:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5000,7 +5000,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5004 "inc/vcf/validator_detail_v42.hpp"
+#line 5004 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr245;
@@ -5011,17 +5011,17 @@ case 158:
 		goto tr242;
 	goto tr225;
 tr254:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st159;
 tr245:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5030,7 +5030,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5034 "inc/vcf/validator_detail_v42.hpp"
+#line 5034 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5062,17 +5062,17 @@ case 159:
 		goto tr242;
 	goto tr247;
 tr248:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st160;
 tr250:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5081,7 +5081,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5085 "inc/vcf/validator_detail_v42.hpp"
+#line 5085 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5113,17 +5113,17 @@ case 160:
 		goto tr242;
 	goto tr247;
 tr249:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st161;
 tr251:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5132,7 +5132,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5136 "inc/vcf/validator_detail_v42.hpp"
+#line 5136 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5162,11 +5162,11 @@ case 161:
 		goto tr251;
 	goto tr247;
 tr252:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5175,7 +5175,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5179 "inc/vcf/validator_detail_v42.hpp"
+#line 5179 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr243;
@@ -5184,7 +5184,7 @@ case 162:
 		goto tr242;
 	goto tr225;
 tr253:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5193,7 +5193,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5197 "inc/vcf/validator_detail_v42.hpp"
+#line 5197 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 44: goto tr254;
@@ -5204,17 +5204,17 @@ case 163:
 		goto tr240;
 	goto tr225;
 tr255:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st164;
 tr246:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5223,7 +5223,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5227 "inc/vcf/validator_detail_v42.hpp"
+#line 5227 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5243,17 +5243,17 @@ case 165:
 	}
 	goto tr196;
 tr228:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st166;
 tr231:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5262,7 +5262,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5266 "inc/vcf/validator_detail_v42.hpp"
+#line 5266 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr256;
 		case 92: goto tr231;
@@ -5271,11 +5271,11 @@ case 166:
 		goto tr229;
 	goto tr225;
 tr256:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5284,7 +5284,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5288 "inc/vcf/validator_detail_v42.hpp"
+#line 5288 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr257;
@@ -5295,7 +5295,7 @@ case 167:
 		goto tr229;
 	goto tr225;
 tr257:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5304,7 +5304,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5308 "inc/vcf/validator_detail_v42.hpp"
+#line 5308 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5336,17 +5336,17 @@ case 168:
 		goto tr229;
 	goto tr259;
 tr262:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st169;
 tr260:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5355,7 +5355,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5359 "inc/vcf/validator_detail_v42.hpp"
+#line 5359 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5387,17 +5387,17 @@ case 169:
 		goto tr229;
 	goto tr259;
 tr263:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st170;
 tr261:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5406,7 +5406,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5410 "inc/vcf/validator_detail_v42.hpp"
+#line 5410 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5436,11 +5436,11 @@ case 170:
 		goto tr263;
 	goto tr259;
 tr264:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5449,7 +5449,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5453 "inc/vcf/validator_detail_v42.hpp"
+#line 5453 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr231;
@@ -5458,7 +5458,7 @@ case 171:
 		goto tr229;
 	goto tr225;
 tr258:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5467,7 +5467,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5471 "inc/vcf/validator_detail_v42.hpp"
+#line 5471 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5478,7 +5478,7 @@ case 172:
 		goto tr229;
 	goto tr225;
 tr195:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5487,7 +5487,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5491 "inc/vcf/validator_detail_v42.hpp"
+#line 5491 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr266;
@@ -5496,7 +5496,7 @@ case 173:
 		goto tr40;
 	goto tr265;
 tr266:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5505,7 +5505,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5509 "inc/vcf/validator_detail_v42.hpp"
+#line 5509 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr267;
@@ -5514,7 +5514,7 @@ case 174:
 		goto tr40;
 	goto tr265;
 tr267:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5523,7 +5523,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5527 "inc/vcf/validator_detail_v42.hpp"
+#line 5527 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr268;
@@ -5532,7 +5532,7 @@ case 175:
 		goto tr40;
 	goto tr265;
 tr268:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5541,7 +5541,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5545 "inc/vcf/validator_detail_v42.hpp"
+#line 5545 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st177;
@@ -5559,7 +5559,7 @@ case 177:
 		goto tr40;
 	goto tr265;
 tr270:
-#line 124 "src/vcf/vcf_v42.ragel"
+#line 124 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "FORMAT");
     }
@@ -5568,7 +5568,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5572 "inc/vcf/validator_detail_v42.hpp"
+#line 5572 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr265;
@@ -5612,11 +5612,11 @@ case 182:
 		goto tr277;
 	goto tr275;
 tr276:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5625,7 +5625,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5629 "inc/vcf/validator_detail_v42.hpp"
+#line 5629 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5641,21 +5641,21 @@ case 183:
 		goto tr279;
 	goto tr275;
 tr279:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st184;
 tr277:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5664,7 +5664,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5668 "inc/vcf/validator_detail_v42.hpp"
+#line 5668 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr280;
 		case 95: goto tr279;
@@ -5682,7 +5682,7 @@ case 184:
 		goto tr279;
 	goto tr275;
 tr280:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5691,7 +5691,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5695 "inc/vcf/validator_detail_v42.hpp"
+#line 5695 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr265;
@@ -5751,15 +5751,15 @@ case 192:
 		goto tr290;
 	goto tr288;
 tr289:
-#line 148 "src/vcf/vcf_v42.ragel"
+#line 148 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5768,12 +5768,12 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5772 "inc/vcf/validator_detail_v42.hpp"
+#line 5772 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	goto tr288;
 tr291:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5782,7 +5782,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5786 "inc/vcf/validator_detail_v42.hpp"
+#line 5786 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr265;
@@ -5825,21 +5825,21 @@ case 199:
 		goto tr298;
 	goto tr297;
 tr300:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st200;
 tr298:
-#line 152 "src/vcf/vcf_v42.ragel"
+#line 152 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Type");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5848,7 +5848,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5852 "inc/vcf/validator_detail_v42.hpp"
+#line 5852 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr299;
 	if ( (*p) > 90 ) {
@@ -5858,7 +5858,7 @@ case 200:
 		goto tr300;
 	goto tr297;
 tr299:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5867,7 +5867,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5871 "inc/vcf/validator_detail_v42.hpp"
+#line 5871 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr265;
@@ -5956,7 +5956,7 @@ case 213:
 		goto tr313;
 	goto tr265;
 tr313:
-#line 156 "src/vcf/vcf_v42.ragel"
+#line 156 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -5965,7 +5965,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 5969 "inc/vcf/validator_detail_v42.hpp"
+#line 5969 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 92: goto tr317;
@@ -5974,17 +5974,17 @@ case 214:
 		goto tr315;
 	goto tr314;
 tr315:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st215;
 tr318:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5993,7 +5993,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 5997 "inc/vcf/validator_detail_v42.hpp"
+#line 5997 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr320;
@@ -6002,17 +6002,17 @@ case 215:
 		goto tr318;
 	goto tr314;
 tr316:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st216;
 tr319:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6021,7 +6021,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6025 "inc/vcf/validator_detail_v42.hpp"
+#line 6025 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6046,7 +6046,7 @@ case 217:
 		goto tr324;
 	goto tr275;
 tr323:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6055,7 +6055,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6059 "inc/vcf/validator_detail_v42.hpp"
+#line 6059 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6071,17 +6071,17 @@ case 218:
 		goto tr326;
 	goto tr275;
 tr324:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st219;
 tr326:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6090,7 +6090,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6094 "inc/vcf/validator_detail_v42.hpp"
+#line 6094 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr327;
 		case 95: goto tr326;
@@ -6108,7 +6108,7 @@ case 219:
 		goto tr326;
 	goto tr275;
 tr327:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6117,7 +6117,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6121 "inc/vcf/validator_detail_v42.hpp"
+#line 6121 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr265;
@@ -6133,17 +6133,17 @@ case 221:
 		goto tr329;
 	goto tr314;
 tr329:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st222;
 tr331:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6152,7 +6152,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6156 "inc/vcf/validator_detail_v42.hpp"
+#line 6156 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr332;
@@ -6161,17 +6161,17 @@ case 222:
 		goto tr331;
 	goto tr314;
 tr330:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st223;
 tr332:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6180,7 +6180,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6184 "inc/vcf/validator_detail_v42.hpp"
+#line 6184 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr333;
 		case 92: goto tr332;
@@ -6189,11 +6189,11 @@ case 223:
 		goto tr331;
 	goto tr314;
 tr333:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6202,7 +6202,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6206 "inc/vcf/validator_detail_v42.hpp"
+#line 6206 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr334;
@@ -6213,17 +6213,17 @@ case 224:
 		goto tr331;
 	goto tr314;
 tr343:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st225;
 tr334:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6232,7 +6232,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6236 "inc/vcf/validator_detail_v42.hpp"
+#line 6236 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6264,17 +6264,17 @@ case 225:
 		goto tr331;
 	goto tr336;
 tr337:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st226;
 tr339:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6283,7 +6283,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6287 "inc/vcf/validator_detail_v42.hpp"
+#line 6287 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6315,17 +6315,17 @@ case 226:
 		goto tr331;
 	goto tr336;
 tr338:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st227;
 tr340:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6334,7 +6334,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6338 "inc/vcf/validator_detail_v42.hpp"
+#line 6338 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6364,11 +6364,11 @@ case 227:
 		goto tr340;
 	goto tr336;
 tr341:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6377,7 +6377,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6381 "inc/vcf/validator_detail_v42.hpp"
+#line 6381 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr332;
@@ -6386,7 +6386,7 @@ case 228:
 		goto tr331;
 	goto tr314;
 tr342:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6395,7 +6395,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6399 "inc/vcf/validator_detail_v42.hpp"
+#line 6399 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 44: goto tr343;
@@ -6406,17 +6406,17 @@ case 229:
 		goto tr329;
 	goto tr314;
 tr344:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st230;
 tr335:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6425,7 +6425,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6429 "inc/vcf/validator_detail_v42.hpp"
+#line 6429 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6445,17 +6445,17 @@ case 231:
 	}
 	goto tr265;
 tr317:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st232;
 tr320:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6464,7 +6464,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6468 "inc/vcf/validator_detail_v42.hpp"
+#line 6468 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr345;
 		case 92: goto tr320;
@@ -6473,11 +6473,11 @@ case 232:
 		goto tr318;
 	goto tr314;
 tr345:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6486,7 +6486,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6490 "inc/vcf/validator_detail_v42.hpp"
+#line 6490 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr346;
@@ -6497,7 +6497,7 @@ case 233:
 		goto tr318;
 	goto tr314;
 tr346:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6506,7 +6506,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6510 "inc/vcf/validator_detail_v42.hpp"
+#line 6510 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6538,17 +6538,17 @@ case 234:
 		goto tr318;
 	goto tr348;
 tr351:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st235;
 tr349:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6557,7 +6557,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6561 "inc/vcf/validator_detail_v42.hpp"
+#line 6561 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6589,17 +6589,17 @@ case 235:
 		goto tr318;
 	goto tr348;
 tr352:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st236;
 tr350:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6608,7 +6608,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6612 "inc/vcf/validator_detail_v42.hpp"
+#line 6612 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6638,11 +6638,11 @@ case 236:
 		goto tr352;
 	goto tr348;
 tr353:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6651,7 +6651,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6655 "inc/vcf/validator_detail_v42.hpp"
+#line 6655 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr320;
@@ -6660,7 +6660,7 @@ case 237:
 		goto tr318;
 	goto tr314;
 tr347:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6669,7 +6669,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6673 "inc/vcf/validator_detail_v42.hpp"
+#line 6673 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6680,21 +6680,21 @@ case 238:
 		goto tr318;
 	goto tr314;
 tr354:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st239;
 tr290:
-#line 148 "src/vcf/vcf_v42.ragel"
+#line 148 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6703,18 +6703,18 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6707 "inc/vcf/validator_detail_v42.hpp"
+#line 6707 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr354;
 	goto tr288;
 tr33:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6723,7 +6723,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6727 "inc/vcf/validator_detail_v42.hpp"
+#line 6727 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr356;
@@ -6732,7 +6732,7 @@ case 240:
 		goto tr40;
 	goto tr355;
 tr356:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6741,7 +6741,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6745 "inc/vcf/validator_detail_v42.hpp"
+#line 6745 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr357;
@@ -6750,7 +6750,7 @@ case 241:
 		goto tr40;
 	goto tr355;
 tr357:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6759,7 +6759,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6763 "inc/vcf/validator_detail_v42.hpp"
+#line 6763 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st243;
@@ -6777,7 +6777,7 @@ case 243:
 		goto tr40;
 	goto tr355;
 tr359:
-#line 128 "src/vcf/vcf_v42.ragel"
+#line 128 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "INFO");
     }
@@ -6786,7 +6786,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6790 "inc/vcf/validator_detail_v42.hpp"
+#line 6790 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr355;
@@ -6830,11 +6830,11 @@ case 248:
 		goto tr366;
 	goto tr364;
 tr365:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6843,7 +6843,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6847 "inc/vcf/validator_detail_v42.hpp"
+#line 6847 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6859,21 +6859,21 @@ case 249:
 		goto tr368;
 	goto tr364;
 tr368:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st250;
 tr366:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6882,7 +6882,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6886 "inc/vcf/validator_detail_v42.hpp"
+#line 6886 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr369;
 		case 95: goto tr368;
@@ -6900,7 +6900,7 @@ case 250:
 		goto tr368;
 	goto tr364;
 tr369:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6909,7 +6909,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 6913 "inc/vcf/validator_detail_v42.hpp"
+#line 6913 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr355;
@@ -6969,15 +6969,15 @@ case 258:
 		goto tr379;
 	goto tr377;
 tr378:
-#line 148 "src/vcf/vcf_v42.ragel"
+#line 148 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6986,12 +6986,12 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 6990 "inc/vcf/validator_detail_v42.hpp"
+#line 6990 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	goto tr377;
 tr380:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7000,7 +7000,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7004 "inc/vcf/validator_detail_v42.hpp"
+#line 7004 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr355;
@@ -7043,21 +7043,21 @@ case 265:
 		goto tr387;
 	goto tr386;
 tr389:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st266;
 tr387:
-#line 152 "src/vcf/vcf_v42.ragel"
+#line 152 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Type");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7066,7 +7066,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7070 "inc/vcf/validator_detail_v42.hpp"
+#line 7070 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) > 90 ) {
@@ -7076,7 +7076,7 @@ case 266:
 		goto tr389;
 	goto tr386;
 tr388:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7085,7 +7085,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7089 "inc/vcf/validator_detail_v42.hpp"
+#line 7089 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr355;
@@ -7174,7 +7174,7 @@ case 279:
 		goto tr402;
 	goto tr355;
 tr402:
-#line 156 "src/vcf/vcf_v42.ragel"
+#line 156 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -7183,7 +7183,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7187 "inc/vcf/validator_detail_v42.hpp"
+#line 7187 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 92: goto tr406;
@@ -7192,17 +7192,17 @@ case 280:
 		goto tr404;
 	goto tr403;
 tr404:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st281;
 tr407:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7211,7 +7211,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7215 "inc/vcf/validator_detail_v42.hpp"
+#line 7215 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr409;
@@ -7220,17 +7220,17 @@ case 281:
 		goto tr407;
 	goto tr403;
 tr405:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st282;
 tr408:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7239,7 +7239,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7243 "inc/vcf/validator_detail_v42.hpp"
+#line 7243 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7264,7 +7264,7 @@ case 283:
 		goto tr413;
 	goto tr364;
 tr412:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7273,7 +7273,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7277 "inc/vcf/validator_detail_v42.hpp"
+#line 7277 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7289,17 +7289,17 @@ case 284:
 		goto tr415;
 	goto tr364;
 tr413:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st285;
 tr415:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7308,7 +7308,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7312 "inc/vcf/validator_detail_v42.hpp"
+#line 7312 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr416;
 		case 95: goto tr415;
@@ -7326,7 +7326,7 @@ case 285:
 		goto tr415;
 	goto tr364;
 tr416:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7335,7 +7335,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7339 "inc/vcf/validator_detail_v42.hpp"
+#line 7339 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr355;
@@ -7351,17 +7351,17 @@ case 287:
 		goto tr418;
 	goto tr403;
 tr418:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st288;
 tr420:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7370,7 +7370,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7374 "inc/vcf/validator_detail_v42.hpp"
+#line 7374 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr421;
@@ -7379,17 +7379,17 @@ case 288:
 		goto tr420;
 	goto tr403;
 tr419:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st289;
 tr421:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7398,7 +7398,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7402 "inc/vcf/validator_detail_v42.hpp"
+#line 7402 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr422;
 		case 92: goto tr421;
@@ -7407,11 +7407,11 @@ case 289:
 		goto tr420;
 	goto tr403;
 tr422:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7420,7 +7420,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7424 "inc/vcf/validator_detail_v42.hpp"
+#line 7424 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr423;
@@ -7431,17 +7431,17 @@ case 290:
 		goto tr420;
 	goto tr403;
 tr432:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st291;
 tr423:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7450,7 +7450,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7454 "inc/vcf/validator_detail_v42.hpp"
+#line 7454 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7482,17 +7482,17 @@ case 291:
 		goto tr420;
 	goto tr425;
 tr426:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st292;
 tr428:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7501,7 +7501,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7505 "inc/vcf/validator_detail_v42.hpp"
+#line 7505 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7533,17 +7533,17 @@ case 292:
 		goto tr420;
 	goto tr425;
 tr427:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st293;
 tr429:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7552,7 +7552,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7556 "inc/vcf/validator_detail_v42.hpp"
+#line 7556 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7582,11 +7582,11 @@ case 293:
 		goto tr429;
 	goto tr425;
 tr430:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7595,7 +7595,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7599 "inc/vcf/validator_detail_v42.hpp"
+#line 7599 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr421;
@@ -7604,7 +7604,7 @@ case 294:
 		goto tr420;
 	goto tr403;
 tr431:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7613,7 +7613,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7617 "inc/vcf/validator_detail_v42.hpp"
+#line 7617 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 44: goto tr432;
@@ -7624,17 +7624,17 @@ case 295:
 		goto tr418;
 	goto tr403;
 tr433:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st296;
 tr424:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7643,7 +7643,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7647 "inc/vcf/validator_detail_v42.hpp"
+#line 7647 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7663,17 +7663,17 @@ case 297:
 	}
 	goto tr355;
 tr406:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st298;
 tr409:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7682,7 +7682,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7686 "inc/vcf/validator_detail_v42.hpp"
+#line 7686 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr434;
 		case 92: goto tr409;
@@ -7691,11 +7691,11 @@ case 298:
 		goto tr407;
 	goto tr403;
 tr434:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7704,7 +7704,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7708 "inc/vcf/validator_detail_v42.hpp"
+#line 7708 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr435;
@@ -7715,7 +7715,7 @@ case 299:
 		goto tr407;
 	goto tr403;
 tr435:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7724,7 +7724,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7728 "inc/vcf/validator_detail_v42.hpp"
+#line 7728 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7756,17 +7756,17 @@ case 300:
 		goto tr407;
 	goto tr437;
 tr440:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st301;
 tr438:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7775,7 +7775,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7779 "inc/vcf/validator_detail_v42.hpp"
+#line 7779 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7807,17 +7807,17 @@ case 301:
 		goto tr407;
 	goto tr437;
 tr441:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st302;
 tr439:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7826,7 +7826,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7830 "inc/vcf/validator_detail_v42.hpp"
+#line 7830 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7856,11 +7856,11 @@ case 302:
 		goto tr441;
 	goto tr437;
 tr442:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7869,7 +7869,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7873 "inc/vcf/validator_detail_v42.hpp"
+#line 7873 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr409;
@@ -7878,7 +7878,7 @@ case 303:
 		goto tr407;
 	goto tr403;
 tr436:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7887,7 +7887,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7891 "inc/vcf/validator_detail_v42.hpp"
+#line 7891 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7898,21 +7898,21 @@ case 304:
 		goto tr407;
 	goto tr403;
 tr443:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st305;
 tr379:
-#line 148 "src/vcf/vcf_v42.ragel"
+#line 148 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7921,18 +7921,18 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 7925 "inc/vcf/validator_detail_v42.hpp"
+#line 7925 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr443;
 	goto tr377;
 tr34:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7941,7 +7941,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 7945 "inc/vcf/validator_detail_v42.hpp"
+#line 7945 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr445;
@@ -7950,7 +7950,7 @@ case 306:
 		goto tr40;
 	goto tr444;
 tr445:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7959,7 +7959,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 7963 "inc/vcf/validator_detail_v42.hpp"
+#line 7963 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr446;
@@ -7968,7 +7968,7 @@ case 307:
 		goto tr40;
 	goto tr444;
 tr446:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7977,7 +7977,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 7981 "inc/vcf/validator_detail_v42.hpp"
+#line 7981 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr447;
@@ -7986,7 +7986,7 @@ case 308:
 		goto tr40;
 	goto tr444;
 tr447:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7995,7 +7995,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 7999 "inc/vcf/validator_detail_v42.hpp"
+#line 7999 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr448;
@@ -8004,7 +8004,7 @@ case 309:
 		goto tr40;
 	goto tr444;
 tr448:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8013,7 +8013,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8017 "inc/vcf/validator_detail_v42.hpp"
+#line 8017 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr449;
@@ -8022,7 +8022,7 @@ case 310:
 		goto tr40;
 	goto tr444;
 tr449:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8031,7 +8031,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 8035 "inc/vcf/validator_detail_v42.hpp"
+#line 8035 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr450;
@@ -8040,7 +8040,7 @@ case 311:
 		goto tr40;
 	goto tr444;
 tr450:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8049,7 +8049,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 8053 "inc/vcf/validator_detail_v42.hpp"
+#line 8053 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st313;
@@ -8067,7 +8067,7 @@ case 313:
 		goto tr40;
 	goto tr444;
 tr452:
-#line 132 "src/vcf/vcf_v42.ragel"
+#line 132 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "PEDIGREE");
     }
@@ -8076,12 +8076,12 @@ st314:
 	if ( ++p == pe )
 		goto _test_eof314;
 case 314:
-#line 8080 "inc/vcf/validator_detail_v42.hpp"
+#line 8080 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st315;
 	goto tr444;
 tr464:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8090,7 +8090,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8094 "inc/vcf/validator_detail_v42.hpp"
+#line 8094 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr455;
 	if ( (*p) < 48 ) {
@@ -8106,7 +8106,7 @@ case 315:
 		goto tr456;
 	goto tr454;
 tr455:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -8115,7 +8115,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8119 "inc/vcf/validator_detail_v42.hpp"
+#line 8119 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st316;
 	if ( (*p) < 48 ) {
@@ -8131,17 +8131,17 @@ case 316:
 		goto tr458;
 	goto tr454;
 tr456:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st317;
 tr458:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8150,7 +8150,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8154 "inc/vcf/validator_detail_v42.hpp"
+#line 8154 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr459;
 		case 95: goto tr458;
@@ -8168,7 +8168,7 @@ case 317:
 		goto tr458;
 	goto tr454;
 tr459:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8177,7 +8177,7 @@ st318:
 	if ( ++p == pe )
 		goto _test_eof318;
 case 318:
-#line 8181 "inc/vcf/validator_detail_v42.hpp"
+#line 8181 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr460;
 	if ( (*p) < 48 ) {
@@ -8193,7 +8193,7 @@ case 318:
 		goto tr461;
 	goto tr454;
 tr460:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -8202,7 +8202,7 @@ st319:
 	if ( ++p == pe )
 		goto _test_eof319;
 case 319:
-#line 8206 "inc/vcf/validator_detail_v42.hpp"
+#line 8206 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st319;
 	if ( (*p) < 48 ) {
@@ -8218,17 +8218,17 @@ case 319:
 		goto tr463;
 	goto tr454;
 tr461:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st320;
 tr463:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8237,7 +8237,7 @@ st320:
 	if ( ++p == pe )
 		goto _test_eof320;
 case 320:
-#line 8241 "inc/vcf/validator_detail_v42.hpp"
+#line 8241 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr464;
 		case 62: goto tr465;
@@ -8256,7 +8256,7 @@ case 320:
 		goto tr463;
 	goto tr454;
 tr465:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8265,18 +8265,18 @@ st321:
 	if ( ++p == pe )
 		goto _test_eof321;
 case 321:
-#line 8269 "inc/vcf/validator_detail_v42.hpp"
+#line 8269 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
 	}
 	goto tr444;
 tr35:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8285,7 +8285,7 @@ st322:
 	if ( ++p == pe )
 		goto _test_eof322;
 case 322:
-#line 8289 "inc/vcf/validator_detail_v42.hpp"
+#line 8289 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr467;
@@ -8294,7 +8294,7 @@ case 322:
 		goto tr40;
 	goto tr466;
 tr467:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8303,7 +8303,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 8307 "inc/vcf/validator_detail_v42.hpp"
+#line 8307 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr468;
@@ -8312,7 +8312,7 @@ case 323:
 		goto tr40;
 	goto tr466;
 tr468:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8321,7 +8321,7 @@ st324:
 	if ( ++p == pe )
 		goto _test_eof324;
 case 324:
-#line 8325 "inc/vcf/validator_detail_v42.hpp"
+#line 8325 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr469;
@@ -8330,7 +8330,7 @@ case 324:
 		goto tr40;
 	goto tr466;
 tr469:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8339,7 +8339,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8343 "inc/vcf/validator_detail_v42.hpp"
+#line 8343 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr470;
@@ -8348,7 +8348,7 @@ case 325:
 		goto tr40;
 	goto tr466;
 tr470:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8357,7 +8357,7 @@ st326:
 	if ( ++p == pe )
 		goto _test_eof326;
 case 326:
-#line 8361 "inc/vcf/validator_detail_v42.hpp"
+#line 8361 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st327;
@@ -8375,7 +8375,7 @@ case 327:
 		goto tr40;
 	goto tr466;
 tr472:
-#line 140 "src/vcf/vcf_v42.ragel"
+#line 140 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "SAMPLE");
     }
@@ -8384,7 +8384,7 @@ st328:
 	if ( ++p == pe )
 		goto _test_eof328;
 case 328:
-#line 8388 "inc/vcf/validator_detail_v42.hpp"
+#line 8388 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st329;
 	goto tr466;
@@ -8428,11 +8428,11 @@ case 332:
 		goto tr479;
 	goto tr477;
 tr478:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -8441,7 +8441,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 8445 "inc/vcf/validator_detail_v42.hpp"
+#line 8445 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st333;
 	if ( (*p) < 48 ) {
@@ -8457,21 +8457,21 @@ case 333:
 		goto tr481;
 	goto tr477;
 tr481:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st334;
 tr479:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8480,7 +8480,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 8484 "inc/vcf/validator_detail_v42.hpp"
+#line 8484 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr483;
 		case 95: goto tr481;
@@ -8498,7 +8498,7 @@ case 334:
 		goto tr481;
 	goto tr482;
 tr483:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8507,7 +8507,7 @@ st335:
 	if ( ++p == pe )
 		goto _test_eof335;
 case 335:
-#line 8511 "inc/vcf/validator_detail_v42.hpp"
+#line 8511 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 71 )
 		goto st336;
 	goto tr484;
@@ -8577,21 +8577,21 @@ case 343:
 		goto tr493;
 	goto tr484;
 tr495:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st344;
 tr493:
-#line 160 "src/vcf/vcf_v42.ragel"
+#line 160 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Genomes");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8600,7 +8600,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 8604 "inc/vcf/validator_detail_v42.hpp"
+#line 8604 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr496;
 	if ( (*p) < 35 ) {
@@ -8613,7 +8613,7 @@ case 344:
 		goto tr495;
 	goto tr494;
 tr496:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8622,7 +8622,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 8626 "inc/vcf/validator_detail_v42.hpp"
+#line 8626 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 77 )
 		goto st346;
 	goto tr497;
@@ -8692,21 +8692,21 @@ case 353:
 		goto tr506;
 	goto tr497;
 tr508:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st354;
 tr506:
-#line 164 "src/vcf/vcf_v42.ragel"
+#line 164 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Mixture");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8715,7 +8715,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8719 "inc/vcf/validator_detail_v42.hpp"
+#line 8719 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr509;
 	if ( (*p) < 35 ) {
@@ -8728,7 +8728,7 @@ case 354:
 		goto tr508;
 	goto tr507;
 tr509:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8737,7 +8737,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8741 "inc/vcf/validator_detail_v42.hpp"
+#line 8741 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st356;
 	goto tr510;
@@ -8826,7 +8826,7 @@ case 367:
 		goto tr523;
 	goto tr510;
 tr523:
-#line 156 "src/vcf/vcf_v42.ragel"
+#line 156 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -8835,7 +8835,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 8839 "inc/vcf/validator_detail_v42.hpp"
+#line 8839 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr525;
 		case 92: goto tr526;
@@ -8844,17 +8844,17 @@ case 368:
 		goto tr524;
 	goto tr510;
 tr524:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st369;
 tr527:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8863,7 +8863,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 8867 "inc/vcf/validator_detail_v42.hpp"
+#line 8867 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 92: goto tr529;
@@ -8872,17 +8872,17 @@ case 369:
 		goto tr527;
 	goto tr510;
 tr525:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st370;
 tr528:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8891,7 +8891,7 @@ st370:
 	if ( ++p == pe )
 		goto _test_eof370;
 case 370:
-#line 8895 "inc/vcf/validator_detail_v42.hpp"
+#line 8895 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st371;
 	goto tr510;
@@ -8905,17 +8905,17 @@ case 371:
 	}
 	goto tr466;
 tr526:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st372;
 tr529:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8924,7 +8924,7 @@ st372:
 	if ( ++p == pe )
 		goto _test_eof372;
 case 372:
-#line 8928 "inc/vcf/validator_detail_v42.hpp"
+#line 8928 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr531;
 		case 92: goto tr529;
@@ -8933,11 +8933,11 @@ case 372:
 		goto tr527;
 	goto tr510;
 tr531:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8946,7 +8946,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 8950 "inc/vcf/validator_detail_v42.hpp"
+#line 8950 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 62: goto tr532;
@@ -8956,7 +8956,7 @@ case 373:
 		goto tr527;
 	goto tr510;
 tr532:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8965,7 +8965,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 8969 "inc/vcf/validator_detail_v42.hpp"
+#line 8969 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8976,11 +8976,11 @@ case 374:
 		goto tr527;
 	goto tr510;
 tr36:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8989,7 +8989,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8993 "inc/vcf/validator_detail_v42.hpp"
+#line 8993 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr534;
@@ -8998,7 +8998,7 @@ case 375:
 		goto tr40;
 	goto tr533;
 tr534:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9007,7 +9007,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 9011 "inc/vcf/validator_detail_v42.hpp"
+#line 9011 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr535;
@@ -9016,7 +9016,7 @@ case 376:
 		goto tr40;
 	goto tr533;
 tr535:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9025,7 +9025,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 9029 "inc/vcf/validator_detail_v42.hpp"
+#line 9029 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr536;
@@ -9034,7 +9034,7 @@ case 377:
 		goto tr40;
 	goto tr533;
 tr536:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9043,7 +9043,7 @@ st378:
 	if ( ++p == pe )
 		goto _test_eof378;
 case 378:
-#line 9047 "inc/vcf/validator_detail_v42.hpp"
+#line 9047 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr537;
@@ -9052,7 +9052,7 @@ case 378:
 		goto tr40;
 	goto tr533;
 tr537:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9061,7 +9061,7 @@ st379:
 	if ( ++p == pe )
 		goto _test_eof379;
 case 379:
-#line 9065 "inc/vcf/validator_detail_v42.hpp"
+#line 9065 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr538;
@@ -9070,7 +9070,7 @@ case 379:
 		goto tr40;
 	goto tr533;
 tr538:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9079,7 +9079,7 @@ st380:
 	if ( ++p == pe )
 		goto _test_eof380;
 case 380:
-#line 9083 "inc/vcf/validator_detail_v42.hpp"
+#line 9083 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr539;
@@ -9088,7 +9088,7 @@ case 380:
 		goto tr40;
 	goto tr533;
 tr539:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9097,7 +9097,7 @@ st381:
 	if ( ++p == pe )
 		goto _test_eof381;
 case 381:
-#line 9101 "inc/vcf/validator_detail_v42.hpp"
+#line 9101 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st382;
@@ -9115,7 +9115,7 @@ case 382:
 		goto tr40;
 	goto tr533;
 tr541:
-#line 112 "src/vcf/vcf_v42.ragel"
+#line 112 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "assembly");
     }
@@ -9124,7 +9124,7 @@ st383:
 	if ( ++p == pe )
 		goto _test_eof383;
 case 383:
-#line 9128 "inc/vcf/validator_detail_v42.hpp"
+#line 9128 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr543;
@@ -9132,7 +9132,7 @@ case 383:
 		goto tr543;
 	goto tr542;
 tr543:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9141,7 +9141,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 9145 "inc/vcf/validator_detail_v42.hpp"
+#line 9145 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9152,7 +9152,7 @@ case 384:
 	}
 	goto st385;
 tr545:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -9167,7 +9167,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9171 "inc/vcf/validator_detail_v42.hpp"
+#line 9171 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9253,13 +9253,13 @@ case 394:
 		goto tr550;
 	goto tr542;
 tr550:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st395;
 tr559:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -9269,15 +9269,15 @@ tr559:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 176 "src/vcf/vcf_v42.ragel"
+#line 176 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -9290,7 +9290,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9294 "inc/vcf/validator_detail_v42.hpp"
+#line 9294 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr559;
@@ -9345,11 +9345,11 @@ case 401:
 		goto st390;
 	goto tr542;
 tr37:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9358,7 +9358,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 9362 "inc/vcf/validator_detail_v42.hpp"
+#line 9362 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr564;
@@ -9367,7 +9367,7 @@ case 402:
 		goto tr40;
 	goto tr563;
 tr564:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9376,7 +9376,7 @@ st403:
 	if ( ++p == pe )
 		goto _test_eof403;
 case 403:
-#line 9380 "inc/vcf/validator_detail_v42.hpp"
+#line 9380 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr565;
@@ -9385,7 +9385,7 @@ case 403:
 		goto tr40;
 	goto tr563;
 tr565:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9394,7 +9394,7 @@ st404:
 	if ( ++p == pe )
 		goto _test_eof404;
 case 404:
-#line 9398 "inc/vcf/validator_detail_v42.hpp"
+#line 9398 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr566;
@@ -9403,7 +9403,7 @@ case 404:
 		goto tr40;
 	goto tr563;
 tr566:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9412,7 +9412,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 9416 "inc/vcf/validator_detail_v42.hpp"
+#line 9416 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr567;
@@ -9421,7 +9421,7 @@ case 405:
 		goto tr40;
 	goto tr563;
 tr567:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9430,7 +9430,7 @@ st406:
 	if ( ++p == pe )
 		goto _test_eof406;
 case 406:
-#line 9434 "inc/vcf/validator_detail_v42.hpp"
+#line 9434 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st407;
@@ -9448,7 +9448,7 @@ case 407:
 		goto tr40;
 	goto tr563;
 tr569:
-#line 116 "src/vcf/vcf_v42.ragel"
+#line 116 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "contig");
     }
@@ -9457,7 +9457,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9461 "inc/vcf/validator_detail_v42.hpp"
+#line 9461 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st409;
 	goto tr563;
@@ -9496,21 +9496,21 @@ case 412:
 		goto tr575;
 	goto tr574;
 tr576:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st413;
 tr575:
-#line 144 "src/vcf/vcf_v42.ragel"
+#line 144 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9519,7 +9519,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9523 "inc/vcf/validator_detail_v42.hpp"
+#line 9523 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 59: goto tr576;
@@ -9532,7 +9532,7 @@ case 413:
 		goto tr576;
 	goto tr574;
 tr577:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9541,7 +9541,7 @@ st414:
 	if ( ++p == pe )
 		goto _test_eof414;
 case 414:
-#line 9545 "inc/vcf/validator_detail_v42.hpp"
+#line 9545 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr579;
 	if ( (*p) < 48 ) {
@@ -9557,7 +9557,7 @@ case 414:
 		goto tr580;
 	goto tr563;
 tr579:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9566,7 +9566,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9570 "inc/vcf/validator_detail_v42.hpp"
+#line 9570 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st415;
 	if ( (*p) < 48 ) {
@@ -9582,17 +9582,17 @@ case 415:
 		goto tr582;
 	goto tr563;
 tr580:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st416;
 tr582:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9601,7 +9601,7 @@ st416:
 	if ( ++p == pe )
 		goto _test_eof416;
 case 416:
-#line 9605 "inc/vcf/validator_detail_v42.hpp"
+#line 9605 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr583;
 		case 95: goto tr582;
@@ -9619,7 +9619,7 @@ case 416:
 		goto tr582;
 	goto tr563;
 tr583:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9628,7 +9628,7 @@ st417:
 	if ( ++p == pe )
 		goto _test_eof417;
 case 417:
-#line 9632 "inc/vcf/validator_detail_v42.hpp"
+#line 9632 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st420;
 	if ( (*p) < 45 ) {
@@ -9641,17 +9641,17 @@ case 417:
 		goto tr584;
 	goto tr563;
 tr584:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st418;
 tr586:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9660,7 +9660,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 9664 "inc/vcf/validator_detail_v42.hpp"
+#line 9664 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 62: goto tr578;
@@ -9672,7 +9672,7 @@ case 418:
 		goto tr586;
 	goto tr563;
 tr578:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9681,7 +9681,7 @@ st419:
 	if ( ++p == pe )
 		goto _test_eof419;
 case 419:
-#line 9685 "inc/vcf/validator_detail_v42.hpp"
+#line 9685 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -9699,17 +9699,17 @@ case 420:
 		goto tr587;
 	goto tr563;
 tr587:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st421;
 tr590:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9718,7 +9718,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9722 "inc/vcf/validator_detail_v42.hpp"
+#line 9722 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 92: goto tr592;
@@ -9727,17 +9727,17 @@ case 421:
 		goto tr590;
 	goto tr563;
 tr588:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st422;
 tr591:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9746,24 +9746,24 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9750 "inc/vcf/validator_detail_v42.hpp"
+#line 9750 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st414;
 		case 62: goto st419;
 	}
 	goto tr563;
 tr589:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st423;
 tr592:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9772,7 +9772,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9776 "inc/vcf/validator_detail_v42.hpp"
+#line 9776 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 92: goto tr592;
@@ -9781,11 +9781,11 @@ case 423:
 		goto tr590;
 	goto tr563;
 tr595:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9794,7 +9794,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9798 "inc/vcf/validator_detail_v42.hpp"
+#line 9798 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr596;
@@ -9805,27 +9805,27 @@ case 424:
 		goto tr590;
 	goto tr563;
 tr610:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st425;
 tr596:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st425;
 tr607:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9834,7 +9834,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9838 "inc/vcf/validator_detail_v42.hpp"
+#line 9838 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9866,17 +9866,17 @@ case 425:
 		goto tr590;
 	goto tr563;
 tr598:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st426;
 tr600:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9885,7 +9885,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9889 "inc/vcf/validator_detail_v42.hpp"
+#line 9889 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9917,17 +9917,17 @@ case 426:
 		goto tr590;
 	goto tr563;
 tr599:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st427;
 tr601:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9936,7 +9936,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9940 "inc/vcf/validator_detail_v42.hpp"
+#line 9940 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9966,11 +9966,11 @@ case 427:
 		goto tr601;
 	goto tr563;
 tr602:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9979,7 +9979,7 @@ st428:
 	if ( ++p == pe )
 		goto _test_eof428;
 case 428:
-#line 9983 "inc/vcf/validator_detail_v42.hpp"
+#line 9983 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr604;
 		case 44: goto tr590;
@@ -9990,17 +9990,17 @@ case 428:
 		goto tr603;
 	goto tr563;
 tr606:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st429;
 tr603:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -10009,7 +10009,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 10013 "inc/vcf/validator_detail_v42.hpp"
+#line 10013 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr607;
@@ -10020,27 +10020,27 @@ case 429:
 		goto tr606;
 	goto tr563;
 tr611:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st430;
 tr597:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st430;
 tr608:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10049,7 +10049,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 10053 "inc/vcf/validator_detail_v42.hpp"
+#line 10053 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -10060,17 +10060,17 @@ case 430:
 		goto tr590;
 	goto tr563;
 tr609:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st431;
 tr605:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -10079,7 +10079,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 10083 "inc/vcf/validator_detail_v42.hpp"
+#line 10083 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 44: goto tr607;
@@ -10090,7 +10090,7 @@ case 431:
 		goto tr606;
 	goto tr563;
 tr604:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10099,7 +10099,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 10103 "inc/vcf/validator_detail_v42.hpp"
+#line 10103 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr588;
 		case 44: goto tr610;
@@ -10110,11 +10110,11 @@ case 432:
 		goto tr587;
 	goto tr563;
 tr38:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10123,7 +10123,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10127 "inc/vcf/validator_detail_v42.hpp"
+#line 10127 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr613;
@@ -10132,7 +10132,7 @@ case 433:
 		goto tr40;
 	goto tr612;
 tr613:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10141,7 +10141,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10145 "inc/vcf/validator_detail_v42.hpp"
+#line 10145 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr614;
@@ -10150,7 +10150,7 @@ case 434:
 		goto tr40;
 	goto tr612;
 tr614:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10159,7 +10159,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10163 "inc/vcf/validator_detail_v42.hpp"
+#line 10163 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr615;
@@ -10168,7 +10168,7 @@ case 435:
 		goto tr40;
 	goto tr612;
 tr615:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10177,7 +10177,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10181 "inc/vcf/validator_detail_v42.hpp"
+#line 10181 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr616;
@@ -10186,7 +10186,7 @@ case 436:
 		goto tr40;
 	goto tr612;
 tr616:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10195,7 +10195,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10199 "inc/vcf/validator_detail_v42.hpp"
+#line 10199 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr617;
@@ -10204,7 +10204,7 @@ case 437:
 		goto tr40;
 	goto tr612;
 tr617:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10213,7 +10213,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10217 "inc/vcf/validator_detail_v42.hpp"
+#line 10217 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr618;
@@ -10222,7 +10222,7 @@ case 438:
 		goto tr40;
 	goto tr612;
 tr618:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10231,7 +10231,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10235 "inc/vcf/validator_detail_v42.hpp"
+#line 10235 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr619;
@@ -10240,7 +10240,7 @@ case 439:
 		goto tr40;
 	goto tr612;
 tr619:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10249,7 +10249,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10253 "inc/vcf/validator_detail_v42.hpp"
+#line 10253 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr620;
@@ -10258,7 +10258,7 @@ case 440:
 		goto tr40;
 	goto tr612;
 tr620:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10267,7 +10267,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10271 "inc/vcf/validator_detail_v42.hpp"
+#line 10271 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st442;
@@ -10285,7 +10285,7 @@ case 442:
 		goto tr40;
 	goto tr612;
 tr622:
-#line 136 "src/vcf/vcf_v42.ragel"
+#line 136 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "pedigreeDB");
     }
@@ -10294,7 +10294,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10298 "inc/vcf/validator_detail_v42.hpp"
+#line 10298 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st444;
 	goto tr612;
@@ -10309,7 +10309,7 @@ case 444:
 		goto tr625;
 	goto tr624;
 tr625:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -10318,7 +10318,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10322 "inc/vcf/validator_detail_v42.hpp"
+#line 10322 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10329,7 +10329,7 @@ case 445:
 	}
 	goto st446;
 tr627:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -10344,7 +10344,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10348 "inc/vcf/validator_detail_v42.hpp"
+#line 10348 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10430,13 +10430,13 @@ case 455:
 		goto tr632;
 	goto tr624;
 tr632:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st456;
 tr641:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -10446,7 +10446,7 @@ tr641:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10455,7 +10455,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 10459 "inc/vcf/validator_detail_v42.hpp"
+#line 10459 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr641;
@@ -10463,11 +10463,11 @@ case 456:
 	}
 	goto tr632;
 tr642:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10476,7 +10476,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 10480 "inc/vcf/validator_detail_v42.hpp"
+#line 10480 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr643;
@@ -10484,7 +10484,7 @@ case 457:
 	}
 	goto tr632;
 tr643:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -10494,11 +10494,11 @@ tr643:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 176 "src/vcf/vcf_v42.ragel"
+#line 176 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -10511,7 +10511,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 10515 "inc/vcf/validator_detail_v42.hpp"
+#line 10515 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr641;
@@ -10602,7 +10602,7 @@ case 469:
 		goto tr652;
 	goto tr647;
 tr652:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10611,7 +10611,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10615 "inc/vcf/validator_detail_v42.hpp"
+#line 10615 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 80 )
 		goto st471;
 	goto tr647;
@@ -10637,7 +10637,7 @@ case 473:
 		goto tr656;
 	goto tr647;
 tr656:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10646,7 +10646,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10650 "inc/vcf/validator_detail_v42.hpp"
+#line 10650 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st475;
 	goto tr647;
@@ -10665,7 +10665,7 @@ case 476:
 		goto tr659;
 	goto tr647;
 tr659:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10674,7 +10674,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 10678 "inc/vcf/validator_detail_v42.hpp"
+#line 10678 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 82 )
 		goto st478;
 	goto tr647;
@@ -10700,7 +10700,7 @@ case 480:
 		goto tr663;
 	goto tr647;
 tr663:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10709,7 +10709,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10713 "inc/vcf/validator_detail_v42.hpp"
+#line 10713 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 65 )
 		goto st482;
 	goto tr647;
@@ -10735,7 +10735,7 @@ case 484:
 		goto tr667;
 	goto tr647;
 tr667:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10744,7 +10744,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10748 "inc/vcf/validator_detail_v42.hpp"
+#line 10748 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 81 )
 		goto st486;
 	goto tr647;
@@ -10777,7 +10777,7 @@ case 489:
 		goto tr672;
 	goto tr647;
 tr672:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10786,7 +10786,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10790 "inc/vcf/validator_detail_v42.hpp"
+#line 10790 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st491;
 	goto tr647;
@@ -10833,7 +10833,7 @@ case 496:
 		goto tr679;
 	goto tr647;
 tr679:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10842,7 +10842,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10846 "inc/vcf/validator_detail_v42.hpp"
+#line 10846 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st498;
 	goto tr647;
@@ -10878,7 +10878,7 @@ case 501:
 	}
 	goto tr647;
 tr684:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10887,7 +10887,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10891 "inc/vcf/validator_detail_v42.hpp"
+#line 10891 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st503;
 	goto tr687;
@@ -10934,17 +10934,17 @@ case 508:
 		goto tr694;
 	goto tr687;
 tr694:
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
 	goto st509;
 tr696:
-#line 184 "src/vcf/vcf_v42.ragel"
+#line 184 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -10953,22 +10953,22 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10957 "inc/vcf/validator_detail_v42.hpp"
+#line 10957 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr695;
 	goto tr687;
 tr695:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st510;
 tr699:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10977,7 +10977,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10981 "inc/vcf/validator_detail_v42.hpp"
+#line 10981 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr696;
 		case 10: goto tr697;
@@ -10987,11 +10987,11 @@ case 510:
 		goto tr699;
 	goto tr687;
 tr685:
-#line 188 "src/vcf/vcf_v42.ragel"
+#line 188 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11003,15 +11003,15 @@ tr685:
     }
 	goto st726;
 tr697:
-#line 184 "src/vcf/vcf_v42.ragel"
+#line 184 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 188 "src/vcf/vcf_v42.ragel"
+#line 188 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11026,7 +11026,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 11030 "inc/vcf/validator_detail_v42.hpp"
+#line 11030 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr981;
 		case 13: goto tr982;
@@ -11042,7 +11042,7 @@ case 726:
 		goto tr983;
 	goto tr980;
 tr985:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11054,7 +11054,7 @@ tr985:
     }
 	goto st727;
 tr981:
-#line 70 "src/vcf/vcf_v42.ragel"
+#line 70 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -11062,7 +11062,7 @@ tr981:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11077,14 +11077,14 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 11081 "inc/vcf/validator_detail_v42.hpp"
+#line 11081 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr985;
 		case 13: goto tr986;
 	}
 	goto st0;
 tr986:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11096,7 +11096,7 @@ tr986:
     }
 	goto st511;
 tr982:
-#line 70 "src/vcf/vcf_v42.ragel"
+#line 70 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -11104,7 +11104,7 @@ tr982:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11119,28 +11119,28 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11123 "inc/vcf/validator_detail_v42.hpp"
+#line 11123 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st727;
 	goto st0;
 tr987:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st512;
 tr704:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st512;
 tr983:
-#line 70 "src/vcf/vcf_v42.ragel"
+#line 70 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -11148,11 +11148,11 @@ tr983:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11161,7 +11161,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11165 "inc/vcf/validator_detail_v42.hpp"
+#line 11165 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr703;
 		case 59: goto tr704;
@@ -11177,25 +11177,25 @@ case 512:
 		goto tr704;
 	goto tr702;
 tr703:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
 	goto st513;
 tr783:
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11204,22 +11204,22 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11208 "inc/vcf/validator_detail_v42.hpp"
+#line 11208 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr706;
 	goto tr705;
 tr706:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st514;
 tr708:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11228,28 +11228,28 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11232 "inc/vcf/validator_detail_v42.hpp"
+#line 11232 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr707;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr708;
 	goto tr705;
 tr713:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st515;
 tr707:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11258,7 +11258,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11262 "inc/vcf/validator_detail_v42.hpp"
+#line 11262 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr710;
@@ -11266,17 +11266,17 @@ case 515:
 		goto tr710;
 	goto tr709;
 tr710:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st516;
 tr712:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11285,7 +11285,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11289 "inc/vcf/validator_detail_v42.hpp"
+#line 11289 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr711;
 		case 59: goto tr713;
@@ -11294,15 +11294,15 @@ case 516:
 		goto tr712;
 	goto tr709;
 tr711:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11311,7 +11311,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11315 "inc/vcf/validator_detail_v42.hpp"
+#line 11315 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr715;
 		case 67: goto tr715;
@@ -11326,17 +11326,17 @@ case 517:
 	}
 	goto tr714;
 tr715:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st518;
 tr717:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11345,7 +11345,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11349 "inc/vcf/validator_detail_v42.hpp"
+#line 11349 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr716;
 		case 65: goto tr717;
@@ -11361,15 +11361,15 @@ case 518:
 	}
 	goto tr714;
 tr716:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11378,7 +11378,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11382 "inc/vcf/validator_detail_v42.hpp"
+#line 11382 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr720;
@@ -11398,17 +11398,17 @@ case 519:
 	}
 	goto tr718;
 tr719:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st520;
 tr943:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11417,22 +11417,22 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11421 "inc/vcf/validator_detail_v42.hpp"
+#line 11421 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
 	}
 	goto tr718;
 tr725:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11441,7 +11441,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11445 "inc/vcf/validator_detail_v42.hpp"
+#line 11445 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr728;
 		case 45: goto tr728;
@@ -11453,11 +11453,11 @@ case 521:
 		goto tr730;
 	goto tr727;
 tr728:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11466,24 +11466,24 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11470 "inc/vcf/validator_detail_v42.hpp"
+#line 11470 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr734;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr733;
 	goto tr727;
 tr730:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st523;
 tr733:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11492,7 +11492,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11496 "inc/vcf/validator_detail_v42.hpp"
+#line 11496 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 46: goto tr736;
@@ -11503,15 +11503,15 @@ case 523:
 		goto tr733;
 	goto tr727;
 tr735:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11520,7 +11520,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11524 "inc/vcf/validator_detail_v42.hpp"
+#line 11524 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr740;
 		case 58: goto tr739;
@@ -11547,7 +11547,7 @@ case 524:
 		goto tr741;
 	goto tr738;
 tr739:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -11556,7 +11556,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11560 "inc/vcf/validator_detail_v42.hpp"
+#line 11560 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto st525;
 	if ( (*p) < 65 ) {
@@ -11581,17 +11581,17 @@ case 525:
 		goto tr743;
 	goto tr738;
 tr741:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st526;
 tr743:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11600,7 +11600,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11604 "inc/vcf/validator_detail_v42.hpp"
+#line 11604 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 59: goto tr745;
@@ -11609,15 +11609,15 @@ case 526:
 		goto tr743;
 	goto tr738;
 tr744:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11626,7 +11626,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11630 "inc/vcf/validator_detail_v42.hpp"
+#line 11630 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr748;
 		case 49: goto tr750;
@@ -11665,17 +11665,17 @@ case 527:
 		goto tr749;
 	goto tr746;
 tr747:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st528;
 tr761:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11684,7 +11684,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11688 "inc/vcf/validator_detail_v42.hpp"
+#line 11688 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr761;
 		case 60: goto tr761;
@@ -11711,17 +11711,17 @@ case 528:
 		goto tr762;
 	goto tr746;
 tr749:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st529;
 tr762:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11730,7 +11730,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 11734 "inc/vcf/validator_detail_v42.hpp"
+#line 11734 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -11742,21 +11742,21 @@ case 529:
 		goto tr762;
 	goto tr746;
 tr772:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st530;
 tr763:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11765,7 +11765,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 11769 "inc/vcf/validator_detail_v42.hpp"
+#line 11769 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr769;
@@ -11776,17 +11776,17 @@ case 530:
 		goto tr769;
 	goto tr768;
 tr769:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st531;
 tr771:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11795,7 +11795,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 11799 "inc/vcf/validator_detail_v42.hpp"
+#line 11799 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 58: goto tr772;
@@ -11810,15 +11810,15 @@ case 531:
 		goto tr771;
 	goto tr768;
 tr770:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v42.ragel"
+#line 53 "../src/vcf/vcf_v42.ragel"
 	{
         ++n_columns;
     }
@@ -11827,7 +11827,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 11831 "inc/vcf/validator_detail_v42.hpp"
+#line 11831 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr775;
 	if ( (*p) < 48 ) {
@@ -11840,17 +11840,17 @@ case 532:
 		goto tr776;
 	goto tr773;
 tr774:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st533;
 tr778:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11859,7 +11859,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 11863 "inc/vcf/validator_detail_v42.hpp"
+#line 11863 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -11870,28 +11870,28 @@ case 533:
 		goto tr778;
 	goto tr777;
 tr764:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 198 "src/vcf/vcf_v42.ragel"
+#line 198 "../src/vcf/vcf_v42.ragel"
 	{
         try {
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                 ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -11901,7 +11901,7 @@ tr764:
             ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11916,7 +11916,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 11920 "inc/vcf/validator_detail_v42.hpp"
+#line 11920 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr985;
 		case 13: goto tr986;
@@ -11932,7 +11932,7 @@ case 728:
 		goto tr987;
 	goto tr702;
 tr984:
-#line 70 "src/vcf/vcf_v42.ragel"
+#line 70 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -11945,7 +11945,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 11949 "inc/vcf/validator_detail_v42.hpp"
+#line 11949 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr780;
@@ -11956,17 +11956,17 @@ case 534:
 		goto tr780;
 	goto tr702;
 tr780:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st535;
 tr781:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11975,7 +11975,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 11979 "inc/vcf/validator_detail_v42.hpp"
+#line 11979 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr781;
 		case 62: goto tr782;
@@ -11990,7 +11990,7 @@ case 535:
 		goto tr781;
 	goto tr702;
 tr782:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11999,33 +11999,33 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12003 "inc/vcf/validator_detail_v42.hpp"
+#line 12003 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr783;
 	goto tr702;
 tr765:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 194 "src/vcf/vcf_v42.ragel"
+#line 194 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 198 "src/vcf/vcf_v42.ragel"
+#line 198 "../src/vcf/vcf_v42.ragel"
 	{
         try {
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                 ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -12035,7 +12035,7 @@ tr765:
             ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -12050,12 +12050,12 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12054 "inc/vcf/validator_detail_v42.hpp"
+#line 12054 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st728;
 	goto tr784;
 tr779:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12064,7 +12064,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12068 "inc/vcf/validator_detail_v42.hpp"
+#line 12068 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr778;
@@ -12072,17 +12072,17 @@ case 538:
 		goto tr778;
 	goto tr777;
 tr775:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st539;
 tr787:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12091,7 +12091,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12095 "inc/vcf/validator_detail_v42.hpp"
+#line 12095 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12104,7 +12104,7 @@ case 539:
 		goto tr778;
 	goto tr773;
 tr786:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12113,7 +12113,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12117 "inc/vcf/validator_detail_v42.hpp"
+#line 12117 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12131,17 +12131,17 @@ case 540:
 		goto tr788;
 	goto tr773;
 tr776:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st541;
 tr788:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12150,7 +12150,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12154 "inc/vcf/validator_detail_v42.hpp"
+#line 12154 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12169,7 +12169,7 @@ case 541:
 		goto tr788;
 	goto tr773;
 tr766:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -12178,7 +12178,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12182 "inc/vcf/validator_detail_v42.hpp"
+#line 12182 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 49: goto tr750;
 		case 58: goto tr747;
@@ -12216,11 +12216,11 @@ case 542:
 		goto tr749;
 	goto tr746;
 tr750:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12229,7 +12229,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12233 "inc/vcf/validator_detail_v42.hpp"
+#line 12233 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12242,7 +12242,7 @@ case 543:
 		goto tr762;
 	goto tr746;
 tr789:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12251,7 +12251,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12255 "inc/vcf/validator_detail_v42.hpp"
+#line 12255 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12264,7 +12264,7 @@ case 544:
 		goto tr762;
 	goto tr746;
 tr790:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12273,7 +12273,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12277 "inc/vcf/validator_detail_v42.hpp"
+#line 12277 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12286,7 +12286,7 @@ case 545:
 		goto tr762;
 	goto tr746;
 tr791:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12295,7 +12295,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12299 "inc/vcf/validator_detail_v42.hpp"
+#line 12299 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12308,7 +12308,7 @@ case 546:
 		goto tr762;
 	goto tr746;
 tr767:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12317,7 +12317,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12321 "inc/vcf/validator_detail_v42.hpp"
+#line 12321 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr794;
@@ -12325,7 +12325,7 @@ case 547:
 		goto tr794;
 	goto tr793;
 tr794:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12334,7 +12334,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12338 "inc/vcf/validator_detail_v42.hpp"
+#line 12338 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12345,7 +12345,7 @@ case 548:
 		goto tr794;
 	goto tr793;
 tr792:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12354,7 +12354,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12358 "inc/vcf/validator_detail_v42.hpp"
+#line 12358 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12366,7 +12366,7 @@ case 549:
 		goto tr762;
 	goto tr795;
 tr796:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12375,12 +12375,12 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12379 "inc/vcf/validator_detail_v42.hpp"
+#line 12379 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr798;
 	goto tr797;
 tr798:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12389,7 +12389,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12393 "inc/vcf/validator_detail_v42.hpp"
+#line 12393 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12398,11 +12398,11 @@ case 551:
 	}
 	goto tr797;
 tr751:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12411,7 +12411,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12415 "inc/vcf/validator_detail_v42.hpp"
+#line 12415 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12427,7 +12427,7 @@ case 552:
 		goto tr762;
 	goto tr746;
 tr799:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12436,7 +12436,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12440 "inc/vcf/validator_detail_v42.hpp"
+#line 12440 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr803;
 	if ( (*p) > 58 ) {
@@ -12446,7 +12446,7 @@ case 553:
 		goto tr762;
 	goto tr746;
 tr803:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12455,7 +12455,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12459 "inc/vcf/validator_detail_v42.hpp"
+#line 12459 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr805;
 	if ( (*p) < 45 ) {
@@ -12468,7 +12468,7 @@ case 554:
 		goto tr805;
 	goto tr804;
 tr805:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12477,7 +12477,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12481 "inc/vcf/validator_detail_v42.hpp"
+#line 12481 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12494,7 +12494,7 @@ case 555:
 		goto tr805;
 	goto tr804;
 tr800:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12503,7 +12503,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12507 "inc/vcf/validator_detail_v42.hpp"
+#line 12507 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr806;
 	if ( (*p) > 58 ) {
@@ -12513,7 +12513,7 @@ case 556:
 		goto tr762;
 	goto tr746;
 tr806:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12522,12 +12522,12 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12526 "inc/vcf/validator_detail_v42.hpp"
+#line 12526 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr808;
 	goto tr807;
 tr808:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12536,7 +12536,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12540 "inc/vcf/validator_detail_v42.hpp"
+#line 12540 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12548,7 +12548,7 @@ case 558:
 		goto tr808;
 	goto tr807;
 tr801:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12557,7 +12557,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12561 "inc/vcf/validator_detail_v42.hpp"
+#line 12561 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr809;
 	if ( (*p) > 58 ) {
@@ -12567,7 +12567,7 @@ case 559:
 		goto tr762;
 	goto tr746;
 tr809:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12576,7 +12576,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12580 "inc/vcf/validator_detail_v42.hpp"
+#line 12580 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr811;
 		case 45: goto tr811;
@@ -12587,7 +12587,7 @@ case 560:
 		goto tr812;
 	goto tr810;
 tr811:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12596,14 +12596,14 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 12600 "inc/vcf/validator_detail_v42.hpp"
+#line 12600 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr813;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr812;
 	goto tr810;
 tr812:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12612,7 +12612,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 12616 "inc/vcf/validator_detail_v42.hpp"
+#line 12616 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12627,7 +12627,7 @@ case 562:
 		goto tr812;
 	goto tr810;
 tr815:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12636,12 +12636,12 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12640 "inc/vcf/validator_detail_v42.hpp"
+#line 12640 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr817;
 	goto tr810;
 tr817:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12650,7 +12650,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 12654 "inc/vcf/validator_detail_v42.hpp"
+#line 12654 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12664,7 +12664,7 @@ case 564:
 		goto tr817;
 	goto tr810;
 tr816:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12673,7 +12673,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 12677 "inc/vcf/validator_detail_v42.hpp"
+#line 12677 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr818;
 		case 45: goto tr818;
@@ -12682,7 +12682,7 @@ case 565:
 		goto tr819;
 	goto tr810;
 tr818:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12691,12 +12691,12 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 12695 "inc/vcf/validator_detail_v42.hpp"
+#line 12695 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr819;
 	goto tr810;
 tr819:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12705,7 +12705,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 12709 "inc/vcf/validator_detail_v42.hpp"
+#line 12709 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12717,7 +12717,7 @@ case 567:
 		goto tr819;
 	goto tr810;
 tr813:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12726,12 +12726,12 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12730 "inc/vcf/validator_detail_v42.hpp"
+#line 12730 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr820;
 	goto tr810;
 tr820:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12740,12 +12740,12 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 12744 "inc/vcf/validator_detail_v42.hpp"
+#line 12744 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr821;
 	goto tr810;
 tr821:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12754,7 +12754,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 12758 "inc/vcf/validator_detail_v42.hpp"
+#line 12758 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12764,7 +12764,7 @@ case 570:
 	}
 	goto tr810;
 tr814:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12773,12 +12773,12 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 12777 "inc/vcf/validator_detail_v42.hpp"
+#line 12777 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr822;
 	goto tr810;
 tr822:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12787,12 +12787,12 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 12791 "inc/vcf/validator_detail_v42.hpp"
+#line 12791 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr821;
 	goto tr810;
 tr802:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12801,7 +12801,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 12805 "inc/vcf/validator_detail_v42.hpp"
+#line 12805 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr823;
 	if ( (*p) > 58 ) {
@@ -12811,7 +12811,7 @@ case 573:
 		goto tr762;
 	goto tr746;
 tr823:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12820,12 +12820,12 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 12824 "inc/vcf/validator_detail_v42.hpp"
+#line 12824 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr825;
 	goto tr824;
 tr825:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12834,7 +12834,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12838 "inc/vcf/validator_detail_v42.hpp"
+#line 12838 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12845,11 +12845,11 @@ case 575:
 		goto tr825;
 	goto tr824;
 tr752:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12858,7 +12858,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12862 "inc/vcf/validator_detail_v42.hpp"
+#line 12862 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12871,7 +12871,7 @@ case 576:
 		goto tr762;
 	goto tr746;
 tr826:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12880,7 +12880,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12884 "inc/vcf/validator_detail_v42.hpp"
+#line 12884 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr827;
 	if ( (*p) > 58 ) {
@@ -12890,7 +12890,7 @@ case 577:
 		goto tr762;
 	goto tr746;
 tr827:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12899,7 +12899,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12903 "inc/vcf/validator_detail_v42.hpp"
+#line 12903 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr829;
 		case 45: goto tr829;
@@ -12910,7 +12910,7 @@ case 578:
 		goto tr830;
 	goto tr828;
 tr829:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12919,14 +12919,14 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12923 "inc/vcf/validator_detail_v42.hpp"
+#line 12923 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr831;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr830;
 	goto tr828;
 tr830:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12935,7 +12935,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12939 "inc/vcf/validator_detail_v42.hpp"
+#line 12939 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12949,7 +12949,7 @@ case 580:
 		goto tr830;
 	goto tr828;
 tr833:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12958,12 +12958,12 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12962 "inc/vcf/validator_detail_v42.hpp"
+#line 12962 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr828;
 tr835:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12972,7 +12972,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12976 "inc/vcf/validator_detail_v42.hpp"
+#line 12976 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12985,7 +12985,7 @@ case 582:
 		goto tr835;
 	goto tr828;
 tr834:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12994,7 +12994,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12998 "inc/vcf/validator_detail_v42.hpp"
+#line 12998 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr836;
 		case 45: goto tr836;
@@ -13003,7 +13003,7 @@ case 583:
 		goto tr837;
 	goto tr828;
 tr836:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13012,12 +13012,12 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 13016 "inc/vcf/validator_detail_v42.hpp"
+#line 13016 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr837;
 	goto tr828;
 tr837:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13026,7 +13026,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 13030 "inc/vcf/validator_detail_v42.hpp"
+#line 13030 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13037,7 +13037,7 @@ case 585:
 		goto tr837;
 	goto tr828;
 tr831:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13046,12 +13046,12 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 13050 "inc/vcf/validator_detail_v42.hpp"
+#line 13050 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr838;
 	goto tr828;
 tr838:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13060,12 +13060,12 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 13064 "inc/vcf/validator_detail_v42.hpp"
+#line 13064 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr839;
 	goto tr828;
 tr839:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13074,7 +13074,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 13078 "inc/vcf/validator_detail_v42.hpp"
+#line 13078 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13083,7 +13083,7 @@ case 588:
 	}
 	goto tr828;
 tr832:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13092,12 +13092,12 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 13096 "inc/vcf/validator_detail_v42.hpp"
+#line 13096 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr840;
 	goto tr828;
 tr840:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13106,16 +13106,16 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 13110 "inc/vcf/validator_detail_v42.hpp"
+#line 13110 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr839;
 	goto tr828;
 tr753:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13124,7 +13124,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 13128 "inc/vcf/validator_detail_v42.hpp"
+#line 13128 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13137,7 +13137,7 @@ case 591:
 		goto tr762;
 	goto tr746;
 tr841:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13146,7 +13146,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 13150 "inc/vcf/validator_detail_v42.hpp"
+#line 13150 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13159,7 +13159,7 @@ case 592:
 		goto tr762;
 	goto tr746;
 tr842:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13168,7 +13168,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 13172 "inc/vcf/validator_detail_v42.hpp"
+#line 13172 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13181,7 +13181,7 @@ case 593:
 		goto tr762;
 	goto tr746;
 tr843:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13190,7 +13190,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13194 "inc/vcf/validator_detail_v42.hpp"
+#line 13194 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13203,7 +13203,7 @@ case 594:
 		goto tr762;
 	goto tr746;
 tr844:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13212,7 +13212,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13216 "inc/vcf/validator_detail_v42.hpp"
+#line 13216 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr845;
 	if ( (*p) > 58 ) {
@@ -13222,7 +13222,7 @@ case 595:
 		goto tr762;
 	goto tr746;
 tr845:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13231,12 +13231,12 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13235 "inc/vcf/validator_detail_v42.hpp"
+#line 13235 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr847;
 	goto tr846;
 tr847:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13245,7 +13245,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13249 "inc/vcf/validator_detail_v42.hpp"
+#line 13249 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 68: goto tr848;
 		case 80: goto tr848;
@@ -13262,7 +13262,7 @@ case 597:
 		goto tr848;
 	goto tr846;
 tr848:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13271,7 +13271,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13275 "inc/vcf/validator_detail_v42.hpp"
+#line 13275 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13282,11 +13282,11 @@ case 598:
 		goto tr847;
 	goto tr846;
 tr754:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13295,7 +13295,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13299 "inc/vcf/validator_detail_v42.hpp"
+#line 13299 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13309,7 +13309,7 @@ case 599:
 		goto tr762;
 	goto tr746;
 tr849:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13318,7 +13318,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13322 "inc/vcf/validator_detail_v42.hpp"
+#line 13322 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13330,7 +13330,7 @@ case 600:
 		goto tr762;
 	goto tr851;
 tr852:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13339,12 +13339,12 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13343 "inc/vcf/validator_detail_v42.hpp"
+#line 13343 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr854;
 	goto tr853;
 tr854:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13353,7 +13353,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13357 "inc/vcf/validator_detail_v42.hpp"
+#line 13357 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13362,7 +13362,7 @@ case 602:
 	}
 	goto tr853;
 tr850:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13371,7 +13371,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13375 "inc/vcf/validator_detail_v42.hpp"
+#line 13375 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr855;
 	if ( (*p) > 58 ) {
@@ -13381,7 +13381,7 @@ case 603:
 		goto tr762;
 	goto tr746;
 tr855:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13390,12 +13390,12 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13394 "inc/vcf/validator_detail_v42.hpp"
+#line 13394 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr857;
 	goto tr856;
 tr857:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13404,7 +13404,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13408 "inc/vcf/validator_detail_v42.hpp"
+#line 13408 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13415,11 +13415,11 @@ case 605:
 		goto tr857;
 	goto tr856;
 tr755:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13428,7 +13428,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13432 "inc/vcf/validator_detail_v42.hpp"
+#line 13432 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13441,7 +13441,7 @@ case 606:
 		goto tr762;
 	goto tr746;
 tr858:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13450,7 +13450,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13454 "inc/vcf/validator_detail_v42.hpp"
+#line 13454 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13463,7 +13463,7 @@ case 607:
 		goto tr762;
 	goto tr746;
 tr859:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13472,7 +13472,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13476 "inc/vcf/validator_detail_v42.hpp"
+#line 13476 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr860;
 	if ( (*p) > 58 ) {
@@ -13482,7 +13482,7 @@ case 608:
 		goto tr762;
 	goto tr746;
 tr860:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13491,12 +13491,12 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13495 "inc/vcf/validator_detail_v42.hpp"
+#line 13495 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr862;
 	goto tr861;
 tr862:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13505,7 +13505,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13509 "inc/vcf/validator_detail_v42.hpp"
+#line 13509 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13516,11 +13516,11 @@ case 610:
 		goto tr862;
 	goto tr861;
 tr756:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13529,7 +13529,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13533 "inc/vcf/validator_detail_v42.hpp"
+#line 13533 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13543,7 +13543,7 @@ case 611:
 		goto tr762;
 	goto tr746;
 tr863:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13552,7 +13552,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13556 "inc/vcf/validator_detail_v42.hpp"
+#line 13556 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13564,7 +13564,7 @@ case 612:
 		goto tr762;
 	goto tr865;
 tr866:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13573,12 +13573,12 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13577 "inc/vcf/validator_detail_v42.hpp"
+#line 13577 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr868;
 	goto tr867;
 tr868:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13587,7 +13587,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13591 "inc/vcf/validator_detail_v42.hpp"
+#line 13591 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13596,7 +13596,7 @@ case 614:
 	}
 	goto tr867;
 tr864:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13605,7 +13605,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13609 "inc/vcf/validator_detail_v42.hpp"
+#line 13609 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13617,7 +13617,7 @@ case 615:
 		goto tr762;
 	goto tr869;
 tr870:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13626,12 +13626,12 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13630 "inc/vcf/validator_detail_v42.hpp"
+#line 13630 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr872;
 	goto tr871;
 tr872:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13640,7 +13640,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13644 "inc/vcf/validator_detail_v42.hpp"
+#line 13644 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13649,11 +13649,11 @@ case 617:
 	}
 	goto tr871;
 tr757:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13662,7 +13662,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13666 "inc/vcf/validator_detail_v42.hpp"
+#line 13666 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13675,7 +13675,7 @@ case 618:
 		goto tr762;
 	goto tr746;
 tr873:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13684,7 +13684,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13688 "inc/vcf/validator_detail_v42.hpp"
+#line 13688 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 48: goto tr874;
 		case 61: goto tr875;
@@ -13696,7 +13696,7 @@ case 619:
 		goto tr762;
 	goto tr746;
 tr874:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13705,7 +13705,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13709 "inc/vcf/validator_detail_v42.hpp"
+#line 13709 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr876;
 	if ( (*p) > 58 ) {
@@ -13715,7 +13715,7 @@ case 620:
 		goto tr762;
 	goto tr746;
 tr876:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13724,12 +13724,12 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13728 "inc/vcf/validator_detail_v42.hpp"
+#line 13728 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr878;
 	goto tr877;
 tr878:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13738,7 +13738,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13742 "inc/vcf/validator_detail_v42.hpp"
+#line 13742 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13749,7 +13749,7 @@ case 622:
 		goto tr878;
 	goto tr877;
 tr875:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13758,7 +13758,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13762 "inc/vcf/validator_detail_v42.hpp"
+#line 13762 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr880;
 		case 45: goto tr880;
@@ -13769,7 +13769,7 @@ case 623:
 		goto tr881;
 	goto tr879;
 tr880:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13778,14 +13778,14 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13782 "inc/vcf/validator_detail_v42.hpp"
+#line 13782 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr882;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr881;
 	goto tr879;
 tr881:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13794,7 +13794,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13798 "inc/vcf/validator_detail_v42.hpp"
+#line 13798 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13808,7 +13808,7 @@ case 625:
 		goto tr881;
 	goto tr879;
 tr884:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13817,12 +13817,12 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13821 "inc/vcf/validator_detail_v42.hpp"
+#line 13821 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr886;
 	goto tr879;
 tr886:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13831,7 +13831,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13835 "inc/vcf/validator_detail_v42.hpp"
+#line 13835 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13844,7 +13844,7 @@ case 627:
 		goto tr886;
 	goto tr879;
 tr885:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13853,7 +13853,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 13857 "inc/vcf/validator_detail_v42.hpp"
+#line 13857 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr887;
 		case 45: goto tr887;
@@ -13862,7 +13862,7 @@ case 628:
 		goto tr888;
 	goto tr879;
 tr887:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13871,12 +13871,12 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 13875 "inc/vcf/validator_detail_v42.hpp"
+#line 13875 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr888;
 	goto tr879;
 tr888:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13885,7 +13885,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 13889 "inc/vcf/validator_detail_v42.hpp"
+#line 13889 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13896,7 +13896,7 @@ case 630:
 		goto tr888;
 	goto tr879;
 tr882:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13905,12 +13905,12 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 13909 "inc/vcf/validator_detail_v42.hpp"
+#line 13909 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr889;
 	goto tr879;
 tr889:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13919,12 +13919,12 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 13923 "inc/vcf/validator_detail_v42.hpp"
+#line 13923 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr890;
 	goto tr879;
 tr890:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13933,7 +13933,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 13937 "inc/vcf/validator_detail_v42.hpp"
+#line 13937 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13942,7 +13942,7 @@ case 633:
 	}
 	goto tr879;
 tr883:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13951,12 +13951,12 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 13955 "inc/vcf/validator_detail_v42.hpp"
+#line 13955 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr891;
 	goto tr879;
 tr891:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13965,16 +13965,16 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 13969 "inc/vcf/validator_detail_v42.hpp"
+#line 13969 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr890;
 	goto tr879;
 tr758:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13983,7 +13983,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13987 "inc/vcf/validator_detail_v42.hpp"
+#line 13987 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13996,7 +13996,7 @@ case 636:
 		goto tr762;
 	goto tr746;
 tr892:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14005,7 +14005,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14009 "inc/vcf/validator_detail_v42.hpp"
+#line 14009 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr893;
 	if ( (*p) > 58 ) {
@@ -14015,7 +14015,7 @@ case 637:
 		goto tr762;
 	goto tr746;
 tr893:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14024,12 +14024,12 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14028 "inc/vcf/validator_detail_v42.hpp"
+#line 14028 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr895;
 	goto tr894;
 tr895:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14038,7 +14038,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14042 "inc/vcf/validator_detail_v42.hpp"
+#line 14042 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14049,11 +14049,11 @@ case 639:
 		goto tr895;
 	goto tr894;
 tr759:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14062,7 +14062,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14066 "inc/vcf/validator_detail_v42.hpp"
+#line 14066 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14076,7 +14076,7 @@ case 640:
 		goto tr762;
 	goto tr746;
 tr896:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14085,7 +14085,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14089 "inc/vcf/validator_detail_v42.hpp"
+#line 14089 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr898;
 	if ( (*p) > 58 ) {
@@ -14095,7 +14095,7 @@ case 641:
 		goto tr762;
 	goto tr746;
 tr898:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14104,7 +14104,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14108 "inc/vcf/validator_detail_v42.hpp"
+#line 14108 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr900;
 		case 45: goto tr900;
@@ -14115,7 +14115,7 @@ case 642:
 		goto tr901;
 	goto tr899;
 tr900:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14124,14 +14124,14 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14128 "inc/vcf/validator_detail_v42.hpp"
+#line 14128 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr902;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr901;
 	goto tr899;
 tr901:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14140,7 +14140,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14144 "inc/vcf/validator_detail_v42.hpp"
+#line 14144 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14154,7 +14154,7 @@ case 644:
 		goto tr901;
 	goto tr899;
 tr904:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14163,12 +14163,12 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14167 "inc/vcf/validator_detail_v42.hpp"
+#line 14167 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr906;
 	goto tr899;
 tr906:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14177,7 +14177,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14181 "inc/vcf/validator_detail_v42.hpp"
+#line 14181 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14190,7 +14190,7 @@ case 646:
 		goto tr906;
 	goto tr899;
 tr905:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14199,7 +14199,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14203 "inc/vcf/validator_detail_v42.hpp"
+#line 14203 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr907;
 		case 45: goto tr907;
@@ -14208,7 +14208,7 @@ case 647:
 		goto tr908;
 	goto tr899;
 tr907:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14217,12 +14217,12 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14221 "inc/vcf/validator_detail_v42.hpp"
+#line 14221 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr908;
 	goto tr899;
 tr908:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14231,7 +14231,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14235 "inc/vcf/validator_detail_v42.hpp"
+#line 14235 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14242,7 +14242,7 @@ case 649:
 		goto tr908;
 	goto tr899;
 tr902:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14251,12 +14251,12 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14255 "inc/vcf/validator_detail_v42.hpp"
+#line 14255 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr909;
 	goto tr899;
 tr909:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14265,12 +14265,12 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14269 "inc/vcf/validator_detail_v42.hpp"
+#line 14269 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr910;
 	goto tr899;
 tr910:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14279,7 +14279,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14283 "inc/vcf/validator_detail_v42.hpp"
+#line 14283 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14288,7 +14288,7 @@ case 652:
 	}
 	goto tr899;
 tr903:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14297,12 +14297,12 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14301 "inc/vcf/validator_detail_v42.hpp"
+#line 14301 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr911;
 	goto tr899;
 tr911:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14311,12 +14311,12 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14315 "inc/vcf/validator_detail_v42.hpp"
+#line 14315 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr910;
 	goto tr899;
 tr897:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14325,7 +14325,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14329 "inc/vcf/validator_detail_v42.hpp"
+#line 14329 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14338,7 +14338,7 @@ case 655:
 		goto tr762;
 	goto tr746;
 tr912:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14347,7 +14347,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14351 "inc/vcf/validator_detail_v42.hpp"
+#line 14351 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14360,7 +14360,7 @@ case 656:
 		goto tr762;
 	goto tr746;
 tr913:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14369,7 +14369,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14373 "inc/vcf/validator_detail_v42.hpp"
+#line 14373 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14382,7 +14382,7 @@ case 657:
 		goto tr762;
 	goto tr746;
 tr914:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14391,7 +14391,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14395 "inc/vcf/validator_detail_v42.hpp"
+#line 14395 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14404,7 +14404,7 @@ case 658:
 		goto tr762;
 	goto tr746;
 tr915:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14413,7 +14413,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14417 "inc/vcf/validator_detail_v42.hpp"
+#line 14417 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14426,7 +14426,7 @@ case 659:
 		goto tr762;
 	goto tr746;
 tr916:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14435,7 +14435,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14439 "inc/vcf/validator_detail_v42.hpp"
+#line 14439 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14447,7 +14447,7 @@ case 660:
 		goto tr762;
 	goto tr917;
 tr918:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14456,12 +14456,12 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14460 "inc/vcf/validator_detail_v42.hpp"
+#line 14460 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr920;
 	goto tr919;
 tr920:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14470,7 +14470,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14474 "inc/vcf/validator_detail_v42.hpp"
+#line 14474 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14479,11 +14479,11 @@ case 662:
 	}
 	goto tr919;
 tr760:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14492,7 +14492,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14496 "inc/vcf/validator_detail_v42.hpp"
+#line 14496 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14505,7 +14505,7 @@ case 663:
 		goto tr762;
 	goto tr746;
 tr921:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14514,7 +14514,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14518 "inc/vcf/validator_detail_v42.hpp"
+#line 14518 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14527,7 +14527,7 @@ case 664:
 		goto tr762;
 	goto tr746;
 tr922:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14536,7 +14536,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14540 "inc/vcf/validator_detail_v42.hpp"
+#line 14540 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14549,7 +14549,7 @@ case 665:
 		goto tr762;
 	goto tr746;
 tr923:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14558,7 +14558,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14562 "inc/vcf/validator_detail_v42.hpp"
+#line 14562 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14571,7 +14571,7 @@ case 666:
 		goto tr762;
 	goto tr746;
 tr924:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14580,7 +14580,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14584 "inc/vcf/validator_detail_v42.hpp"
+#line 14584 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14593,7 +14593,7 @@ case 667:
 		goto tr762;
 	goto tr746;
 tr925:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14602,7 +14602,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14606 "inc/vcf/validator_detail_v42.hpp"
+#line 14606 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14615,7 +14615,7 @@ case 668:
 		goto tr762;
 	goto tr746;
 tr926:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14624,7 +14624,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14628 "inc/vcf/validator_detail_v42.hpp"
+#line 14628 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14637,7 +14637,7 @@ case 669:
 		goto tr762;
 	goto tr746;
 tr927:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14646,7 +14646,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14650 "inc/vcf/validator_detail_v42.hpp"
+#line 14650 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14659,7 +14659,7 @@ case 670:
 		goto tr762;
 	goto tr746;
 tr928:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14668,7 +14668,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14672 "inc/vcf/validator_detail_v42.hpp"
+#line 14672 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14680,7 +14680,7 @@ case 671:
 		goto tr762;
 	goto tr929;
 tr930:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14689,12 +14689,12 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14693 "inc/vcf/validator_detail_v42.hpp"
+#line 14693 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr932;
 	goto tr931;
 tr932:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14703,7 +14703,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14707 "inc/vcf/validator_detail_v42.hpp"
+#line 14707 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14712,11 +14712,11 @@ case 673:
 	}
 	goto tr931;
 tr748:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14725,7 +14725,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14729 "inc/vcf/validator_detail_v42.hpp"
+#line 14729 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14755,7 +14755,7 @@ case 674:
 		goto tr762;
 	goto tr746;
 tr745:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -14764,7 +14764,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14768 "inc/vcf/validator_detail_v42.hpp"
+#line 14768 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr739;
 	if ( (*p) < 65 ) {
@@ -14789,11 +14789,11 @@ case 675:
 		goto tr741;
 	goto tr738;
 tr740:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14802,7 +14802,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14806 "inc/vcf/validator_detail_v42.hpp"
+#line 14806 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 58: goto st525;
@@ -14829,7 +14829,7 @@ case 676:
 		goto tr743;
 	goto tr738;
 tr736:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14838,12 +14838,12 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 14842 "inc/vcf/validator_detail_v42.hpp"
+#line 14842 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr727;
 tr933:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14852,7 +14852,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 14856 "inc/vcf/validator_detail_v42.hpp"
+#line 14856 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 69: goto tr737;
@@ -14862,7 +14862,7 @@ case 678:
 		goto tr933;
 	goto tr727;
 tr737:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14871,7 +14871,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 14875 "inc/vcf/validator_detail_v42.hpp"
+#line 14875 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr934;
 		case 45: goto tr934;
@@ -14880,7 +14880,7 @@ case 679:
 		goto tr935;
 	goto tr727;
 tr934:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14889,12 +14889,12 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 14893 "inc/vcf/validator_detail_v42.hpp"
+#line 14893 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr935;
 	goto tr727;
 tr935:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14903,24 +14903,24 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 14907 "inc/vcf/validator_detail_v42.hpp"
+#line 14907 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr935;
 	goto tr727;
 tr731:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st682;
 tr734:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14929,12 +14929,12 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 14933 "inc/vcf/validator_detail_v42.hpp"
+#line 14933 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr936;
 	goto tr727;
 tr936:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14943,22 +14943,22 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 14947 "inc/vcf/validator_detail_v42.hpp"
+#line 14947 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr937;
 	goto tr727;
 tr729:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st684;
 tr937:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14967,16 +14967,16 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 14971 "inc/vcf/validator_detail_v42.hpp"
+#line 14971 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	goto tr727;
 tr732:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14985,12 +14985,12 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 14989 "inc/vcf/validator_detail_v42.hpp"
+#line 14989 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr938;
 	goto tr727;
 tr938:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14999,12 +14999,12 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15003 "inc/vcf/validator_detail_v42.hpp"
+#line 15003 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr937;
 	goto tr727;
 tr726:
-#line 39 "src/vcf/vcf_v42.ragel"
+#line 39 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -15013,7 +15013,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15017 "inc/vcf/validator_detail_v42.hpp"
+#line 15017 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr939;
@@ -15033,17 +15033,17 @@ case 687:
 	}
 	goto tr718;
 tr939:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st688;
 tr963:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15052,7 +15052,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15056 "inc/vcf/validator_detail_v42.hpp"
+#line 15056 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr940;
 		case 67: goto tr940;
@@ -15067,7 +15067,7 @@ case 688:
 	}
 	goto tr718;
 tr940:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15076,7 +15076,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15080 "inc/vcf/validator_detail_v42.hpp"
+#line 15080 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15093,17 +15093,17 @@ case 689:
 	}
 	goto tr718;
 tr721:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st690;
 tr941:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15112,7 +15112,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15116 "inc/vcf/validator_detail_v42.hpp"
+#line 15116 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr941;
 	if ( (*p) < 63 ) {
@@ -15143,7 +15143,7 @@ case 690:
 		goto tr941;
 	goto tr718;
 tr942:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15152,7 +15152,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15156 "inc/vcf/validator_detail_v42.hpp"
+#line 15156 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto tr943;
 	if ( (*p) < 45 ) {
@@ -15165,17 +15165,17 @@ case 691:
 		goto tr942;
 	goto tr718;
 tr722:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st692;
 tr944:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15184,7 +15184,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15188 "inc/vcf/validator_detail_v42.hpp"
+#line 15188 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15204,7 +15204,7 @@ case 692:
 	}
 	goto tr718;
 tr945:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15213,7 +15213,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15217 "inc/vcf/validator_detail_v42.hpp"
+#line 15217 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr948;
 	if ( (*p) < 65 ) {
@@ -15226,7 +15226,7 @@ case 693:
 		goto tr947;
 	goto tr718;
 tr947:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15235,7 +15235,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15239 "inc/vcf/validator_detail_v42.hpp"
+#line 15239 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr949;
 		case 61: goto tr947;
@@ -15250,7 +15250,7 @@ case 694:
 		goto tr947;
 	goto tr718;
 tr949:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15259,12 +15259,12 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15263 "inc/vcf/validator_detail_v42.hpp"
+#line 15263 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr950;
 	goto tr718;
 tr950:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15273,14 +15273,14 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15277 "inc/vcf/validator_detail_v42.hpp"
+#line 15277 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr943;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr950;
 	goto tr718;
 tr948:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15289,7 +15289,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15293 "inc/vcf/validator_detail_v42.hpp"
+#line 15293 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr951;
@@ -15300,7 +15300,7 @@ case 697:
 		goto tr951;
 	goto tr718;
 tr951:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15309,7 +15309,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15313 "inc/vcf/validator_detail_v42.hpp"
+#line 15313 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr951;
 		case 62: goto tr952;
@@ -15324,7 +15324,7 @@ case 698:
 		goto tr951;
 	goto tr718;
 tr952:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15333,12 +15333,12 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15337 "inc/vcf/validator_detail_v42.hpp"
+#line 15337 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr949;
 	goto tr718;
 tr946:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15347,7 +15347,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15351 "inc/vcf/validator_detail_v42.hpp"
+#line 15351 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr954;
 	if ( (*p) < 65 ) {
@@ -15360,7 +15360,7 @@ case 700:
 		goto tr953;
 	goto tr718;
 tr953:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15369,7 +15369,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15373 "inc/vcf/validator_detail_v42.hpp"
+#line 15373 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr955;
 		case 61: goto tr953;
@@ -15384,7 +15384,7 @@ case 701:
 		goto tr953;
 	goto tr718;
 tr955:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15393,12 +15393,12 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15397 "inc/vcf/validator_detail_v42.hpp"
+#line 15397 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr718;
 tr956:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15407,14 +15407,14 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15411 "inc/vcf/validator_detail_v42.hpp"
+#line 15411 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr943;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr718;
 tr954:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15423,7 +15423,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15427 "inc/vcf/validator_detail_v42.hpp"
+#line 15427 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr957;
@@ -15434,7 +15434,7 @@ case 704:
 		goto tr957;
 	goto tr718;
 tr957:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15443,7 +15443,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15447 "inc/vcf/validator_detail_v42.hpp"
+#line 15447 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr957;
 		case 62: goto tr958;
@@ -15458,7 +15458,7 @@ case 705:
 		goto tr957;
 	goto tr718;
 tr958:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15467,16 +15467,16 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15471 "inc/vcf/validator_detail_v42.hpp"
+#line 15471 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr955;
 	goto tr718;
 tr723:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15485,7 +15485,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15489 "inc/vcf/validator_detail_v42.hpp"
+#line 15489 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr960;
 	if ( (*p) < 65 ) {
@@ -15498,7 +15498,7 @@ case 707:
 		goto tr959;
 	goto tr718;
 tr959:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15507,7 +15507,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15511 "inc/vcf/validator_detail_v42.hpp"
+#line 15511 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr961;
 		case 61: goto tr959;
@@ -15522,7 +15522,7 @@ case 708:
 		goto tr959;
 	goto tr718;
 tr961:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15531,12 +15531,12 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15535 "inc/vcf/validator_detail_v42.hpp"
+#line 15535 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr962;
 	goto tr718;
 tr962:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15545,14 +15545,14 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15549 "inc/vcf/validator_detail_v42.hpp"
+#line 15549 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr963;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr962;
 	goto tr718;
 tr960:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15561,7 +15561,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15565 "inc/vcf/validator_detail_v42.hpp"
+#line 15565 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr964;
@@ -15572,7 +15572,7 @@ case 711:
 		goto tr964;
 	goto tr718;
 tr964:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15581,7 +15581,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15585 "inc/vcf/validator_detail_v42.hpp"
+#line 15585 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr964;
 		case 62: goto tr965;
@@ -15596,7 +15596,7 @@ case 712:
 		goto tr964;
 	goto tr718;
 tr965:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15605,16 +15605,16 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15609 "inc/vcf/validator_detail_v42.hpp"
+#line 15609 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr961;
 	goto tr718;
 tr724:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15623,7 +15623,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15627 "inc/vcf/validator_detail_v42.hpp"
+#line 15627 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr967;
 	if ( (*p) < 65 ) {
@@ -15636,7 +15636,7 @@ case 714:
 		goto tr966;
 	goto tr718;
 tr966:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15645,7 +15645,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15649 "inc/vcf/validator_detail_v42.hpp"
+#line 15649 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr968;
 		case 61: goto tr966;
@@ -15660,7 +15660,7 @@ case 715:
 		goto tr966;
 	goto tr718;
 tr968:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15669,12 +15669,12 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15673 "inc/vcf/validator_detail_v42.hpp"
+#line 15673 "../inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr969;
 	goto tr718;
 tr969:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15683,14 +15683,14 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15687 "inc/vcf/validator_detail_v42.hpp"
+#line 15687 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr963;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr969;
 	goto tr718;
 tr967:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15699,7 +15699,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15703 "inc/vcf/validator_detail_v42.hpp"
+#line 15703 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr970;
@@ -15710,7 +15710,7 @@ case 718:
 		goto tr970;
 	goto tr718;
 tr970:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15719,7 +15719,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15723 "inc/vcf/validator_detail_v42.hpp"
+#line 15723 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr970;
 		case 62: goto tr971;
@@ -15734,7 +15734,7 @@ case 719:
 		goto tr970;
 	goto tr718;
 tr971:
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15743,16 +15743,16 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15747 "inc/vcf/validator_detail_v42.hpp"
+#line 15747 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr968;
 	goto tr718;
 tr720:
-#line 31 "src/vcf/vcf_v42.ragel"
+#line 31 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v42.ragel"
+#line 35 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15761,7 +15761,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15765 "inc/vcf/validator_detail_v42.hpp"
+#line 15765 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 65: goto tr940;
@@ -15777,11 +15777,11 @@ case 721:
 	}
 	goto tr718;
 tr686:
-#line 188 "src/vcf/vcf_v42.ragel"
+#line 188 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -15793,15 +15793,15 @@ tr686:
     }
 	goto st722;
 tr698:
-#line 184 "src/vcf/vcf_v42.ragel"
+#line 184 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 188 "src/vcf/vcf_v42.ragel"
+#line 188 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -15816,12 +15816,12 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15820 "inc/vcf/validator_detail_v42.hpp"
+#line 15820 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st726;
 	goto tr687;
 tr23:
-#line 99 "src/vcf/vcf_v42.ragel"
+#line 99 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
@@ -15830,7 +15830,7 @@ tr23:
           p--; {goto st724;}
         }
     }
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -15845,12 +15845,12 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15849 "inc/vcf/validator_detail_v42.hpp"
+#line 15849 "../inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
 tr976:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -15865,14 +15865,14 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15869 "inc/vcf/validator_detail_v42.hpp"
+#line 15869 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr975;
 		case 13: goto tr976;
 	}
 	goto st724;
 tr975:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -15882,17 +15882,17 @@ tr975:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 821 "src/vcf/vcf_v42.ragel"
+#line 821 "../src/vcf/vcf_v42.ragel"
 	{ {goto st28;} }
 	goto st729;
 st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 15893 "inc/vcf/validator_detail_v42.hpp"
+#line 15893 "../inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 tr979:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -15907,14 +15907,14 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 15911 "inc/vcf/validator_detail_v42.hpp"
+#line 15911 "../inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr978;
 		case 13: goto tr979;
 	}
 	goto st725;
 tr978:
-#line 43 "src/vcf/vcf_v42.ragel"
+#line 43 "../src/vcf/vcf_v42.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -15924,14 +15924,14 @@ tr978:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 822 "src/vcf/vcf_v42.ragel"
+#line 822 "../src/vcf/vcf_v42.ragel"
 	{ {goto st728;} }
 	goto st730;
 st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 15935 "inc/vcf/validator_detail_v42.hpp"
+#line 15935 "../inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -16682,7 +16682,7 @@ case 730:
 	case 12: 
 	case 13: 
 	case 723: 
-#line 60 "src/vcf/vcf_v42.ragel"
+#line 60 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st724;}
@@ -16736,14 +16736,14 @@ case 730:
 	case 71: 
 	case 72: 
 	case 73: 
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	break;
 	case 726: 
-#line 70 "src/vcf/vcf_v42.ragel"
+#line 70 "../src/vcf/vcf_v42.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -16762,7 +16762,7 @@ case 730:
 	case 509: 
 	case 510: 
 	case 722: 
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -16777,7 +16777,7 @@ case 730:
     }
 	break;
 	case 537: 
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -16791,13 +16791,13 @@ case 730:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 225 "src/vcf/vcf_v42.ragel"
+#line 225 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         p--; {goto st724;}
     }
-#line 60 "src/vcf/vcf_v42.ragel"
+#line 60 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st724;}
@@ -16825,12 +16825,12 @@ case 730:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -16844,12 +16844,12 @@ case 730:
 	case 380: 
 	case 381: 
 	case 382: 
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 244 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -16884,12 +16884,12 @@ case 730:
 	case 430: 
 	case 431: 
 	case 432: 
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 250 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -16919,12 +16919,12 @@ case 730:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -16966,12 +16966,12 @@ case 730:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17012,12 +17012,12 @@ case 730:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17033,12 +17033,12 @@ case 730:
 	case 313: 
 	case 314: 
 	case 321: 
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 294 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17055,12 +17055,12 @@ case 730:
 	case 441: 
 	case 442: 
 	case 443: 
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 300 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17077,12 +17077,12 @@ case 730:
 	case 330: 
 	case 331: 
 	case 371: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17125,7 +17125,7 @@ case 730:
 	case 499: 
 	case 500: 
 	case 501: 
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 338 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17139,7 +17139,7 @@ case 730:
         
         p--; {goto st725;}
     }
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -17157,12 +17157,12 @@ case 730:
 	case 534: 
 	case 535: 
 	case 536: 
-#line 355 "src/vcf/vcf_v42.ragel"
+#line 355 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17170,12 +17170,12 @@ case 730:
 	break;
 	case 513: 
 	case 514: 
-#line 361 "src/vcf/vcf_v42.ragel"
+#line 361 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17183,12 +17183,12 @@ case 730:
 	break;
 	case 515: 
 	case 516: 
-#line 367 "src/vcf/vcf_v42.ragel"
+#line 367 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17196,12 +17196,12 @@ case 730:
 	break;
 	case 517: 
 	case 518: 
-#line 373 "src/vcf/vcf_v42.ragel"
+#line 373 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17244,12 +17244,12 @@ case 730:
 	case 719: 
 	case 720: 
 	case 721: 
-#line 379 "src/vcf/vcf_v42.ragel"
+#line 379 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17268,12 +17268,12 @@ case 730:
 	case 684: 
 	case 685: 
 	case 686: 
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 385 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17284,12 +17284,12 @@ case 730:
 	case 526: 
 	case 675: 
 	case 676: 
-#line 391 "src/vcf/vcf_v42.ragel"
+#line 391 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17297,12 +17297,12 @@ case 730:
 	break;
 	case 530: 
 	case 531: 
-#line 557 "src/vcf/vcf_v42.ragel"
+#line 557 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17310,14 +17310,14 @@ case 730:
 	break;
 	case 533: 
 	case 538: 
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 563 "../src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17325,12 +17325,12 @@ case 730:
 	break;
 	case 23: 
 	case 28: 
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 338 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17344,7 +17344,7 @@ case 730:
         
         p--; {goto st725;}
     }
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -17361,35 +17361,35 @@ case 730:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 237 "src/vcf/vcf_v42.ragel"
+#line 237 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	break;
 	case 122: 
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17398,17 +17398,17 @@ case 730:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 267 "src/vcf/vcf_v42.ragel"
+#line 267 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17417,17 +17417,17 @@ case 730:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 283 "src/vcf/vcf_v42.ragel"
+#line 283 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17435,17 +17435,17 @@ case 730:
 	break;
 	case 199: 
 	case 200: 
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 288 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17453,17 +17453,17 @@ case 730:
 	break;
 	case 265: 
 	case 266: 
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 288 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17478,17 +17478,17 @@ case 730:
 	case 341: 
 	case 342: 
 	case 343: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 311 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17503,17 +17503,17 @@ case 730:
 	case 351: 
 	case 352: 
 	case 353: 
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 316 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17522,17 +17522,17 @@ case 730:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17540,17 +17540,17 @@ case 730:
 	break;
 	case 412: 
 	case 413: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 250 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17562,17 +17562,17 @@ case 730:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17584,17 +17584,17 @@ case 730:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17606,17 +17606,17 @@ case 730:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17628,17 +17628,17 @@ case 730:
 	case 318: 
 	case 319: 
 	case 320: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 294 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17646,17 +17646,17 @@ case 730:
 	break;
 	case 332: 
 	case 333: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17676,17 +17676,17 @@ case 730:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17706,17 +17706,17 @@ case 730:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17736,17 +17736,17 @@ case 730:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17766,17 +17766,17 @@ case 730:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17801,17 +17801,17 @@ case 730:
 	case 372: 
 	case 373: 
 	case 374: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17836,17 +17836,17 @@ case 730:
 	case 399: 
 	case 400: 
 	case 401: 
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 332 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 244 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17873,17 +17873,17 @@ case 730:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 332 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 300 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -17936,17 +17936,17 @@ case 730:
 	case 669: 
 	case 670: 
 	case 674: 
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17954,17 +17954,17 @@ case 730:
 	break;
 	case 547: 
 	case 548: 
-#line 407 "src/vcf/vcf_v42.ragel"
+#line 407 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17972,7 +17972,7 @@ case 730:
 	break;
 	case 554: 
 	case 555: 
-#line 412 "src/vcf/vcf_v42.ragel"
+#line 412 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -17980,12 +17980,12 @@ case 730:
                 "AA"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -17993,7 +17993,7 @@ case 730:
 	break;
 	case 557: 
 	case 558: 
-#line 420 "src/vcf/vcf_v42.ragel"
+#line 420 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18001,12 +18001,12 @@ case 730:
                 "AC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18025,7 +18025,7 @@ case 730:
 	case 570: 
 	case 571: 
 	case 572: 
-#line 428 "src/vcf/vcf_v42.ragel"
+#line 428 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18033,12 +18033,12 @@ case 730:
                 "AF"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18046,7 +18046,7 @@ case 730:
 	break;
 	case 574: 
 	case 575: 
-#line 436 "src/vcf/vcf_v42.ragel"
+#line 436 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18054,12 +18054,12 @@ case 730:
                 "AN"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18078,7 +18078,7 @@ case 730:
 	case 588: 
 	case 589: 
 	case 590: 
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 444 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18086,12 +18086,12 @@ case 730:
                 "BQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18100,7 +18100,7 @@ case 730:
 	case 596: 
 	case 597: 
 	case 598: 
-#line 452 "src/vcf/vcf_v42.ragel"
+#line 452 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18108,12 +18108,12 @@ case 730:
                 "CIGAR"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18121,7 +18121,7 @@ case 730:
 	break;
 	case 601: 
 	case 602: 
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 460 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18129,12 +18129,12 @@ case 730:
                 "DB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18142,7 +18142,7 @@ case 730:
 	break;
 	case 604: 
 	case 605: 
-#line 468 "src/vcf/vcf_v42.ragel"
+#line 468 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18150,12 +18150,12 @@ case 730:
                 "DP"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18163,7 +18163,7 @@ case 730:
 	break;
 	case 609: 
 	case 610: 
-#line 476 "src/vcf/vcf_v42.ragel"
+#line 476 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18171,12 +18171,12 @@ case 730:
                 "END"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18184,7 +18184,7 @@ case 730:
 	break;
 	case 613: 
 	case 614: 
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 484 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18192,12 +18192,12 @@ case 730:
                 "H2"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18205,7 +18205,7 @@ case 730:
 	break;
 	case 616: 
 	case 617: 
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 492 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18213,12 +18213,12 @@ case 730:
                 "H3"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18237,7 +18237,7 @@ case 730:
 	case 633: 
 	case 634: 
 	case 635: 
-#line 500 "src/vcf/vcf_v42.ragel"
+#line 500 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18245,12 +18245,12 @@ case 730:
                 "MQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18258,7 +18258,7 @@ case 730:
 	break;
 	case 621: 
 	case 622: 
-#line 508 "src/vcf/vcf_v42.ragel"
+#line 508 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18266,12 +18266,12 @@ case 730:
                 "MQ0"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18279,7 +18279,7 @@ case 730:
 	break;
 	case 638: 
 	case 639: 
-#line 516 "src/vcf/vcf_v42.ragel"
+#line 516 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18287,12 +18287,12 @@ case 730:
                 "NS"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18311,7 +18311,7 @@ case 730:
 	case 652: 
 	case 653: 
 	case 654: 
-#line 524 "src/vcf/vcf_v42.ragel"
+#line 524 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18319,12 +18319,12 @@ case 730:
                 "SB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18332,7 +18332,7 @@ case 730:
 	break;
 	case 661: 
 	case 662: 
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 532 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18340,12 +18340,12 @@ case 730:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18353,7 +18353,7 @@ case 730:
 	break;
 	case 672: 
 	case 673: 
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 540 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18361,12 +18361,12 @@ case 730:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18374,7 +18374,7 @@ case 730:
 	break;
 	case 550: 
 	case 551: 
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 548 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18382,12 +18382,12 @@ case 730:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
@@ -18397,38 +18397,38 @@ case 730:
 	case 539: 
 	case 540: 
 	case 541: 
-#line 570 "src/vcf/vcf_v42.ragel"
+#line 570 "../src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 563 "../src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	break;
 	case 22: 
-#line 60 "src/vcf/vcf_v42.ragel"
+#line 60 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 338 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -18442,7 +18442,7 @@ case 730:
         
         p--; {goto st725;}
     }
-#line 78 "src/vcf/vcf_v42.ragel"
+#line 78 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -18457,66 +18457,66 @@ case 730:
     }
 	break;
 	case 344: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 311 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 316 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	break;
 	case 354: 
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 316 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	break;
 	case 334: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 311 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18525,22 +18525,22 @@ case 730:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18549,22 +18549,22 @@ case 730:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18573,22 +18573,22 @@ case 730:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18597,22 +18597,22 @@ case 730:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18621,22 +18621,22 @@ case 730:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18645,22 +18645,22 @@ case 730:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18669,22 +18669,22 @@ case 730:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
@@ -18693,29 +18693,29 @@ case 730:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 327 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 322 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	break;
 	case 600: 
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 460 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18723,24 +18723,24 @@ case 730:
                 "DB"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	break;
 	case 612: 
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 484 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18748,24 +18748,24 @@ case 730:
                 "H2"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	break;
 	case 615: 
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 492 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18773,24 +18773,24 @@ case 730:
                 "H3"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	break;
 	case 660: 
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 532 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18798,24 +18798,24 @@ case 730:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	break;
 	case 671: 
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 540 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18823,24 +18823,24 @@ case 730:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	break;
 	case 549: 
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 548 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18848,82 +18848,82 @@ case 730:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 402 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 397 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
     }
-#line 91 "src/vcf/vcf_v42.ragel"
+#line 91 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st725;}
     }
 	break;
 	case 24: 
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 232 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 256 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 262 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 278 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 244 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 250 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 306 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 294 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 300 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
     }
-#line 65 "src/vcf/vcf_v42.ragel"
+#line 65 "../src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
 	break;
-#line 18920 "inc/vcf/validator_detail_v42.hpp"
+#line 18920 "../inc/vcf/validator_detail_v42.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 851 "src/vcf/vcf_v42.ragel"
+#line 851 "../src/vcf/vcf_v42.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -1,5 +1,5 @@
 
-#line 1 "src/vcf/vcf_v43.ragel"
+#line 1 "../src/vcf/vcf_v43.ragel"
 /**
  * Copyright 2014-2016 EMBL - European Bioinformatics Institute
  *
@@ -21,13 +21,13 @@
 #include "vcf/validator.hpp"
 
 
-#line 909 "src/vcf/vcf_v43.ragel"
+#line 909 "../src/vcf/vcf_v43.ragel"
 
 
 namespace
 {
   
-#line 31 "inc/vcf/validator_detail_v43.hpp"
+#line 31 "../inc/vcf/validator_detail_v43.hpp"
 static const int vcf_v43_start = 1;
 static const int vcf_v43_first_final = 800;
 static const int vcf_v43_error = 0;
@@ -39,7 +39,7 @@ static const int vcf_v43_en_meta_section_skip = 798;
 static const int vcf_v43_en_body_section_skip = 799;
 
 
-#line 915 "src/vcf/vcf_v43.ragel"
+#line 915 "../src/vcf/vcf_v43.ragel"
 
 }
 
@@ -53,12 +53,12 @@ namespace ebi
     : ParserImpl{source}
     {
       
-#line 57 "inc/vcf/validator_detail_v43.hpp"
+#line 57 "../inc/vcf/validator_detail_v43.hpp"
 	{
 	cs = vcf_v43_start;
 	}
 
-#line 929 "src/vcf/vcf_v43.ragel"
+#line 929 "../src/vcf/vcf_v43.ragel"
 
     }
 
@@ -66,7 +66,7 @@ namespace ebi
     void ParserImpl_v43<Configuration>::parse_buffer(char const * p, char const * pe, char const * eof)
     {
       
-#line 70 "inc/vcf/validator_detail_v43.hpp"
+#line 70 "../inc/vcf/validator_detail_v43.hpp"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -77,37 +77,37 @@ case 1:
 		goto st2;
 	goto tr0;
 tr0:
-#line 60 "src/vcf/vcf_v43.ragel"
+#line 60 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr14:
-#line 237 "src/vcf/vcf_v43.ragel"
+#line 237 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         p--; {goto st798;}
     }
-#line 60 "src/vcf/vcf_v43.ragel"
+#line 60 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr24:
-#line 60 "src/vcf/vcf_v43.ragel"
+#line 60 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 376 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -121,7 +121,7 @@ tr24:
         
         p--; {goto st799;}
     }
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -136,12 +136,12 @@ tr24:
     }
 	goto st0;
 tr26:
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 376 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -155,7 +155,7 @@ tr26:
         
         p--; {goto st799;}
     }
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -170,810 +170,810 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 256 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 262 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 354 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 327 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr40:
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr126:
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr134:
-#line 249 "src/vcf/vcf_v43.ragel"
+#line 249 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr153:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr162:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr176:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr188:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr194:
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr197:
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr207:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr226:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr248:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr260:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr266:
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr276:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr289:
-#line 279 "src/vcf/vcf_v43.ragel"
+#line 279 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr298:
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 300 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr315:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr337:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr349:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr356:
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr365:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr378:
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 295 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr387:
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 300 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr404:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr426:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr438:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr445:
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr454:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr467:
-#line 338 "src/vcf/vcf_v43.ragel"
+#line 338 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr475:
-#line 343 "src/vcf/vcf_v43.ragel"
+#line 343 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr492:
-#line 348 "src/vcf/vcf_v43.ragel"
+#line 348 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr498:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr511:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr517:
-#line 321 "src/vcf/vcf_v43.ragel"
+#line 321 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr527:
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 316 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr564:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 311 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr569:
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 354 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr580:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 354 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr620:
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 256 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr629:
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 370 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 256 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr650:
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 262 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr661:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 262 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr699:
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 327 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr711:
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 370 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 327 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	goto st0;
 tr734:
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 376 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -987,7 +987,7 @@ tr734:
         
         p--; {goto st799;}
     }
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -1002,7 +1002,7 @@ tr734:
     }
 	goto st0;
 tr774:
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -1017,191 +1017,191 @@ tr774:
     }
 	goto st0;
 tr789:
-#line 393 "src/vcf/vcf_v43.ragel"
+#line 393 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr792:
-#line 399 "src/vcf/vcf_v43.ragel"
+#line 399 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr796:
-#line 405 "src/vcf/vcf_v43.ragel"
+#line 405 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr801:
-#line 411 "src/vcf/vcf_v43.ragel"
+#line 411 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr805:
-#line 417 "src/vcf/vcf_v43.ragel"
+#line 417 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr814:
-#line 423 "src/vcf/vcf_v43.ragel"
+#line 423 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr825:
-#line 429 "src/vcf/vcf_v43.ragel"
+#line 429 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr833:
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr847:
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr851:
-#line 619 "src/vcf/vcf_v43.ragel"
+#line 619 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr856:
-#line 632 "src/vcf/vcf_v43.ragel"
+#line 632 "../src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 625 "../src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr860:
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 625 "../src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr867:
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr879:
-#line 445 "src/vcf/vcf_v43.ragel"
+#line 445 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr881:
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 610 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1209,24 +1209,24 @@ tr881:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr883:
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 610 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1234,19 +1234,19 @@ tr883:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr891:
-#line 450 "src/vcf/vcf_v43.ragel"
+#line 450 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1254,19 +1254,19 @@ tr891:
                 "AA"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr894:
-#line 458 "src/vcf/vcf_v43.ragel"
+#line 458 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1274,19 +1274,19 @@ tr894:
                 "AC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr899:
-#line 466 "src/vcf/vcf_v43.ragel"
+#line 466 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1294,19 +1294,19 @@ tr899:
                 "AD"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr902:
-#line 474 "src/vcf/vcf_v43.ragel"
+#line 474 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1314,19 +1314,19 @@ tr902:
                 "ADF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr905:
-#line 482 "src/vcf/vcf_v43.ragel"
+#line 482 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1334,19 +1334,19 @@ tr905:
                 "ADR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr908:
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 490 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1354,19 +1354,19 @@ tr908:
                 "AF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr922:
-#line 498 "src/vcf/vcf_v43.ragel"
+#line 498 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1374,19 +1374,19 @@ tr922:
                 "AN"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr926:
-#line 506 "src/vcf/vcf_v43.ragel"
+#line 506 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1394,19 +1394,19 @@ tr926:
                 "BQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr944:
-#line 514 "src/vcf/vcf_v43.ragel"
+#line 514 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1414,19 +1414,19 @@ tr944:
                 "CIGAR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr949:
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 522 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1434,24 +1434,24 @@ tr949:
                 "DB"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr951:
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 522 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1459,19 +1459,19 @@ tr951:
                 "DB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr954:
-#line 530 "src/vcf/vcf_v43.ragel"
+#line 530 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1479,19 +1479,19 @@ tr954:
                 "DP"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr959:
-#line 538 "src/vcf/vcf_v43.ragel"
+#line 538 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1499,19 +1499,19 @@ tr959:
                 "END"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr963:
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 546 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1519,24 +1519,24 @@ tr963:
                 "H2"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr965:
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 546 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1544,19 +1544,19 @@ tr965:
                 "H2"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr967:
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 554 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1564,24 +1564,24 @@ tr967:
                 "H3"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr969:
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 554 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1589,19 +1589,19 @@ tr969:
                 "H3"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr975:
-#line 570 "src/vcf/vcf_v43.ragel"
+#line 570 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1609,19 +1609,19 @@ tr975:
                 "MQ0"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr977:
-#line 562 "src/vcf/vcf_v43.ragel"
+#line 562 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1629,19 +1629,19 @@ tr977:
                 "MQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr992:
-#line 578 "src/vcf/vcf_v43.ragel"
+#line 578 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1649,19 +1649,19 @@ tr992:
                 "NS"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr997:
-#line 586 "src/vcf/vcf_v43.ragel"
+#line 586 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1669,19 +1669,19 @@ tr997:
                 "SB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr1015:
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 594 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1689,24 +1689,24 @@ tr1015:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr1017:
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 594 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1714,19 +1714,19 @@ tr1017:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr1027:
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 602 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1734,24 +1734,24 @@ tr1027:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr1029:
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 602 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1759,19 +1759,19 @@ tr1029:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
 tr1078:
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -1784,18 +1784,18 @@ tr1078:
         
         p--; {goto st799;}
     }
-#line 393 "src/vcf/vcf_v43.ragel"
+#line 393 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	goto st0;
-#line 1799 "inc/vcf/validator_detail_v43.hpp"
+#line 1799 "../inc/vcf/validator_detail_v43.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1891,11 +1891,11 @@ case 14:
 		goto tr15;
 	goto tr14;
 tr15:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1904,12 +1904,12 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1908 "inc/vcf/validator_detail_v43.hpp"
+#line 1908 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
 tr16:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1918,12 +1918,12 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1922 "inc/vcf/validator_detail_v43.hpp"
+#line 1922 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
 tr17:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1932,12 +1932,12 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1936 "inc/vcf/validator_detail_v43.hpp"
+#line 1936 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
 tr18:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1946,12 +1946,12 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1950 "inc/vcf/validator_detail_v43.hpp"
+#line 1950 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
 tr19:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1960,12 +1960,12 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1964 "inc/vcf/validator_detail_v43.hpp"
+#line 1964 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
 tr20:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1974,12 +1974,12 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1978 "inc/vcf/validator_detail_v43.hpp"
+#line 1978 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 51 )
 		goto tr21;
 	goto tr14;
 tr21:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -1988,14 +1988,14 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1992 "inc/vcf/validator_detail_v43.hpp"
+#line 1992 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
 	}
 	goto tr14;
 tr22:
-#line 99 "src/vcf/vcf_v43.ragel"
+#line 99 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
@@ -2004,7 +2004,7 @@ tr22:
           p--; {goto st798;}
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2019,7 +2019,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 2023 "inc/vcf/validator_detail_v43.hpp"
+#line 2023 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -2054,17 +2054,17 @@ case 24:
 		goto tr30;
 	goto tr29;
 tr30:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st25;
 tr41:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2073,14 +2073,14 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 2077 "inc/vcf/validator_detail_v43.hpp"
+#line 2077 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr42;
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr41;
 	goto tr40;
 tr42:
-#line 180 "src/vcf/vcf_v43.ragel"
+#line 180 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this);
     }
@@ -2089,7 +2089,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2093 "inc/vcf/validator_detail_v43.hpp"
+#line 2093 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2098,17 +2098,17 @@ case 26:
 		goto tr43;
 	goto tr40;
 tr43:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st27;
 tr48:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2117,7 +2117,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2121 "inc/vcf/validator_detail_v43.hpp"
+#line 2121 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr47;
@@ -2126,11 +2126,11 @@ case 27:
 		goto tr48;
 	goto tr40;
 tr46:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 188 "src/vcf/vcf_v43.ragel"
+#line 188 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2138,7 +2138,7 @@ tr46:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2150,7 +2150,7 @@ tr46:
     }
 	goto st28;
 tr56:
-#line 188 "src/vcf/vcf_v43.ragel"
+#line 188 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2158,7 +2158,7 @@ tr56:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2173,16 +2173,16 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2177 "inc/vcf/validator_detail_v43.hpp"
+#line 2177 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
 tr47:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 188 "src/vcf/vcf_v43.ragel"
+#line 188 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2190,7 +2190,7 @@ tr47:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2202,7 +2202,7 @@ tr47:
     }
 	goto st29;
 tr57:
-#line 188 "src/vcf/vcf_v43.ragel"
+#line 188 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -2210,7 +2210,7 @@ tr57:
           ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -2225,7 +2225,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2229 "inc/vcf/validator_detail_v43.hpp"
+#line 2229 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr40;
@@ -2241,17 +2241,17 @@ case 30:
 		goto tr50;
 	goto tr40;
 tr50:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st31;
 tr53:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2260,7 +2260,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2264 "inc/vcf/validator_detail_v43.hpp"
+#line 2264 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr54;
 		case 92: goto tr55;
@@ -2269,17 +2269,17 @@ case 31:
 		goto tr53;
 	goto tr40;
 tr51:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st32;
 tr54:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2288,24 +2288,24 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2292 "inc/vcf/validator_detail_v43.hpp"
+#line 2292 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
 	}
 	goto tr40;
 tr52:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st33;
 tr55:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2314,7 +2314,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2318 "inc/vcf/validator_detail_v43.hpp"
+#line 2318 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr58;
 		case 92: goto tr55;
@@ -2323,11 +2323,11 @@ case 33:
 		goto tr53;
 	goto tr40;
 tr58:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2336,7 +2336,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2340 "inc/vcf/validator_detail_v43.hpp"
+#line 2340 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2378,17 +2378,17 @@ case 36:
 		goto tr62;
 	goto tr40;
 tr62:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st37;
 tr65:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2397,7 +2397,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2401 "inc/vcf/validator_detail_v43.hpp"
+#line 2401 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 92: goto tr67;
@@ -2406,17 +2406,17 @@ case 37:
 		goto tr65;
 	goto tr40;
 tr63:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st38;
 tr66:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2425,22 +2425,22 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2429 "inc/vcf/validator_detail_v43.hpp"
+#line 2429 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr40;
 tr64:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st39;
 tr67:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2449,7 +2449,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2453 "inc/vcf/validator_detail_v43.hpp"
+#line 2453 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr69;
 		case 92: goto tr67;
@@ -2458,11 +2458,11 @@ case 39:
 		goto tr65;
 	goto tr40;
 tr69:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2471,7 +2471,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2475 "inc/vcf/validator_detail_v43.hpp"
+#line 2475 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 62: goto tr70;
@@ -2481,7 +2481,7 @@ case 40:
 		goto tr65;
 	goto tr40;
 tr70:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2490,7 +2490,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2494 "inc/vcf/validator_detail_v43.hpp"
+#line 2494 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2501,7 +2501,7 @@ case 41:
 		goto tr65;
 	goto tr40;
 tr60:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2510,7 +2510,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2514 "inc/vcf/validator_detail_v43.hpp"
+#line 2514 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2526,17 +2526,17 @@ case 42:
 		goto tr72;
 	goto tr40;
 tr61:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st43;
 tr72:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2545,7 +2545,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2549 "inc/vcf/validator_detail_v43.hpp"
+#line 2549 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr73;
 		case 95: goto tr72;
@@ -2563,7 +2563,7 @@ case 43:
 		goto tr72;
 	goto tr40;
 tr73:
-#line 184 "src/vcf/vcf_v43.ragel"
+#line 184 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2572,7 +2572,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2576 "inc/vcf/validator_detail_v43.hpp"
+#line 2576 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2585,17 +2585,17 @@ case 44:
 		goto tr74;
 	goto tr40;
 tr74:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st45;
 tr76:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2604,7 +2604,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2608 "inc/vcf/validator_detail_v43.hpp"
+#line 2608 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr77;
 		case 62: goto tr54;
@@ -2616,7 +2616,7 @@ case 45:
 		goto tr76;
 	goto tr40;
 tr77:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2625,7 +2625,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2629 "inc/vcf/validator_detail_v43.hpp"
+#line 2629 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr78;
 	if ( (*p) < 48 ) {
@@ -2641,7 +2641,7 @@ case 46:
 		goto tr79;
 	goto tr40;
 tr78:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -2650,7 +2650,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2654 "inc/vcf/validator_detail_v43.hpp"
+#line 2654 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2666,17 +2666,17 @@ case 47:
 		goto tr81;
 	goto tr40;
 tr79:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st48;
 tr81:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2685,7 +2685,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2689 "inc/vcf/validator_detail_v43.hpp"
+#line 2689 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr82;
 		case 95: goto tr81;
@@ -2703,7 +2703,7 @@ case 48:
 		goto tr81;
 	goto tr40;
 tr82:
-#line 184 "src/vcf/vcf_v43.ragel"
+#line 184 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2712,7 +2712,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2716 "inc/vcf/validator_detail_v43.hpp"
+#line 2716 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2736,17 +2736,17 @@ case 50:
 		goto tr84;
 	goto tr40;
 tr84:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st51;
 tr87:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2755,7 +2755,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2759 "inc/vcf/validator_detail_v43.hpp"
+#line 2759 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr89;
@@ -2764,17 +2764,17 @@ case 51:
 		goto tr87;
 	goto tr40;
 tr85:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st52;
 tr88:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2783,24 +2783,24 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2787 "inc/vcf/validator_detail_v43.hpp"
+#line 2787 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
 	}
 	goto tr40;
 tr86:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st53;
 tr89:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2809,7 +2809,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2813 "inc/vcf/validator_detail_v43.hpp"
+#line 2813 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 92: goto tr89;
@@ -2818,11 +2818,11 @@ case 53:
 		goto tr87;
 	goto tr40;
 tr91:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2831,7 +2831,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2835 "inc/vcf/validator_detail_v43.hpp"
+#line 2835 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr92;
@@ -2842,27 +2842,27 @@ case 54:
 		goto tr87;
 	goto tr40;
 tr106:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st55;
 tr92:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st55;
 tr103:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -2871,7 +2871,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2875 "inc/vcf/validator_detail_v43.hpp"
+#line 2875 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2903,17 +2903,17 @@ case 55:
 		goto tr87;
 	goto tr40;
 tr94:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st56;
 tr96:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2922,7 +2922,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2926 "inc/vcf/validator_detail_v43.hpp"
+#line 2926 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2954,17 +2954,17 @@ case 56:
 		goto tr87;
 	goto tr40;
 tr95:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st57;
 tr97:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -2973,7 +2973,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2977 "inc/vcf/validator_detail_v43.hpp"
+#line 2977 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -3003,11 +3003,11 @@ case 57:
 		goto tr97;
 	goto tr40;
 tr98:
-#line 184 "src/vcf/vcf_v43.ragel"
+#line 184 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3016,7 +3016,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 3020 "inc/vcf/validator_detail_v43.hpp"
+#line 3020 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr87;
@@ -3027,17 +3027,17 @@ case 58:
 		goto tr99;
 	goto tr40;
 tr102:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st59;
 tr99:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3046,7 +3046,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 3050 "inc/vcf/validator_detail_v43.hpp"
+#line 3050 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr103;
@@ -3057,27 +3057,27 @@ case 59:
 		goto tr102;
 	goto tr40;
 tr107:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st60;
 tr93:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st60;
 tr104:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3086,7 +3086,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 3090 "inc/vcf/validator_detail_v43.hpp"
+#line 3090 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3097,17 +3097,17 @@ case 60:
 		goto tr87;
 	goto tr40;
 tr105:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st61;
 tr101:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3116,7 +3116,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3120 "inc/vcf/validator_detail_v43.hpp"
+#line 3120 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 44: goto tr103;
@@ -3127,7 +3127,7 @@ case 61:
 		goto tr102;
 	goto tr40;
 tr100:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3136,7 +3136,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3140 "inc/vcf/validator_detail_v43.hpp"
+#line 3140 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr85;
 		case 44: goto tr106;
@@ -3158,17 +3158,17 @@ case 63:
 		goto tr108;
 	goto tr40;
 tr108:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st64;
 tr110:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3177,7 +3177,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3181 "inc/vcf/validator_detail_v43.hpp"
+#line 3181 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr111;
@@ -3186,17 +3186,17 @@ case 64:
 		goto tr110;
 	goto tr40;
 tr109:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st65;
 tr111:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3205,7 +3205,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3209 "inc/vcf/validator_detail_v43.hpp"
+#line 3209 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 92: goto tr111;
@@ -3214,11 +3214,11 @@ case 65:
 		goto tr110;
 	goto tr40;
 tr112:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3227,7 +3227,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3231 "inc/vcf/validator_detail_v43.hpp"
+#line 3231 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr113;
@@ -3238,17 +3238,17 @@ case 66:
 		goto tr110;
 	goto tr40;
 tr113:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st67;
 tr123:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3257,7 +3257,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3261 "inc/vcf/validator_detail_v43.hpp"
+#line 3261 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3289,17 +3289,17 @@ case 67:
 		goto tr110;
 	goto tr40;
 tr117:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st68;
 tr115:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3308,7 +3308,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3312 "inc/vcf/validator_detail_v43.hpp"
+#line 3312 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3340,17 +3340,17 @@ case 68:
 		goto tr110;
 	goto tr40;
 tr118:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st69;
 tr116:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3359,7 +3359,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3363 "inc/vcf/validator_detail_v43.hpp"
+#line 3363 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3389,11 +3389,11 @@ case 69:
 		goto tr118;
 	goto tr40;
 tr119:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 184 "src/vcf/vcf_v43.ragel"
+#line 184 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3402,7 +3402,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3406 "inc/vcf/validator_detail_v43.hpp"
+#line 3406 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr110;
@@ -3413,17 +3413,17 @@ case 70:
 		goto tr120;
 	goto tr40;
 tr122:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st71;
 tr120:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3432,7 +3432,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3436 "inc/vcf/validator_detail_v43.hpp"
+#line 3436 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr123;
@@ -3443,17 +3443,17 @@ case 71:
 		goto tr122;
 	goto tr40;
 tr114:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st72;
 tr124:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3462,7 +3462,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3466 "inc/vcf/validator_detail_v43.hpp"
+#line 3466 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3473,17 +3473,17 @@ case 72:
 		goto tr110;
 	goto tr40;
 tr125:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st73;
 tr121:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3492,7 +3492,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3496 "inc/vcf/validator_detail_v43.hpp"
+#line 3496 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 44: goto tr123;
@@ -3503,11 +3503,11 @@ case 73:
 		goto tr122;
 	goto tr40;
 tr31:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3516,7 +3516,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3520 "inc/vcf/validator_detail_v43.hpp"
+#line 3520 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr127;
@@ -3525,7 +3525,7 @@ case 74:
 		goto tr41;
 	goto tr126;
 tr127:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3534,7 +3534,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3538 "inc/vcf/validator_detail_v43.hpp"
+#line 3538 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st76;
@@ -3552,7 +3552,7 @@ case 76:
 		goto tr41;
 	goto tr126;
 tr129:
-#line 108 "src/vcf/vcf_v43.ragel"
+#line 108 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "ALT");
     }
@@ -3561,7 +3561,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3565 "inc/vcf/validator_detail_v43.hpp"
+#line 3565 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr126;
@@ -3620,11 +3620,11 @@ case 81:
 		goto tr135;
 	goto tr134;
 tr135:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3633,7 +3633,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3637 "inc/vcf/validator_detail_v43.hpp"
+#line 3637 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3664,21 +3664,21 @@ case 82:
 		goto st82;
 	goto tr134;
 tr138:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st83;
 tr136:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3687,7 +3687,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3691 "inc/vcf/validator_detail_v43.hpp"
+#line 3691 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr139;
 		case 61: goto tr138;
@@ -3699,7 +3699,7 @@ case 83:
 		goto tr138;
 	goto tr134;
 tr139:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3708,7 +3708,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3712 "inc/vcf/validator_detail_v43.hpp"
+#line 3712 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr126;
@@ -3797,7 +3797,7 @@ case 96:
 		goto tr152;
 	goto tr126;
 tr152:
-#line 160 "src/vcf/vcf_v43.ragel"
+#line 160 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -3806,7 +3806,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3810 "inc/vcf/validator_detail_v43.hpp"
+#line 3810 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 92: goto tr156;
@@ -3815,17 +3815,17 @@ case 97:
 		goto tr154;
 	goto tr153;
 tr154:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st98;
 tr157:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3834,7 +3834,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3838 "inc/vcf/validator_detail_v43.hpp"
+#line 3838 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr159;
@@ -3843,17 +3843,17 @@ case 98:
 		goto tr157;
 	goto tr153;
 tr155:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st99;
 tr158:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3862,7 +3862,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3866 "inc/vcf/validator_detail_v43.hpp"
+#line 3866 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3887,7 +3887,7 @@ case 100:
 		goto tr164;
 	goto tr162;
 tr163:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -3896,7 +3896,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3900 "inc/vcf/validator_detail_v43.hpp"
+#line 3900 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3912,17 +3912,17 @@ case 101:
 		goto tr166;
 	goto tr162;
 tr164:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st102;
 tr166:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3931,7 +3931,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3935 "inc/vcf/validator_detail_v43.hpp"
+#line 3935 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr167;
 		case 95: goto tr166;
@@ -3949,7 +3949,7 @@ case 102:
 		goto tr166;
 	goto tr162;
 tr167:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -3958,7 +3958,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3962 "inc/vcf/validator_detail_v43.hpp"
+#line 3962 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr126;
@@ -3974,17 +3974,17 @@ case 104:
 		goto tr169;
 	goto tr153;
 tr169:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st105;
 tr171:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -3993,7 +3993,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3997 "inc/vcf/validator_detail_v43.hpp"
+#line 3997 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr172;
@@ -4002,17 +4002,17 @@ case 105:
 		goto tr171;
 	goto tr153;
 tr170:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st106;
 tr172:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4021,7 +4021,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 4025 "inc/vcf/validator_detail_v43.hpp"
+#line 4025 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr173;
 		case 92: goto tr172;
@@ -4030,11 +4030,11 @@ case 106:
 		goto tr171;
 	goto tr153;
 tr173:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4043,7 +4043,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 4047 "inc/vcf/validator_detail_v43.hpp"
+#line 4047 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr174;
@@ -4054,17 +4054,17 @@ case 107:
 		goto tr171;
 	goto tr153;
 tr183:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st108;
 tr174:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4073,7 +4073,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 4077 "inc/vcf/validator_detail_v43.hpp"
+#line 4077 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4105,17 +4105,17 @@ case 108:
 		goto tr171;
 	goto tr176;
 tr177:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st109;
 tr179:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4124,7 +4124,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4128 "inc/vcf/validator_detail_v43.hpp"
+#line 4128 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4156,17 +4156,17 @@ case 109:
 		goto tr171;
 	goto tr176;
 tr178:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st110;
 tr180:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4175,7 +4175,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4179 "inc/vcf/validator_detail_v43.hpp"
+#line 4179 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4205,11 +4205,11 @@ case 110:
 		goto tr180;
 	goto tr176;
 tr181:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4218,7 +4218,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4222 "inc/vcf/validator_detail_v43.hpp"
+#line 4222 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr172;
@@ -4227,7 +4227,7 @@ case 111:
 		goto tr171;
 	goto tr153;
 tr182:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4236,7 +4236,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4240 "inc/vcf/validator_detail_v43.hpp"
+#line 4240 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 44: goto tr183;
@@ -4247,17 +4247,17 @@ case 112:
 		goto tr169;
 	goto tr153;
 tr184:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st113;
 tr175:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4266,7 +4266,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4270 "inc/vcf/validator_detail_v43.hpp"
+#line 4270 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4286,17 +4286,17 @@ case 114:
 	}
 	goto tr126;
 tr156:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st115;
 tr159:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4305,7 +4305,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4309 "inc/vcf/validator_detail_v43.hpp"
+#line 4309 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr185;
 		case 92: goto tr159;
@@ -4314,11 +4314,11 @@ case 115:
 		goto tr157;
 	goto tr153;
 tr185:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4327,7 +4327,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4331 "inc/vcf/validator_detail_v43.hpp"
+#line 4331 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr186;
@@ -4338,7 +4338,7 @@ case 116:
 		goto tr157;
 	goto tr153;
 tr186:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4347,7 +4347,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4351 "inc/vcf/validator_detail_v43.hpp"
+#line 4351 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4379,17 +4379,17 @@ case 117:
 		goto tr157;
 	goto tr188;
 tr191:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st118;
 tr189:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4398,7 +4398,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4402 "inc/vcf/validator_detail_v43.hpp"
+#line 4402 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4430,17 +4430,17 @@ case 118:
 		goto tr157;
 	goto tr188;
 tr192:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st119;
 tr190:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4449,7 +4449,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4453 "inc/vcf/validator_detail_v43.hpp"
+#line 4453 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4479,11 +4479,11 @@ case 119:
 		goto tr192;
 	goto tr188;
 tr193:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4492,7 +4492,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4496 "inc/vcf/validator_detail_v43.hpp"
+#line 4496 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr159;
@@ -4501,7 +4501,7 @@ case 120:
 		goto tr157;
 	goto tr153;
 tr187:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4510,7 +4510,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4514 "inc/vcf/validator_detail_v43.hpp"
+#line 4514 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4521,11 +4521,11 @@ case 121:
 		goto tr157;
 	goto tr153;
 tr32:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4534,7 +4534,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4538 "inc/vcf/validator_detail_v43.hpp"
+#line 4538 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr195;
@@ -4544,7 +4544,7 @@ case 122:
 		goto tr41;
 	goto tr194;
 tr195:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4553,7 +4553,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4557 "inc/vcf/validator_detail_v43.hpp"
+#line 4557 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr198;
@@ -4562,7 +4562,7 @@ case 123:
 		goto tr41;
 	goto tr197;
 tr198:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4571,7 +4571,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4575 "inc/vcf/validator_detail_v43.hpp"
+#line 4575 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr199;
@@ -4580,7 +4580,7 @@ case 124:
 		goto tr41;
 	goto tr197;
 tr199:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4589,7 +4589,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4593 "inc/vcf/validator_detail_v43.hpp"
+#line 4593 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr200;
@@ -4598,7 +4598,7 @@ case 125:
 		goto tr41;
 	goto tr197;
 tr200:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4607,7 +4607,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4611 "inc/vcf/validator_detail_v43.hpp"
+#line 4611 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto st127;
@@ -4625,7 +4625,7 @@ case 127:
 		goto tr41;
 	goto tr197;
 tr202:
-#line 120 "src/vcf/vcf_v43.ragel"
+#line 120 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "FILTER");
     }
@@ -4634,7 +4634,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4638 "inc/vcf/validator_detail_v43.hpp"
+#line 4638 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr197;
@@ -4678,11 +4678,11 @@ case 132:
 		goto tr209;
 	goto tr207;
 tr208:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4691,7 +4691,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4695 "inc/vcf/validator_detail_v43.hpp"
+#line 4695 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4707,21 +4707,21 @@ case 133:
 		goto tr211;
 	goto tr207;
 tr211:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st134;
 tr209:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4730,7 +4730,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4734 "inc/vcf/validator_detail_v43.hpp"
+#line 4734 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr212;
 		case 95: goto tr211;
@@ -4748,7 +4748,7 @@ case 134:
 		goto tr211;
 	goto tr207;
 tr212:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4757,7 +4757,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4761 "inc/vcf/validator_detail_v43.hpp"
+#line 4761 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr197;
@@ -4846,7 +4846,7 @@ case 147:
 		goto tr225;
 	goto tr197;
 tr225:
-#line 160 "src/vcf/vcf_v43.ragel"
+#line 160 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -4855,7 +4855,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4859 "inc/vcf/validator_detail_v43.hpp"
+#line 4859 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 92: goto tr229;
@@ -4864,17 +4864,17 @@ case 148:
 		goto tr227;
 	goto tr226;
 tr227:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st149;
 tr230:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4883,7 +4883,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4887 "inc/vcf/validator_detail_v43.hpp"
+#line 4887 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr232;
@@ -4892,17 +4892,17 @@ case 149:
 		goto tr230;
 	goto tr226;
 tr228:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st150;
 tr231:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -4911,7 +4911,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4915 "inc/vcf/validator_detail_v43.hpp"
+#line 4915 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4936,7 +4936,7 @@ case 151:
 		goto tr236;
 	goto tr207;
 tr235:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -4945,7 +4945,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4949 "inc/vcf/validator_detail_v43.hpp"
+#line 4949 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4961,17 +4961,17 @@ case 152:
 		goto tr238;
 	goto tr207;
 tr236:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st153;
 tr238:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -4980,7 +4980,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4984 "inc/vcf/validator_detail_v43.hpp"
+#line 4984 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr239;
 		case 95: goto tr238;
@@ -4998,7 +4998,7 @@ case 153:
 		goto tr238;
 	goto tr207;
 tr239:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5007,7 +5007,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 5011 "inc/vcf/validator_detail_v43.hpp"
+#line 5011 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr197;
@@ -5023,17 +5023,17 @@ case 155:
 		goto tr241;
 	goto tr226;
 tr241:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st156;
 tr243:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5042,7 +5042,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 5046 "inc/vcf/validator_detail_v43.hpp"
+#line 5046 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr244;
@@ -5051,17 +5051,17 @@ case 156:
 		goto tr243;
 	goto tr226;
 tr242:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st157;
 tr244:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5070,7 +5070,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 5074 "inc/vcf/validator_detail_v43.hpp"
+#line 5074 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr245;
 		case 92: goto tr244;
@@ -5079,11 +5079,11 @@ case 157:
 		goto tr243;
 	goto tr226;
 tr245:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5092,7 +5092,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5096 "inc/vcf/validator_detail_v43.hpp"
+#line 5096 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr246;
@@ -5103,17 +5103,17 @@ case 158:
 		goto tr243;
 	goto tr226;
 tr255:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st159;
 tr246:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5122,7 +5122,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5126 "inc/vcf/validator_detail_v43.hpp"
+#line 5126 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5154,17 +5154,17 @@ case 159:
 		goto tr243;
 	goto tr248;
 tr249:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st160;
 tr251:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5173,7 +5173,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5177 "inc/vcf/validator_detail_v43.hpp"
+#line 5177 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5205,17 +5205,17 @@ case 160:
 		goto tr243;
 	goto tr248;
 tr250:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st161;
 tr252:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5224,7 +5224,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5228 "inc/vcf/validator_detail_v43.hpp"
+#line 5228 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5254,11 +5254,11 @@ case 161:
 		goto tr252;
 	goto tr248;
 tr253:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5267,7 +5267,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5271 "inc/vcf/validator_detail_v43.hpp"
+#line 5271 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr244;
@@ -5276,7 +5276,7 @@ case 162:
 		goto tr243;
 	goto tr226;
 tr254:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5285,7 +5285,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5289 "inc/vcf/validator_detail_v43.hpp"
+#line 5289 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 44: goto tr255;
@@ -5296,17 +5296,17 @@ case 163:
 		goto tr241;
 	goto tr226;
 tr256:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st164;
 tr247:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5315,7 +5315,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5319 "inc/vcf/validator_detail_v43.hpp"
+#line 5319 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5335,17 +5335,17 @@ case 165:
 	}
 	goto tr197;
 tr229:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st166;
 tr232:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5354,7 +5354,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5358 "inc/vcf/validator_detail_v43.hpp"
+#line 5358 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr257;
 		case 92: goto tr232;
@@ -5363,11 +5363,11 @@ case 166:
 		goto tr230;
 	goto tr226;
 tr257:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5376,7 +5376,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5380 "inc/vcf/validator_detail_v43.hpp"
+#line 5380 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr258;
@@ -5387,7 +5387,7 @@ case 167:
 		goto tr230;
 	goto tr226;
 tr258:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5396,7 +5396,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5400 "inc/vcf/validator_detail_v43.hpp"
+#line 5400 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5428,17 +5428,17 @@ case 168:
 		goto tr230;
 	goto tr260;
 tr263:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st169;
 tr261:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5447,7 +5447,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5451 "inc/vcf/validator_detail_v43.hpp"
+#line 5451 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5479,17 +5479,17 @@ case 169:
 		goto tr230;
 	goto tr260;
 tr264:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st170;
 tr262:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5498,7 +5498,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5502 "inc/vcf/validator_detail_v43.hpp"
+#line 5502 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5528,11 +5528,11 @@ case 170:
 		goto tr264;
 	goto tr260;
 tr265:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5541,7 +5541,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5545 "inc/vcf/validator_detail_v43.hpp"
+#line 5545 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr232;
@@ -5550,7 +5550,7 @@ case 171:
 		goto tr230;
 	goto tr226;
 tr259:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5559,7 +5559,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5563 "inc/vcf/validator_detail_v43.hpp"
+#line 5563 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5570,7 +5570,7 @@ case 172:
 		goto tr230;
 	goto tr226;
 tr196:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5579,7 +5579,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5583 "inc/vcf/validator_detail_v43.hpp"
+#line 5583 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr267;
@@ -5588,7 +5588,7 @@ case 173:
 		goto tr41;
 	goto tr266;
 tr267:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5597,7 +5597,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5601 "inc/vcf/validator_detail_v43.hpp"
+#line 5601 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr268;
@@ -5606,7 +5606,7 @@ case 174:
 		goto tr41;
 	goto tr266;
 tr268:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5615,7 +5615,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5619 "inc/vcf/validator_detail_v43.hpp"
+#line 5619 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr269;
@@ -5624,7 +5624,7 @@ case 175:
 		goto tr41;
 	goto tr266;
 tr269:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5633,7 +5633,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5637 "inc/vcf/validator_detail_v43.hpp"
+#line 5637 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st177;
@@ -5651,7 +5651,7 @@ case 177:
 		goto tr41;
 	goto tr266;
 tr271:
-#line 124 "src/vcf/vcf_v43.ragel"
+#line 124 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "FORMAT");
     }
@@ -5660,7 +5660,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5664 "inc/vcf/validator_detail_v43.hpp"
+#line 5664 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr266;
@@ -5704,11 +5704,11 @@ case 182:
 		goto tr278;
 	goto tr276;
 tr277:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -5717,7 +5717,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5721 "inc/vcf/validator_detail_v43.hpp"
+#line 5721 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5733,21 +5733,21 @@ case 183:
 		goto tr280;
 	goto tr276;
 tr280:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st184;
 tr278:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5756,7 +5756,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5760 "inc/vcf/validator_detail_v43.hpp"
+#line 5760 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr281;
 		case 95: goto tr280;
@@ -5774,7 +5774,7 @@ case 184:
 		goto tr280;
 	goto tr276;
 tr281:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5783,7 +5783,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5787 "inc/vcf/validator_detail_v43.hpp"
+#line 5787 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr266;
@@ -5843,15 +5843,15 @@ case 192:
 		goto tr291;
 	goto tr289;
 tr290:
-#line 152 "src/vcf/vcf_v43.ragel"
+#line 152 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5860,12 +5860,12 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5864 "inc/vcf/validator_detail_v43.hpp"
+#line 5864 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	goto tr289;
 tr292:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5874,7 +5874,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5878 "inc/vcf/validator_detail_v43.hpp"
+#line 5878 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr266;
@@ -5917,21 +5917,21 @@ case 199:
 		goto tr299;
 	goto tr298;
 tr301:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st200;
 tr299:
-#line 156 "src/vcf/vcf_v43.ragel"
+#line 156 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Type");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -5940,7 +5940,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5944 "inc/vcf/validator_detail_v43.hpp"
+#line 5944 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr300;
 	if ( (*p) > 90 ) {
@@ -5950,7 +5950,7 @@ case 200:
 		goto tr301;
 	goto tr298;
 tr300:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -5959,7 +5959,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5963 "inc/vcf/validator_detail_v43.hpp"
+#line 5963 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr266;
@@ -6048,7 +6048,7 @@ case 213:
 		goto tr314;
 	goto tr266;
 tr314:
-#line 160 "src/vcf/vcf_v43.ragel"
+#line 160 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -6057,7 +6057,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 6061 "inc/vcf/validator_detail_v43.hpp"
+#line 6061 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -6066,17 +6066,17 @@ case 214:
 		goto tr316;
 	goto tr315;
 tr316:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st215;
 tr319:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6085,7 +6085,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 6089 "inc/vcf/validator_detail_v43.hpp"
+#line 6089 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr321;
@@ -6094,17 +6094,17 @@ case 215:
 		goto tr319;
 	goto tr315;
 tr317:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st216;
 tr320:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6113,7 +6113,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6117 "inc/vcf/validator_detail_v43.hpp"
+#line 6117 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6138,7 +6138,7 @@ case 217:
 		goto tr325;
 	goto tr276;
 tr324:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6147,7 +6147,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6151 "inc/vcf/validator_detail_v43.hpp"
+#line 6151 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6163,17 +6163,17 @@ case 218:
 		goto tr327;
 	goto tr276;
 tr325:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st219;
 tr327:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6182,7 +6182,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6186 "inc/vcf/validator_detail_v43.hpp"
+#line 6186 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr328;
 		case 95: goto tr327;
@@ -6200,7 +6200,7 @@ case 219:
 		goto tr327;
 	goto tr276;
 tr328:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6209,7 +6209,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6213 "inc/vcf/validator_detail_v43.hpp"
+#line 6213 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr266;
@@ -6225,17 +6225,17 @@ case 221:
 		goto tr330;
 	goto tr315;
 tr330:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st222;
 tr332:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6244,7 +6244,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6248 "inc/vcf/validator_detail_v43.hpp"
+#line 6248 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr333;
@@ -6253,17 +6253,17 @@ case 222:
 		goto tr332;
 	goto tr315;
 tr331:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st223;
 tr333:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6272,7 +6272,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6276 "inc/vcf/validator_detail_v43.hpp"
+#line 6276 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr334;
 		case 92: goto tr333;
@@ -6281,11 +6281,11 @@ case 223:
 		goto tr332;
 	goto tr315;
 tr334:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6294,7 +6294,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6298 "inc/vcf/validator_detail_v43.hpp"
+#line 6298 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr335;
@@ -6305,17 +6305,17 @@ case 224:
 		goto tr332;
 	goto tr315;
 tr344:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st225;
 tr335:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6324,7 +6324,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6328 "inc/vcf/validator_detail_v43.hpp"
+#line 6328 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6356,17 +6356,17 @@ case 225:
 		goto tr332;
 	goto tr337;
 tr338:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st226;
 tr340:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6375,7 +6375,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6379 "inc/vcf/validator_detail_v43.hpp"
+#line 6379 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6407,17 +6407,17 @@ case 226:
 		goto tr332;
 	goto tr337;
 tr339:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st227;
 tr341:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6426,7 +6426,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6430 "inc/vcf/validator_detail_v43.hpp"
+#line 6430 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6456,11 +6456,11 @@ case 227:
 		goto tr341;
 	goto tr337;
 tr342:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6469,7 +6469,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6473 "inc/vcf/validator_detail_v43.hpp"
+#line 6473 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr333;
@@ -6478,7 +6478,7 @@ case 228:
 		goto tr332;
 	goto tr315;
 tr343:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6487,7 +6487,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6491 "inc/vcf/validator_detail_v43.hpp"
+#line 6491 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 44: goto tr344;
@@ -6498,17 +6498,17 @@ case 229:
 		goto tr330;
 	goto tr315;
 tr345:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st230;
 tr336:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6517,7 +6517,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6521 "inc/vcf/validator_detail_v43.hpp"
+#line 6521 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6537,17 +6537,17 @@ case 231:
 	}
 	goto tr266;
 tr318:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st232;
 tr321:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6556,7 +6556,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6560 "inc/vcf/validator_detail_v43.hpp"
+#line 6560 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr346;
 		case 92: goto tr321;
@@ -6565,11 +6565,11 @@ case 232:
 		goto tr319;
 	goto tr315;
 tr346:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6578,7 +6578,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6582 "inc/vcf/validator_detail_v43.hpp"
+#line 6582 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr347;
@@ -6589,7 +6589,7 @@ case 233:
 		goto tr319;
 	goto tr315;
 tr347:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6598,7 +6598,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6602 "inc/vcf/validator_detail_v43.hpp"
+#line 6602 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6630,17 +6630,17 @@ case 234:
 		goto tr319;
 	goto tr349;
 tr352:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st235;
 tr350:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6649,7 +6649,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6653 "inc/vcf/validator_detail_v43.hpp"
+#line 6653 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6681,17 +6681,17 @@ case 235:
 		goto tr319;
 	goto tr349;
 tr353:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st236;
 tr351:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6700,7 +6700,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6704 "inc/vcf/validator_detail_v43.hpp"
+#line 6704 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6730,11 +6730,11 @@ case 236:
 		goto tr353;
 	goto tr349;
 tr354:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -6743,7 +6743,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6747 "inc/vcf/validator_detail_v43.hpp"
+#line 6747 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr321;
@@ -6752,7 +6752,7 @@ case 237:
 		goto tr319;
 	goto tr315;
 tr348:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6761,7 +6761,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6765 "inc/vcf/validator_detail_v43.hpp"
+#line 6765 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6772,21 +6772,21 @@ case 238:
 		goto tr319;
 	goto tr315;
 tr355:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st239;
 tr291:
-#line 152 "src/vcf/vcf_v43.ragel"
+#line 152 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6795,18 +6795,18 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6799 "inc/vcf/validator_detail_v43.hpp"
+#line 6799 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr355;
 	goto tr289;
 tr33:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6815,7 +6815,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6819 "inc/vcf/validator_detail_v43.hpp"
+#line 6819 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 78: goto tr357;
@@ -6824,7 +6824,7 @@ case 240:
 		goto tr41;
 	goto tr356;
 tr357:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6833,7 +6833,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6837 "inc/vcf/validator_detail_v43.hpp"
+#line 6837 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 70: goto tr358;
@@ -6842,7 +6842,7 @@ case 241:
 		goto tr41;
 	goto tr356;
 tr358:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6851,7 +6851,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6855 "inc/vcf/validator_detail_v43.hpp"
+#line 6855 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 79: goto st243;
@@ -6869,7 +6869,7 @@ case 243:
 		goto tr41;
 	goto tr356;
 tr360:
-#line 128 "src/vcf/vcf_v43.ragel"
+#line 128 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "INFO");
     }
@@ -6878,7 +6878,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6882 "inc/vcf/validator_detail_v43.hpp"
+#line 6882 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr356;
@@ -6922,11 +6922,11 @@ case 248:
 		goto tr367;
 	goto tr365;
 tr366:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -6935,7 +6935,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6939 "inc/vcf/validator_detail_v43.hpp"
+#line 6939 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6951,21 +6951,21 @@ case 249:
 		goto tr369;
 	goto tr365;
 tr369:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st250;
 tr367:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -6974,7 +6974,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6978 "inc/vcf/validator_detail_v43.hpp"
+#line 6978 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr370;
 		case 95: goto tr369;
@@ -6992,7 +6992,7 @@ case 250:
 		goto tr369;
 	goto tr365;
 tr370:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7001,7 +7001,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 7005 "inc/vcf/validator_detail_v43.hpp"
+#line 7005 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr356;
@@ -7061,15 +7061,15 @@ case 258:
 		goto tr380;
 	goto tr378;
 tr379:
-#line 152 "src/vcf/vcf_v43.ragel"
+#line 152 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7078,12 +7078,12 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 7082 "inc/vcf/validator_detail_v43.hpp"
+#line 7082 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	goto tr378;
 tr381:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7092,7 +7092,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7096 "inc/vcf/validator_detail_v43.hpp"
+#line 7096 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr356;
@@ -7135,21 +7135,21 @@ case 265:
 		goto tr388;
 	goto tr387;
 tr390:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st266;
 tr388:
-#line 156 "src/vcf/vcf_v43.ragel"
+#line 156 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Type");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7158,7 +7158,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7162 "inc/vcf/validator_detail_v43.hpp"
+#line 7162 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr389;
 	if ( (*p) > 90 ) {
@@ -7168,7 +7168,7 @@ case 266:
 		goto tr390;
 	goto tr387;
 tr389:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7177,7 +7177,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7181 "inc/vcf/validator_detail_v43.hpp"
+#line 7181 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr356;
@@ -7266,7 +7266,7 @@ case 279:
 		goto tr403;
 	goto tr356;
 tr403:
-#line 160 "src/vcf/vcf_v43.ragel"
+#line 160 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Description");
     }
@@ -7275,7 +7275,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7279 "inc/vcf/validator_detail_v43.hpp"
+#line 7279 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 92: goto tr407;
@@ -7284,17 +7284,17 @@ case 280:
 		goto tr405;
 	goto tr404;
 tr405:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st281;
 tr408:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7303,7 +7303,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7307 "inc/vcf/validator_detail_v43.hpp"
+#line 7307 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr410;
@@ -7312,17 +7312,17 @@ case 281:
 		goto tr408;
 	goto tr404;
 tr406:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st282;
 tr409:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7331,7 +7331,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7335 "inc/vcf/validator_detail_v43.hpp"
+#line 7335 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7356,7 +7356,7 @@ case 283:
 		goto tr414;
 	goto tr365;
 tr413:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7365,7 +7365,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7369 "inc/vcf/validator_detail_v43.hpp"
+#line 7369 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7381,17 +7381,17 @@ case 284:
 		goto tr416;
 	goto tr365;
 tr414:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st285;
 tr416:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7400,7 +7400,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7404 "inc/vcf/validator_detail_v43.hpp"
+#line 7404 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr417;
 		case 95: goto tr416;
@@ -7418,7 +7418,7 @@ case 285:
 		goto tr416;
 	goto tr365;
 tr417:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7427,7 +7427,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7431 "inc/vcf/validator_detail_v43.hpp"
+#line 7431 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr356;
@@ -7443,17 +7443,17 @@ case 287:
 		goto tr419;
 	goto tr404;
 tr419:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st288;
 tr421:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7462,7 +7462,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7466 "inc/vcf/validator_detail_v43.hpp"
+#line 7466 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr422;
@@ -7471,17 +7471,17 @@ case 288:
 		goto tr421;
 	goto tr404;
 tr420:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st289;
 tr422:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7490,7 +7490,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7494 "inc/vcf/validator_detail_v43.hpp"
+#line 7494 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr423;
 		case 92: goto tr422;
@@ -7499,11 +7499,11 @@ case 289:
 		goto tr421;
 	goto tr404;
 tr423:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7512,7 +7512,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7516 "inc/vcf/validator_detail_v43.hpp"
+#line 7516 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr424;
@@ -7523,17 +7523,17 @@ case 290:
 		goto tr421;
 	goto tr404;
 tr433:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st291;
 tr424:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7542,7 +7542,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7546 "inc/vcf/validator_detail_v43.hpp"
+#line 7546 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7574,17 +7574,17 @@ case 291:
 		goto tr421;
 	goto tr426;
 tr427:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st292;
 tr429:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7593,7 +7593,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7597 "inc/vcf/validator_detail_v43.hpp"
+#line 7597 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7625,17 +7625,17 @@ case 292:
 		goto tr421;
 	goto tr426;
 tr428:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st293;
 tr430:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7644,7 +7644,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7648 "inc/vcf/validator_detail_v43.hpp"
+#line 7648 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7674,11 +7674,11 @@ case 293:
 		goto tr430;
 	goto tr426;
 tr431:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7687,7 +7687,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7691 "inc/vcf/validator_detail_v43.hpp"
+#line 7691 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr422;
@@ -7696,7 +7696,7 @@ case 294:
 		goto tr421;
 	goto tr404;
 tr432:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7705,7 +7705,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7709 "inc/vcf/validator_detail_v43.hpp"
+#line 7709 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 44: goto tr433;
@@ -7716,17 +7716,17 @@ case 295:
 		goto tr419;
 	goto tr404;
 tr434:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st296;
 tr425:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7735,7 +7735,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7739 "inc/vcf/validator_detail_v43.hpp"
+#line 7739 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -7755,17 +7755,17 @@ case 297:
 	}
 	goto tr356;
 tr407:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st298;
 tr410:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7774,7 +7774,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7778 "inc/vcf/validator_detail_v43.hpp"
+#line 7778 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr435;
 		case 92: goto tr410;
@@ -7783,11 +7783,11 @@ case 298:
 		goto tr408;
 	goto tr404;
 tr435:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7796,7 +7796,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7800 "inc/vcf/validator_detail_v43.hpp"
+#line 7800 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr436;
@@ -7807,7 +7807,7 @@ case 299:
 		goto tr408;
 	goto tr404;
 tr436:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7816,7 +7816,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7820 "inc/vcf/validator_detail_v43.hpp"
+#line 7820 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7848,17 +7848,17 @@ case 300:
 		goto tr408;
 	goto tr438;
 tr441:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st301;
 tr439:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7867,7 +7867,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7871 "inc/vcf/validator_detail_v43.hpp"
+#line 7871 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7899,17 +7899,17 @@ case 301:
 		goto tr408;
 	goto tr438;
 tr442:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st302;
 tr440:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -7918,7 +7918,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7922 "inc/vcf/validator_detail_v43.hpp"
+#line 7922 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7948,11 +7948,11 @@ case 302:
 		goto tr442;
 	goto tr438;
 tr443:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -7961,7 +7961,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7965 "inc/vcf/validator_detail_v43.hpp"
+#line 7965 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr410;
@@ -7970,7 +7970,7 @@ case 303:
 		goto tr408;
 	goto tr404;
 tr437:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -7979,7 +7979,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7983 "inc/vcf/validator_detail_v43.hpp"
+#line 7983 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -7990,21 +7990,21 @@ case 304:
 		goto tr408;
 	goto tr404;
 tr444:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st305;
 tr380:
-#line 152 "src/vcf/vcf_v43.ragel"
+#line 152 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8013,18 +8013,18 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 8017 "inc/vcf/validator_detail_v43.hpp"
+#line 8017 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr444;
 	goto tr378;
 tr34:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8033,7 +8033,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 8037 "inc/vcf/validator_detail_v43.hpp"
+#line 8037 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr446;
@@ -8042,7 +8042,7 @@ case 306:
 		goto tr41;
 	goto tr445;
 tr446:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8051,7 +8051,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 8055 "inc/vcf/validator_detail_v43.hpp"
+#line 8055 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr447;
@@ -8060,7 +8060,7 @@ case 307:
 		goto tr41;
 	goto tr445;
 tr447:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8069,7 +8069,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 8073 "inc/vcf/validator_detail_v43.hpp"
+#line 8073 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto st309;
@@ -8087,7 +8087,7 @@ case 309:
 		goto tr41;
 	goto tr445;
 tr449:
-#line 140 "src/vcf/vcf_v43.ragel"
+#line 140 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "META");
     }
@@ -8096,7 +8096,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8100 "inc/vcf/validator_detail_v43.hpp"
+#line 8100 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st311;
 	goto tr445;
@@ -8140,11 +8140,11 @@ case 314:
 		goto tr456;
 	goto tr454;
 tr455:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -8153,7 +8153,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8157 "inc/vcf/validator_detail_v43.hpp"
+#line 8157 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st315;
 	if ( (*p) < 48 ) {
@@ -8169,21 +8169,21 @@ case 315:
 		goto tr458;
 	goto tr454;
 tr458:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st316;
 tr456:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8192,7 +8192,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8196 "inc/vcf/validator_detail_v43.hpp"
+#line 8196 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr459;
 		case 95: goto tr458;
@@ -8210,7 +8210,7 @@ case 316:
 		goto tr458;
 	goto tr454;
 tr459:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8219,7 +8219,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8223 "inc/vcf/validator_detail_v43.hpp"
+#line 8223 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st318;
 	goto tr445;
@@ -8273,7 +8273,7 @@ case 324:
 		goto tr468;
 	goto tr467;
 tr468:
-#line 152 "src/vcf/vcf_v43.ragel"
+#line 152 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Number");
     }
@@ -8282,7 +8282,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8286 "inc/vcf/validator_detail_v43.hpp"
+#line 8286 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto st326;
 	goto tr467;
@@ -8329,7 +8329,7 @@ case 331:
 		goto tr476;
 	goto tr475;
 tr476:
-#line 156 "src/vcf/vcf_v43.ragel"
+#line 156 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Type");
     }
@@ -8338,7 +8338,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 8342 "inc/vcf/validator_detail_v43.hpp"
+#line 8342 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 116 )
 		goto st333;
 	goto tr475;
@@ -8434,7 +8434,7 @@ case 345:
 		goto tr490;
 	goto tr445;
 tr490:
-#line 164 "src/vcf/vcf_v43.ragel"
+#line 164 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Values");
     }
@@ -8443,7 +8443,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 8447 "inc/vcf/validator_detail_v43.hpp"
+#line 8447 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr491;
 	if ( (*p) < 45 ) {
@@ -8456,17 +8456,17 @@ case 346:
 		goto tr491;
 	goto tr445;
 tr491:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st347;
 tr493:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8475,7 +8475,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 8479 "inc/vcf/validator_detail_v43.hpp"
+#line 8479 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 61: goto tr493;
@@ -8488,7 +8488,7 @@ case 347:
 		goto tr493;
 	goto tr492;
 tr494:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8497,7 +8497,7 @@ st348:
 	if ( ++p == pe )
 		goto _test_eof348;
 case 348:
-#line 8501 "inc/vcf/validator_detail_v43.hpp"
+#line 8501 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr496;
 		case 61: goto tr493;
@@ -8515,7 +8515,7 @@ case 348:
 		goto tr493;
 	goto tr445;
 tr496:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8524,7 +8524,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 8528 "inc/vcf/validator_detail_v43.hpp"
+#line 8528 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr493;
 	if ( (*p) < 45 ) {
@@ -8537,11 +8537,11 @@ case 349:
 		goto tr493;
 	goto tr445;
 tr495:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8550,7 +8550,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 8554 "inc/vcf/validator_detail_v43.hpp"
+#line 8554 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 62: goto st351;
@@ -8572,11 +8572,11 @@ case 351:
 	}
 	goto tr445;
 tr35:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8585,7 +8585,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 8589 "inc/vcf/validator_detail_v43.hpp"
+#line 8589 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr499;
@@ -8594,7 +8594,7 @@ case 352:
 		goto tr41;
 	goto tr498;
 tr499:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8603,7 +8603,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 8607 "inc/vcf/validator_detail_v43.hpp"
+#line 8607 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr500;
@@ -8612,7 +8612,7 @@ case 353:
 		goto tr41;
 	goto tr498;
 tr500:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8621,7 +8621,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8625 "inc/vcf/validator_detail_v43.hpp"
+#line 8625 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr501;
@@ -8630,7 +8630,7 @@ case 354:
 		goto tr41;
 	goto tr498;
 tr501:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8639,7 +8639,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8643 "inc/vcf/validator_detail_v43.hpp"
+#line 8643 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 71: goto tr502;
@@ -8648,7 +8648,7 @@ case 355:
 		goto tr41;
 	goto tr498;
 tr502:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8657,7 +8657,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 8661 "inc/vcf/validator_detail_v43.hpp"
+#line 8661 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr503;
@@ -8666,7 +8666,7 @@ case 356:
 		goto tr41;
 	goto tr498;
 tr503:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8675,7 +8675,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 8679 "inc/vcf/validator_detail_v43.hpp"
+#line 8679 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr504;
@@ -8684,7 +8684,7 @@ case 357:
 		goto tr41;
 	goto tr498;
 tr504:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8693,7 +8693,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 8697 "inc/vcf/validator_detail_v43.hpp"
+#line 8697 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st359;
@@ -8711,7 +8711,7 @@ case 359:
 		goto tr41;
 	goto tr498;
 tr506:
-#line 132 "src/vcf/vcf_v43.ragel"
+#line 132 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "PEDIGREE");
     }
@@ -8720,7 +8720,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 8724 "inc/vcf/validator_detail_v43.hpp"
+#line 8724 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st361;
 	goto tr498;
@@ -8764,11 +8764,11 @@ case 364:
 		goto tr513;
 	goto tr511;
 tr512:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -8777,7 +8777,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 8781 "inc/vcf/validator_detail_v43.hpp"
+#line 8781 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st365;
 	if ( (*p) < 48 ) {
@@ -8793,21 +8793,21 @@ case 365:
 		goto tr515;
 	goto tr511;
 tr515:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st366;
 tr513:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8816,7 +8816,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 8820 "inc/vcf/validator_detail_v43.hpp"
+#line 8820 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr516;
 		case 95: goto tr515;
@@ -8834,7 +8834,7 @@ case 366:
 		goto tr515;
 	goto tr511;
 tr516:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8843,7 +8843,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 8847 "inc/vcf/validator_detail_v43.hpp"
+#line 8847 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 70: goto st368;
 		case 78: goto tr519;
@@ -8911,11 +8911,11 @@ case 374:
 		goto tr529;
 	goto tr527;
 tr528:
-#line 172 "src/vcf/vcf_v43.ragel"
+#line 172 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Father");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -8924,7 +8924,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8928 "inc/vcf/validator_detail_v43.hpp"
+#line 8928 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st375;
 	if ( (*p) < 48 ) {
@@ -8940,21 +8940,21 @@ case 375:
 		goto tr531;
 	goto tr527;
 tr531:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st376;
 tr529:
-#line 172 "src/vcf/vcf_v43.ragel"
+#line 172 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Father");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -8963,7 +8963,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 8967 "inc/vcf/validator_detail_v43.hpp"
+#line 8967 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr532;
 		case 95: goto tr531;
@@ -8981,7 +8981,7 @@ case 376:
 		goto tr531;
 	goto tr527;
 tr532:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -8990,7 +8990,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 8994 "inc/vcf/validator_detail_v43.hpp"
+#line 8994 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 77 )
 		goto st378;
 	goto tr498;
@@ -9055,11 +9055,11 @@ case 384:
 		goto tr541;
 	goto tr527;
 tr540:
-#line 176 "src/vcf/vcf_v43.ragel"
+#line 176 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Mother");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9068,7 +9068,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9072 "inc/vcf/validator_detail_v43.hpp"
+#line 9072 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st385;
 	if ( (*p) < 48 ) {
@@ -9084,21 +9084,21 @@ case 385:
 		goto tr543;
 	goto tr527;
 tr543:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st386;
 tr541:
-#line 176 "src/vcf/vcf_v43.ragel"
+#line 176 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Mother");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9107,7 +9107,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 9111 "inc/vcf/validator_detail_v43.hpp"
+#line 9111 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr543;
@@ -9125,7 +9125,7 @@ case 386:
 		goto tr543;
 	goto tr527;
 tr544:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9134,18 +9134,18 @@ st387:
 	if ( ++p == pe )
 		goto _test_eof387;
 case 387:
-#line 9138 "inc/vcf/validator_detail_v43.hpp"
+#line 9138 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
 	}
 	goto tr498;
 tr519:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9154,12 +9154,12 @@ st388:
 	if ( ++p == pe )
 		goto _test_eof388;
 case 388:
-#line 9158 "inc/vcf/validator_detail_v43.hpp"
+#line 9158 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr545;
 	goto tr517;
 tr545:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9168,12 +9168,12 @@ st389:
 	if ( ++p == pe )
 		goto _test_eof389;
 case 389:
-#line 9172 "inc/vcf/validator_detail_v43.hpp"
+#line 9172 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 109 )
 		goto tr546;
 	goto tr517;
 tr546:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9182,12 +9182,12 @@ st390:
 	if ( ++p == pe )
 		goto _test_eof390;
 case 390:
-#line 9186 "inc/vcf/validator_detail_v43.hpp"
+#line 9186 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 101 )
 		goto tr547;
 	goto tr517;
 tr547:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9196,12 +9196,12 @@ st391:
 	if ( ++p == pe )
 		goto _test_eof391;
 case 391:
-#line 9200 "inc/vcf/validator_detail_v43.hpp"
+#line 9200 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr548;
 	goto tr517;
 tr548:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9210,12 +9210,12 @@ st392:
 	if ( ++p == pe )
 		goto _test_eof392;
 case 392:
-#line 9214 "inc/vcf/validator_detail_v43.hpp"
+#line 9214 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr549;
 	goto tr517;
 tr549:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9224,14 +9224,14 @@ st393:
 	if ( ++p == pe )
 		goto _test_eof393;
 case 393:
-#line 9228 "inc/vcf/validator_detail_v43.hpp"
+#line 9228 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr550;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr549;
 	goto tr517;
 tr550:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9240,7 +9240,7 @@ st394:
 	if ( ++p == pe )
 		goto _test_eof394;
 case 394:
-#line 9244 "inc/vcf/validator_detail_v43.hpp"
+#line 9244 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr551;
 	if ( (*p) < 48 ) {
@@ -9256,7 +9256,7 @@ case 394:
 		goto tr552;
 	goto tr517;
 tr551:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9265,7 +9265,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9269 "inc/vcf/validator_detail_v43.hpp"
+#line 9269 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st395;
 	if ( (*p) < 48 ) {
@@ -9281,17 +9281,17 @@ case 395:
 		goto tr554;
 	goto tr517;
 tr552:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st396;
 tr554:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9300,7 +9300,7 @@ st396:
 	if ( ++p == pe )
 		goto _test_eof396;
 case 396:
-#line 9304 "inc/vcf/validator_detail_v43.hpp"
+#line 9304 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr555;
 		case 62: goto tr544;
@@ -9319,7 +9319,7 @@ case 396:
 		goto tr554;
 	goto tr517;
 tr555:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9328,7 +9328,7 @@ st397:
 	if ( ++p == pe )
 		goto _test_eof397;
 case 397:
-#line 9332 "inc/vcf/validator_detail_v43.hpp"
+#line 9332 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr519;
 	goto tr517;
@@ -9407,11 +9407,11 @@ case 406:
 		goto tr566;
 	goto tr564;
 tr565:
-#line 168 "src/vcf/vcf_v43.ragel"
+#line 168 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Original");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9420,7 +9420,7 @@ st407:
 	if ( ++p == pe )
 		goto _test_eof407;
 case 407:
-#line 9424 "inc/vcf/validator_detail_v43.hpp"
+#line 9424 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st407;
 	if ( (*p) < 48 ) {
@@ -9436,21 +9436,21 @@ case 407:
 		goto tr568;
 	goto tr564;
 tr568:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st408;
 tr566:
-#line 168 "src/vcf/vcf_v43.ragel"
+#line 168 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "Original");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9459,7 +9459,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9463 "inc/vcf/validator_detail_v43.hpp"
+#line 9463 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr568;
@@ -9477,11 +9477,11 @@ case 408:
 		goto tr568;
 	goto tr564;
 tr36:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9490,7 +9490,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 9494 "inc/vcf/validator_detail_v43.hpp"
+#line 9494 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr570;
@@ -9499,7 +9499,7 @@ case 409:
 		goto tr41;
 	goto tr569;
 tr570:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9508,7 +9508,7 @@ st410:
 	if ( ++p == pe )
 		goto _test_eof410;
 case 410:
-#line 9512 "inc/vcf/validator_detail_v43.hpp"
+#line 9512 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr571;
@@ -9517,7 +9517,7 @@ case 410:
 		goto tr41;
 	goto tr569;
 tr571:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9526,7 +9526,7 @@ st411:
 	if ( ++p == pe )
 		goto _test_eof411;
 case 411:
-#line 9530 "inc/vcf/validator_detail_v43.hpp"
+#line 9530 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 80: goto tr572;
@@ -9535,7 +9535,7 @@ case 411:
 		goto tr41;
 	goto tr569;
 tr572:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9544,7 +9544,7 @@ st412:
 	if ( ++p == pe )
 		goto _test_eof412;
 case 412:
-#line 9548 "inc/vcf/validator_detail_v43.hpp"
+#line 9548 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr573;
@@ -9553,7 +9553,7 @@ case 412:
 		goto tr41;
 	goto tr569;
 tr573:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9562,7 +9562,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9566 "inc/vcf/validator_detail_v43.hpp"
+#line 9566 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st414;
@@ -9580,7 +9580,7 @@ case 414:
 		goto tr41;
 	goto tr569;
 tr575:
-#line 144 "src/vcf/vcf_v43.ragel"
+#line 144 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "SAMPLE");
     }
@@ -9589,7 +9589,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9593 "inc/vcf/validator_detail_v43.hpp"
+#line 9593 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st416;
 	goto tr569;
@@ -9633,11 +9633,11 @@ case 419:
 		goto tr582;
 	goto tr580;
 tr581:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9646,7 +9646,7 @@ st420:
 	if ( ++p == pe )
 		goto _test_eof420;
 case 420:
-#line 9650 "inc/vcf/validator_detail_v43.hpp"
+#line 9650 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st420;
 	if ( (*p) < 48 ) {
@@ -9662,21 +9662,21 @@ case 420:
 		goto tr584;
 	goto tr580;
 tr584:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st421;
 tr582:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9685,7 +9685,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9689 "inc/vcf/validator_detail_v43.hpp"
+#line 9689 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9704,7 +9704,7 @@ case 421:
 		goto tr584;
 	goto tr580;
 tr585:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9713,7 +9713,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9717 "inc/vcf/validator_detail_v43.hpp"
+#line 9717 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr587;
 	if ( (*p) < 48 ) {
@@ -9729,7 +9729,7 @@ case 422:
 		goto tr588;
 	goto tr569;
 tr587:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -9738,7 +9738,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9742 "inc/vcf/validator_detail_v43.hpp"
+#line 9742 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st423;
 	if ( (*p) < 48 ) {
@@ -9754,17 +9754,17 @@ case 423:
 		goto tr590;
 	goto tr569;
 tr588:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st424;
 tr590:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9773,7 +9773,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9777 "inc/vcf/validator_detail_v43.hpp"
+#line 9777 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr591;
 		case 95: goto tr590;
@@ -9791,7 +9791,7 @@ case 424:
 		goto tr590;
 	goto tr569;
 tr591:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9800,7 +9800,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9804 "inc/vcf/validator_detail_v43.hpp"
+#line 9804 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st428;
 	if ( (*p) < 45 ) {
@@ -9813,17 +9813,17 @@ case 425:
 		goto tr592;
 	goto tr569;
 tr592:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st426;
 tr594:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9832,7 +9832,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9836 "inc/vcf/validator_detail_v43.hpp"
+#line 9836 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9844,7 +9844,7 @@ case 426:
 		goto tr594;
 	goto tr569;
 tr586:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9853,7 +9853,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9857 "inc/vcf/validator_detail_v43.hpp"
+#line 9857 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -9871,17 +9871,17 @@ case 428:
 		goto tr595;
 	goto tr569;
 tr595:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st429;
 tr598:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9890,7 +9890,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 9894 "inc/vcf/validator_detail_v43.hpp"
+#line 9894 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 92: goto tr600;
@@ -9899,17 +9899,17 @@ case 429:
 		goto tr598;
 	goto tr569;
 tr596:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st430;
 tr599:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9918,24 +9918,24 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 9922 "inc/vcf/validator_detail_v43.hpp"
+#line 9922 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st422;
 		case 62: goto st427;
 	}
 	goto tr569;
 tr597:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st431;
 tr600:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -9944,7 +9944,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 9948 "inc/vcf/validator_detail_v43.hpp"
+#line 9948 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 92: goto tr600;
@@ -9953,11 +9953,11 @@ case 431:
 		goto tr598;
 	goto tr569;
 tr603:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -9966,7 +9966,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 9970 "inc/vcf/validator_detail_v43.hpp"
+#line 9970 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr604;
@@ -9977,27 +9977,27 @@ case 432:
 		goto tr598;
 	goto tr569;
 tr618:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st433;
 tr604:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st433;
 tr615:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10006,7 +10006,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10010 "inc/vcf/validator_detail_v43.hpp"
+#line 10010 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10038,17 +10038,17 @@ case 433:
 		goto tr598;
 	goto tr569;
 tr606:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st434;
 tr608:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10057,7 +10057,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10061 "inc/vcf/validator_detail_v43.hpp"
+#line 10061 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10089,17 +10089,17 @@ case 434:
 		goto tr598;
 	goto tr569;
 tr607:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st435;
 tr609:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10108,7 +10108,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10112 "inc/vcf/validator_detail_v43.hpp"
+#line 10112 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10138,11 +10138,11 @@ case 435:
 		goto tr609;
 	goto tr569;
 tr610:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10151,7 +10151,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10155 "inc/vcf/validator_detail_v43.hpp"
+#line 10155 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr612;
 		case 44: goto tr598;
@@ -10162,17 +10162,17 @@ case 436:
 		goto tr611;
 	goto tr569;
 tr614:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st437;
 tr611:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -10181,7 +10181,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10185 "inc/vcf/validator_detail_v43.hpp"
+#line 10185 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr615;
@@ -10192,27 +10192,27 @@ case 437:
 		goto tr614;
 	goto tr569;
 tr619:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st438;
 tr605:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st438;
 tr616:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10221,7 +10221,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10225 "inc/vcf/validator_detail_v43.hpp"
+#line 10225 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -10232,17 +10232,17 @@ case 438:
 		goto tr598;
 	goto tr569;
 tr617:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st439;
 tr613:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -10251,7 +10251,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10255 "inc/vcf/validator_detail_v43.hpp"
+#line 10255 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 44: goto tr615;
@@ -10262,7 +10262,7 @@ case 439:
 		goto tr614;
 	goto tr569;
 tr612:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10271,7 +10271,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10275 "inc/vcf/validator_detail_v43.hpp"
+#line 10275 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr596;
 		case 44: goto tr618;
@@ -10282,11 +10282,11 @@ case 440:
 		goto tr595;
 	goto tr569;
 tr37:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10295,7 +10295,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10299 "inc/vcf/validator_detail_v43.hpp"
+#line 10299 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr621;
@@ -10304,7 +10304,7 @@ case 441:
 		goto tr41;
 	goto tr620;
 tr621:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10313,7 +10313,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 10317 "inc/vcf/validator_detail_v43.hpp"
+#line 10317 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr622;
@@ -10322,7 +10322,7 @@ case 442:
 		goto tr41;
 	goto tr620;
 tr622:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10331,7 +10331,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10335 "inc/vcf/validator_detail_v43.hpp"
+#line 10335 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr623;
@@ -10340,7 +10340,7 @@ case 443:
 		goto tr41;
 	goto tr620;
 tr623:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10349,7 +10349,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 10353 "inc/vcf/validator_detail_v43.hpp"
+#line 10353 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 109: goto tr624;
@@ -10358,7 +10358,7 @@ case 444:
 		goto tr41;
 	goto tr620;
 tr624:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10367,7 +10367,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10371 "inc/vcf/validator_detail_v43.hpp"
+#line 10371 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 98: goto tr625;
@@ -10376,7 +10376,7 @@ case 445:
 		goto tr41;
 	goto tr620;
 tr625:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10385,7 +10385,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10389 "inc/vcf/validator_detail_v43.hpp"
+#line 10389 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 108: goto tr626;
@@ -10394,7 +10394,7 @@ case 446:
 		goto tr41;
 	goto tr620;
 tr626:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10403,7 +10403,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 10407 "inc/vcf/validator_detail_v43.hpp"
+#line 10407 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 121: goto st448;
@@ -10421,7 +10421,7 @@ case 448:
 		goto tr41;
 	goto tr620;
 tr628:
-#line 112 "src/vcf/vcf_v43.ragel"
+#line 112 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "assembly");
     }
@@ -10430,7 +10430,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 10434 "inc/vcf/validator_detail_v43.hpp"
+#line 10434 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr630;
@@ -10438,7 +10438,7 @@ case 449:
 		goto tr630;
 	goto tr629;
 tr630:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -10447,7 +10447,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 10451 "inc/vcf/validator_detail_v43.hpp"
+#line 10451 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10458,7 +10458,7 @@ case 450:
 	}
 	goto st451;
 tr632:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -10473,7 +10473,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 10477 "inc/vcf/validator_detail_v43.hpp"
+#line 10477 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10559,13 +10559,13 @@ case 460:
 		goto tr637;
 	goto tr629;
 tr637:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st461;
 tr646:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -10575,15 +10575,15 @@ tr646:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 188 "src/vcf/vcf_v43.ragel"
+#line 188 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -10596,7 +10596,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 10600 "inc/vcf/validator_detail_v43.hpp"
+#line 10600 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr646;
@@ -10651,11 +10651,11 @@ case 467:
 		goto st456;
 	goto tr629;
 tr38:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10664,7 +10664,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 10668 "inc/vcf/validator_detail_v43.hpp"
+#line 10668 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 111: goto tr651;
@@ -10673,7 +10673,7 @@ case 468:
 		goto tr41;
 	goto tr650;
 tr651:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10682,7 +10682,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 10686 "inc/vcf/validator_detail_v43.hpp"
+#line 10686 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 110: goto tr652;
@@ -10691,7 +10691,7 @@ case 469:
 		goto tr41;
 	goto tr650;
 tr652:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10700,7 +10700,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10704 "inc/vcf/validator_detail_v43.hpp"
+#line 10704 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 116: goto tr653;
@@ -10709,7 +10709,7 @@ case 470:
 		goto tr41;
 	goto tr650;
 tr653:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10718,7 +10718,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 10722 "inc/vcf/validator_detail_v43.hpp"
+#line 10722 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr654;
@@ -10727,7 +10727,7 @@ case 471:
 		goto tr41;
 	goto tr650;
 tr654:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10736,7 +10736,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 10740 "inc/vcf/validator_detail_v43.hpp"
+#line 10740 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto st473;
@@ -10754,7 +10754,7 @@ case 473:
 		goto tr41;
 	goto tr650;
 tr656:
-#line 116 "src/vcf/vcf_v43.ragel"
+#line 116 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "contig");
     }
@@ -10763,7 +10763,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10767 "inc/vcf/validator_detail_v43.hpp"
+#line 10767 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st475;
 	goto tr650;
@@ -10813,21 +10813,21 @@ case 478:
 		goto tr662;
 	goto tr661;
 tr663:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st479;
 tr662:
-#line 148 "src/vcf/vcf_v43.ragel"
+#line 148 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this, "ID");
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10836,7 +10836,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 10840 "inc/vcf/validator_detail_v43.hpp"
+#line 10840 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 59: goto tr663;
@@ -10856,7 +10856,7 @@ case 479:
 		goto tr663;
 	goto tr661;
 tr664:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10865,7 +10865,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 10869 "inc/vcf/validator_detail_v43.hpp"
+#line 10869 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr666;
 	if ( (*p) < 48 ) {
@@ -10881,7 +10881,7 @@ case 480:
 		goto tr667;
 	goto tr650;
 tr666:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -10890,7 +10890,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10894 "inc/vcf/validator_detail_v43.hpp"
+#line 10894 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st481;
 	if ( (*p) < 48 ) {
@@ -10906,17 +10906,17 @@ case 481:
 		goto tr669;
 	goto tr650;
 tr667:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st482;
 tr669:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10925,7 +10925,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 10929 "inc/vcf/validator_detail_v43.hpp"
+#line 10929 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr670;
 		case 95: goto tr669;
@@ -10943,7 +10943,7 @@ case 482:
 		goto tr669;
 	goto tr650;
 tr670:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -10952,7 +10952,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 10956 "inc/vcf/validator_detail_v43.hpp"
+#line 10956 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st486;
 	if ( (*p) < 45 ) {
@@ -10965,17 +10965,17 @@ case 483:
 		goto tr671;
 	goto tr650;
 tr671:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st484;
 tr673:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -10984,7 +10984,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10988 "inc/vcf/validator_detail_v43.hpp"
+#line 10988 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 62: goto tr665;
@@ -10996,7 +10996,7 @@ case 484:
 		goto tr673;
 	goto tr650;
 tr665:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11005,7 +11005,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 11009 "inc/vcf/validator_detail_v43.hpp"
+#line 11009 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11023,17 +11023,17 @@ case 486:
 		goto tr674;
 	goto tr650;
 tr674:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st487;
 tr677:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11042,7 +11042,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 11046 "inc/vcf/validator_detail_v43.hpp"
+#line 11046 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 92: goto tr679;
@@ -11051,17 +11051,17 @@ case 487:
 		goto tr677;
 	goto tr650;
 tr675:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st488;
 tr678:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11070,24 +11070,24 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 11074 "inc/vcf/validator_detail_v43.hpp"
+#line 11074 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st480;
 		case 62: goto st485;
 	}
 	goto tr650;
 tr676:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st489;
 tr679:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11096,7 +11096,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 11100 "inc/vcf/validator_detail_v43.hpp"
+#line 11100 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 92: goto tr679;
@@ -11105,11 +11105,11 @@ case 489:
 		goto tr677;
 	goto tr650;
 tr682:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11118,7 +11118,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 11122 "inc/vcf/validator_detail_v43.hpp"
+#line 11122 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr683;
@@ -11129,27 +11129,27 @@ case 490:
 		goto tr677;
 	goto tr650;
 tr697:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st491;
 tr683:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st491;
 tr694:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11158,7 +11158,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 11162 "inc/vcf/validator_detail_v43.hpp"
+#line 11162 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11190,17 +11190,17 @@ case 491:
 		goto tr677;
 	goto tr650;
 tr685:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st492;
 tr687:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11209,7 +11209,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 11213 "inc/vcf/validator_detail_v43.hpp"
+#line 11213 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11241,17 +11241,17 @@ case 492:
 		goto tr677;
 	goto tr650;
 tr686:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st493;
 tr688:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11260,7 +11260,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 11264 "inc/vcf/validator_detail_v43.hpp"
+#line 11264 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11290,11 +11290,11 @@ case 493:
 		goto tr688;
 	goto tr650;
 tr689:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11303,7 +11303,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 11307 "inc/vcf/validator_detail_v43.hpp"
+#line 11307 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr691;
 		case 44: goto tr677;
@@ -11314,17 +11314,17 @@ case 494:
 		goto tr690;
 	goto tr650;
 tr693:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st495;
 tr690:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -11333,7 +11333,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 11337 "inc/vcf/validator_detail_v43.hpp"
+#line 11337 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr694;
@@ -11344,27 +11344,27 @@ case 495:
 		goto tr693;
 	goto tr650;
 tr698:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st496;
 tr684:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st496;
 tr695:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11373,7 +11373,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 11377 "inc/vcf/validator_detail_v43.hpp"
+#line 11377 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11384,17 +11384,17 @@ case 496:
 		goto tr677;
 	goto tr650;
 tr696:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st497;
 tr692:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -11403,7 +11403,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 11407 "inc/vcf/validator_detail_v43.hpp"
+#line 11407 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 44: goto tr694;
@@ -11414,7 +11414,7 @@ case 497:
 		goto tr693;
 	goto tr650;
 tr691:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11423,7 +11423,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 11427 "inc/vcf/validator_detail_v43.hpp"
+#line 11427 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr675;
 		case 44: goto tr697;
@@ -11434,11 +11434,11 @@ case 498:
 		goto tr674;
 	goto tr650;
 tr39:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11447,7 +11447,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 11451 "inc/vcf/validator_detail_v43.hpp"
+#line 11451 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr700;
@@ -11456,7 +11456,7 @@ case 499:
 		goto tr41;
 	goto tr699;
 tr700:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11465,7 +11465,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 11469 "inc/vcf/validator_detail_v43.hpp"
+#line 11469 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 100: goto tr701;
@@ -11474,7 +11474,7 @@ case 500:
 		goto tr41;
 	goto tr699;
 tr701:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11483,7 +11483,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 11487 "inc/vcf/validator_detail_v43.hpp"
+#line 11487 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr702;
@@ -11492,7 +11492,7 @@ case 501:
 		goto tr41;
 	goto tr699;
 tr702:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11501,7 +11501,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 11505 "inc/vcf/validator_detail_v43.hpp"
+#line 11505 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto tr703;
@@ -11510,7 +11510,7 @@ case 502:
 		goto tr41;
 	goto tr699;
 tr703:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11519,7 +11519,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11523 "inc/vcf/validator_detail_v43.hpp"
+#line 11523 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 114: goto tr704;
@@ -11528,7 +11528,7 @@ case 503:
 		goto tr41;
 	goto tr699;
 tr704:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11537,7 +11537,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11541 "inc/vcf/validator_detail_v43.hpp"
+#line 11541 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr705;
@@ -11546,7 +11546,7 @@ case 504:
 		goto tr41;
 	goto tr699;
 tr705:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11555,7 +11555,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11559 "inc/vcf/validator_detail_v43.hpp"
+#line 11559 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr706;
@@ -11564,7 +11564,7 @@ case 505:
 		goto tr41;
 	goto tr699;
 tr706:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11573,7 +11573,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11577 "inc/vcf/validator_detail_v43.hpp"
+#line 11577 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr707;
@@ -11582,7 +11582,7 @@ case 506:
 		goto tr41;
 	goto tr699;
 tr707:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11591,7 +11591,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11595 "inc/vcf/validator_detail_v43.hpp"
+#line 11595 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 66: goto st508;
@@ -11609,7 +11609,7 @@ case 508:
 		goto tr41;
 	goto tr699;
 tr709:
-#line 136 "src/vcf/vcf_v43.ragel"
+#line 136 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_meta_typeid(*this, "pedigreeDB");
     }
@@ -11618,7 +11618,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11622 "inc/vcf/validator_detail_v43.hpp"
+#line 11622 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st510;
 	goto tr699;
@@ -11633,7 +11633,7 @@ case 510:
 		goto tr712;
 	goto tr711;
 tr712:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -11642,7 +11642,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11646 "inc/vcf/validator_detail_v43.hpp"
+#line 11646 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11653,7 +11653,7 @@ case 511:
 	}
 	goto st512;
 tr714:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11668,7 +11668,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11672 "inc/vcf/validator_detail_v43.hpp"
+#line 11672 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11754,13 +11754,13 @@ case 521:
 		goto tr719;
 	goto tr711;
 tr719:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st522;
 tr728:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11770,7 +11770,7 @@ tr728:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -11779,7 +11779,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11783 "inc/vcf/validator_detail_v43.hpp"
+#line 11783 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr728;
@@ -11787,11 +11787,11 @@ case 522:
 	}
 	goto tr719;
 tr729:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -11800,7 +11800,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11804 "inc/vcf/validator_detail_v43.hpp"
+#line 11804 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr730;
@@ -11808,7 +11808,7 @@ case 523:
 	}
 	goto tr719;
 tr730:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -11818,11 +11818,11 @@ tr730:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
-#line 188 "src/vcf/vcf_v43.ragel"
+#line 188 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
@@ -11835,7 +11835,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11839 "inc/vcf/validator_detail_v43.hpp"
+#line 11839 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr728;
@@ -11926,7 +11926,7 @@ case 535:
 		goto tr739;
 	goto tr734;
 tr739:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -11935,7 +11935,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 11939 "inc/vcf/validator_detail_v43.hpp"
+#line 11939 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 80 )
 		goto st537;
 	goto tr734;
@@ -11961,7 +11961,7 @@ case 539:
 		goto tr743;
 	goto tr734;
 tr743:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -11970,7 +11970,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 11974 "inc/vcf/validator_detail_v43.hpp"
+#line 11974 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st541;
 	goto tr734;
@@ -11989,7 +11989,7 @@ case 542:
 		goto tr746;
 	goto tr734;
 tr746:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -11998,7 +11998,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12002 "inc/vcf/validator_detail_v43.hpp"
+#line 12002 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 82 )
 		goto st544;
 	goto tr734;
@@ -12024,7 +12024,7 @@ case 546:
 		goto tr750;
 	goto tr734;
 tr750:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12033,7 +12033,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12037 "inc/vcf/validator_detail_v43.hpp"
+#line 12037 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 65 )
 		goto st548;
 	goto tr734;
@@ -12059,7 +12059,7 @@ case 550:
 		goto tr754;
 	goto tr734;
 tr754:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12068,7 +12068,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12072 "inc/vcf/validator_detail_v43.hpp"
+#line 12072 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 81 )
 		goto st552;
 	goto tr734;
@@ -12101,7 +12101,7 @@ case 555:
 		goto tr759;
 	goto tr734;
 tr759:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12110,7 +12110,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12114 "inc/vcf/validator_detail_v43.hpp"
+#line 12114 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st557;
 	goto tr734;
@@ -12157,7 +12157,7 @@ case 562:
 		goto tr766;
 	goto tr734;
 tr766:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12166,7 +12166,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12170 "inc/vcf/validator_detail_v43.hpp"
+#line 12170 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st564;
 	goto tr734;
@@ -12202,7 +12202,7 @@ case 567:
 	}
 	goto tr734;
 tr771:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12211,7 +12211,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12215 "inc/vcf/validator_detail_v43.hpp"
+#line 12215 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st569;
 	goto tr774;
@@ -12258,17 +12258,17 @@ case 574:
 		goto tr781;
 	goto tr774;
 tr781:
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
 	goto st575;
 tr783:
-#line 196 "src/vcf/vcf_v43.ragel"
+#line 196 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12277,22 +12277,22 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12281 "inc/vcf/validator_detail_v43.hpp"
+#line 12281 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr782;
 	goto tr774;
 tr782:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st576;
 tr786:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12301,7 +12301,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12305 "inc/vcf/validator_detail_v43.hpp"
+#line 12305 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr783;
 		case 10: goto tr784;
@@ -12311,11 +12311,11 @@ case 576:
 		goto tr786;
 	goto tr774;
 tr772:
-#line 200 "src/vcf/vcf_v43.ragel"
+#line 200 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -12327,15 +12327,15 @@ tr772:
     }
 	goto st800;
 tr784:
-#line 196 "src/vcf/vcf_v43.ragel"
+#line 196 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 200 "src/vcf/vcf_v43.ragel"
+#line 200 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -12350,7 +12350,7 @@ st800:
 	if ( ++p == pe )
 		goto _test_eof800;
 case 800:
-#line 12354 "inc/vcf/validator_detail_v43.hpp"
+#line 12354 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1079;
 		case 13: goto tr1080;
@@ -12375,7 +12375,7 @@ case 800:
 		goto tr1081;
 	goto tr1078;
 tr1083:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -12387,7 +12387,7 @@ tr1083:
     }
 	goto st801;
 tr1079:
-#line 70 "src/vcf/vcf_v43.ragel"
+#line 70 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -12395,7 +12395,7 @@ tr1079:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -12410,14 +12410,14 @@ st801:
 	if ( ++p == pe )
 		goto _test_eof801;
 case 801:
-#line 12414 "inc/vcf/validator_detail_v43.hpp"
+#line 12414 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1083;
 		case 13: goto tr1084;
 	}
 	goto st0;
 tr1084:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -12429,7 +12429,7 @@ tr1084:
     }
 	goto st577;
 tr1080:
-#line 70 "src/vcf/vcf_v43.ragel"
+#line 70 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -12437,7 +12437,7 @@ tr1080:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -12452,28 +12452,28 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12456 "inc/vcf/validator_detail_v43.hpp"
+#line 12456 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st801;
 	goto st0;
 tr1085:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st578;
 tr791:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st578;
 tr1081:
-#line 70 "src/vcf/vcf_v43.ragel"
+#line 70 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -12481,11 +12481,11 @@ tr1081:
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12494,7 +12494,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12498 "inc/vcf/validator_detail_v43.hpp"
+#line 12498 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr790;
 		case 43: goto tr791;
@@ -12514,25 +12514,25 @@ case 578:
 		goto tr791;
 	goto tr789;
 tr790:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
 	goto st579;
 tr866:
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12541,22 +12541,22 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12545 "inc/vcf/validator_detail_v43.hpp"
+#line 12545 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr793;
 	goto tr792;
 tr793:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st580;
 tr795:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12565,28 +12565,28 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12569 "inc/vcf/validator_detail_v43.hpp"
+#line 12569 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr794;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr795;
 	goto tr792;
 tr800:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st581;
 tr794:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12595,7 +12595,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12599 "inc/vcf/validator_detail_v43.hpp"
+#line 12599 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr797;
@@ -12603,17 +12603,17 @@ case 581:
 		goto tr797;
 	goto tr796;
 tr797:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st582;
 tr799:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12622,7 +12622,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12626 "inc/vcf/validator_detail_v43.hpp"
+#line 12626 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr798;
 		case 59: goto tr800;
@@ -12631,15 +12631,15 @@ case 582:
 		goto tr799;
 	goto tr796;
 tr798:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12648,7 +12648,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12652 "inc/vcf/validator_detail_v43.hpp"
+#line 12652 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr802;
 		case 67: goto tr802;
@@ -12663,17 +12663,17 @@ case 583:
 	}
 	goto tr801;
 tr802:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st584;
 tr804:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12682,7 +12682,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 12686 "inc/vcf/validator_detail_v43.hpp"
+#line 12686 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr803;
 		case 65: goto tr804;
@@ -12698,15 +12698,15 @@ case 584:
 	}
 	goto tr801;
 tr803:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12715,7 +12715,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 12719 "inc/vcf/validator_detail_v43.hpp"
+#line 12719 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr807;
@@ -12735,17 +12735,17 @@ case 585:
 	}
 	goto tr805;
 tr806:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st586;
 tr1041:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12754,22 +12754,22 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 12758 "inc/vcf/validator_detail_v43.hpp"
+#line 12758 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
 	}
 	goto tr805;
 tr812:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12778,7 +12778,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 12782 "inc/vcf/validator_detail_v43.hpp"
+#line 12782 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr815;
 		case 45: goto tr815;
@@ -12790,11 +12790,11 @@ case 587:
 		goto tr817;
 	goto tr814;
 tr815:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12803,24 +12803,24 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 12807 "inc/vcf/validator_detail_v43.hpp"
+#line 12807 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr821;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr820;
 	goto tr814;
 tr817:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st589;
 tr820:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12829,7 +12829,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 12833 "inc/vcf/validator_detail_v43.hpp"
+#line 12833 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 46: goto tr823;
@@ -12840,15 +12840,15 @@ case 589:
 		goto tr820;
 	goto tr814;
 tr822:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12857,7 +12857,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 12861 "inc/vcf/validator_detail_v43.hpp"
+#line 12861 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr827;
 		case 58: goto tr826;
@@ -12884,7 +12884,7 @@ case 590:
 		goto tr828;
 	goto tr825;
 tr826:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
@@ -12893,7 +12893,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12897 "inc/vcf/validator_detail_v43.hpp"
+#line 12897 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto st591;
 	if ( (*p) < 65 ) {
@@ -12918,17 +12918,17 @@ case 591:
 		goto tr830;
 	goto tr825;
 tr828:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st592;
 tr830:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -12937,7 +12937,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12941 "inc/vcf/validator_detail_v43.hpp"
+#line 12941 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 59: goto tr832;
@@ -12946,15 +12946,15 @@ case 592:
 		goto tr830;
 	goto tr825;
 tr831:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -12963,7 +12963,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12967 "inc/vcf/validator_detail_v43.hpp"
+#line 12967 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr834;
 		case 49: goto tr836;
@@ -12989,11 +12989,11 @@ case 593:
 		goto tr835;
 	goto tr833;
 tr834:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13002,7 +13002,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13006 "inc/vcf/validator_detail_v43.hpp"
+#line 13006 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13010,21 +13010,21 @@ case 594:
 	}
 	goto tr847;
 tr855:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
 	goto st595;
 tr848:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -13033,7 +13033,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13037 "inc/vcf/validator_detail_v43.hpp"
+#line 13037 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr852;
 	if ( (*p) > 90 ) {
@@ -13043,17 +13043,17 @@ case 595:
 		goto tr852;
 	goto tr851;
 tr852:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st596;
 tr854:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13062,7 +13062,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13066 "inc/vcf/validator_detail_v43.hpp"
+#line 13066 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 37: goto tr854;
@@ -13080,15 +13080,15 @@ case 596:
 		goto tr854;
 	goto tr851;
 tr853:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 53 "src/vcf/vcf_v43.ragel"
+#line 53 "../src/vcf/vcf_v43.ragel"
 	{
         ++n_columns;
     }
@@ -13097,7 +13097,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13101 "inc/vcf/validator_detail_v43.hpp"
+#line 13101 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr858;
 	if ( (*p) < 48 ) {
@@ -13110,17 +13110,17 @@ case 597:
 		goto tr859;
 	goto tr856;
 tr857:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st598;
 tr861:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13129,7 +13129,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13133 "inc/vcf/validator_detail_v43.hpp"
+#line 13133 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13140,28 +13140,28 @@ case 598:
 		goto tr861;
 	goto tr860;
 tr849:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 210 "src/vcf/vcf_v43.ragel"
+#line 210 "../src/vcf/vcf_v43.ragel"
 	{
         try {
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                 ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -13171,7 +13171,7 @@ tr849:
             ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13186,7 +13186,7 @@ st802:
 	if ( ++p == pe )
 		goto _test_eof802;
 case 802:
-#line 13190 "inc/vcf/validator_detail_v43.hpp"
+#line 13190 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1083;
 		case 13: goto tr1084;
@@ -13211,7 +13211,7 @@ case 802:
 		goto tr1085;
 	goto tr789;
 tr1082:
-#line 70 "src/vcf/vcf_v43.ragel"
+#line 70 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -13224,7 +13224,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13228 "inc/vcf/validator_detail_v43.hpp"
+#line 13228 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr863;
 		case 59: goto tr863;
@@ -13246,17 +13246,17 @@ case 599:
 		goto tr863;
 	goto tr789;
 tr863:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st600;
 tr864:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13265,7 +13265,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13269 "inc/vcf/validator_detail_v43.hpp"
+#line 13269 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr864;
 		case 59: goto tr864;
@@ -13285,7 +13285,7 @@ case 600:
 		goto tr864;
 	goto tr789;
 tr865:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -13294,33 +13294,33 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13298 "inc/vcf/validator_detail_v43.hpp"
+#line 13298 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr866;
 	goto tr789;
 tr850:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
-#line 206 "src/vcf/vcf_v43.ragel"
+#line 206 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 210 "src/vcf/vcf_v43.ragel"
+#line 210 "../src/vcf/vcf_v43.ragel"
 	{
         try {
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                 ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {
@@ -13330,7 +13330,7 @@ tr850:
             ErrorPolicy::handle_error(*this, error);
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -13345,12 +13345,12 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13349 "inc/vcf/validator_detail_v43.hpp"
+#line 13349 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st802;
 	goto tr867;
 tr862:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13359,7 +13359,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13363 "inc/vcf/validator_detail_v43.hpp"
+#line 13363 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr861;
@@ -13367,17 +13367,17 @@ case 603:
 		goto tr861;
 	goto tr860;
 tr858:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st604;
 tr870:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13386,7 +13386,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13390 "inc/vcf/validator_detail_v43.hpp"
+#line 13390 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13399,7 +13399,7 @@ case 604:
 		goto tr861;
 	goto tr856;
 tr869:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13408,7 +13408,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13412 "inc/vcf/validator_detail_v43.hpp"
+#line 13412 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13426,17 +13426,17 @@ case 605:
 		goto tr871;
 	goto tr856;
 tr859:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st606;
 tr871:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13445,7 +13445,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13449 "inc/vcf/validator_detail_v43.hpp"
+#line 13449 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13464,17 +13464,17 @@ case 606:
 		goto tr871;
 	goto tr856;
 tr835:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st607;
 tr872:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13483,7 +13483,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13487 "inc/vcf/validator_detail_v43.hpp"
+#line 13487 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13503,7 +13503,7 @@ case 607:
 		goto tr872;
 	goto tr833;
 tr873:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -13512,7 +13512,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13516 "inc/vcf/validator_detail_v43.hpp"
+#line 13516 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 49: goto tr836;
 		case 65: goto tr837;
@@ -13537,11 +13537,11 @@ case 608:
 		goto tr835;
 	goto tr833;
 tr836:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13550,7 +13550,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13554 "inc/vcf/validator_detail_v43.hpp"
+#line 13554 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13571,7 +13571,7 @@ case 609:
 		goto tr872;
 	goto tr833;
 tr875:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13580,7 +13580,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13584 "inc/vcf/validator_detail_v43.hpp"
+#line 13584 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13601,7 +13601,7 @@ case 610:
 		goto tr872;
 	goto tr833;
 tr876:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13610,7 +13610,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13614 "inc/vcf/validator_detail_v43.hpp"
+#line 13614 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13631,7 +13631,7 @@ case 611:
 		goto tr872;
 	goto tr833;
 tr877:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13640,7 +13640,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13644 "inc/vcf/validator_detail_v43.hpp"
+#line 13644 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13661,7 +13661,7 @@ case 612:
 		goto tr872;
 	goto tr833;
 tr874:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13670,7 +13670,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13674 "inc/vcf/validator_detail_v43.hpp"
+#line 13674 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr880;
@@ -13678,7 +13678,7 @@ case 613:
 		goto tr880;
 	goto tr879;
 tr880:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13687,7 +13687,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13691 "inc/vcf/validator_detail_v43.hpp"
+#line 13691 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13698,7 +13698,7 @@ case 614:
 		goto tr880;
 	goto tr879;
 tr878:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13707,7 +13707,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13711 "inc/vcf/validator_detail_v43.hpp"
+#line 13711 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13727,7 +13727,7 @@ case 615:
 		goto tr872;
 	goto tr881;
 tr882:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13736,12 +13736,12 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13740 "inc/vcf/validator_detail_v43.hpp"
+#line 13740 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr884;
 	goto tr883;
 tr884:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13750,7 +13750,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13754 "inc/vcf/validator_detail_v43.hpp"
+#line 13754 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13759,11 +13759,11 @@ case 617:
 	}
 	goto tr883;
 tr837:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13772,7 +13772,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13776 "inc/vcf/validator_detail_v43.hpp"
+#line 13776 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13797,7 +13797,7 @@ case 618:
 		goto tr872;
 	goto tr833;
 tr885:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13806,7 +13806,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13810 "inc/vcf/validator_detail_v43.hpp"
+#line 13810 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr890;
@@ -13822,7 +13822,7 @@ case 619:
 		goto tr872;
 	goto tr833;
 tr890:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13831,7 +13831,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13835 "inc/vcf/validator_detail_v43.hpp"
+#line 13835 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr892;
 	if ( (*p) < 45 ) {
@@ -13844,7 +13844,7 @@ case 620:
 		goto tr892;
 	goto tr891;
 tr892:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13853,7 +13853,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13857 "inc/vcf/validator_detail_v43.hpp"
+#line 13857 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13870,7 +13870,7 @@ case 621:
 		goto tr892;
 	goto tr891;
 tr886:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13879,7 +13879,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13883 "inc/vcf/validator_detail_v43.hpp"
+#line 13883 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr893;
@@ -13895,7 +13895,7 @@ case 622:
 		goto tr872;
 	goto tr833;
 tr893:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13904,12 +13904,12 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13908 "inc/vcf/validator_detail_v43.hpp"
+#line 13908 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr895;
 	goto tr894;
 tr895:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13918,7 +13918,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13922 "inc/vcf/validator_detail_v43.hpp"
+#line 13922 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13930,7 +13930,7 @@ case 624:
 		goto tr895;
 	goto tr894;
 tr887:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13939,7 +13939,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13943 "inc/vcf/validator_detail_v43.hpp"
+#line 13943 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr896;
@@ -13957,7 +13957,7 @@ case 625:
 		goto tr872;
 	goto tr833;
 tr896:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13966,12 +13966,12 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13970 "inc/vcf/validator_detail_v43.hpp"
+#line 13970 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr900;
 	goto tr899;
 tr900:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -13980,7 +13980,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13984 "inc/vcf/validator_detail_v43.hpp"
+#line 13984 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13992,7 +13992,7 @@ case 627:
 		goto tr900;
 	goto tr899;
 tr897:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14001,7 +14001,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 14005 "inc/vcf/validator_detail_v43.hpp"
+#line 14005 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr901;
@@ -14017,7 +14017,7 @@ case 628:
 		goto tr872;
 	goto tr833;
 tr901:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14026,12 +14026,12 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 14030 "inc/vcf/validator_detail_v43.hpp"
+#line 14030 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr903;
 	goto tr902;
 tr903:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14040,7 +14040,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 14044 "inc/vcf/validator_detail_v43.hpp"
+#line 14044 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14052,7 +14052,7 @@ case 630:
 		goto tr903;
 	goto tr902;
 tr898:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14061,7 +14061,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 14065 "inc/vcf/validator_detail_v43.hpp"
+#line 14065 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr904;
@@ -14077,7 +14077,7 @@ case 631:
 		goto tr872;
 	goto tr833;
 tr904:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14086,12 +14086,12 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 14090 "inc/vcf/validator_detail_v43.hpp"
+#line 14090 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr906;
 	goto tr905;
 tr906:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14100,7 +14100,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 14104 "inc/vcf/validator_detail_v43.hpp"
+#line 14104 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14112,7 +14112,7 @@ case 633:
 		goto tr906;
 	goto tr905;
 tr888:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14121,7 +14121,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 14125 "inc/vcf/validator_detail_v43.hpp"
+#line 14125 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr907;
@@ -14137,7 +14137,7 @@ case 634:
 		goto tr872;
 	goto tr833;
 tr907:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14146,7 +14146,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 14150 "inc/vcf/validator_detail_v43.hpp"
+#line 14150 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr909;
 		case 45: goto tr909;
@@ -14157,7 +14157,7 @@ case 635:
 		goto tr910;
 	goto tr908;
 tr909:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14166,14 +14166,14 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 14170 "inc/vcf/validator_detail_v43.hpp"
+#line 14170 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr911;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr910;
 	goto tr908;
 tr910:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14182,7 +14182,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14186 "inc/vcf/validator_detail_v43.hpp"
+#line 14186 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14197,7 +14197,7 @@ case 637:
 		goto tr910;
 	goto tr908;
 tr913:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14206,12 +14206,12 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14210 "inc/vcf/validator_detail_v43.hpp"
+#line 14210 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr915;
 	goto tr908;
 tr915:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14220,7 +14220,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14224 "inc/vcf/validator_detail_v43.hpp"
+#line 14224 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14234,7 +14234,7 @@ case 639:
 		goto tr915;
 	goto tr908;
 tr914:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14243,7 +14243,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14247 "inc/vcf/validator_detail_v43.hpp"
+#line 14247 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr916;
 		case 45: goto tr916;
@@ -14252,7 +14252,7 @@ case 640:
 		goto tr917;
 	goto tr908;
 tr916:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14261,12 +14261,12 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14265 "inc/vcf/validator_detail_v43.hpp"
+#line 14265 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr917;
 	goto tr908;
 tr917:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14275,7 +14275,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14279 "inc/vcf/validator_detail_v43.hpp"
+#line 14279 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14287,7 +14287,7 @@ case 642:
 		goto tr917;
 	goto tr908;
 tr911:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14296,12 +14296,12 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14300 "inc/vcf/validator_detail_v43.hpp"
+#line 14300 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr918;
 	goto tr908;
 tr918:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14310,12 +14310,12 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14314 "inc/vcf/validator_detail_v43.hpp"
+#line 14314 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr919;
 	goto tr908;
 tr919:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14324,7 +14324,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14328 "inc/vcf/validator_detail_v43.hpp"
+#line 14328 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14334,7 +14334,7 @@ case 645:
 	}
 	goto tr908;
 tr912:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14343,12 +14343,12 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14347 "inc/vcf/validator_detail_v43.hpp"
+#line 14347 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr920;
 	goto tr908;
 tr920:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14357,12 +14357,12 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14361 "inc/vcf/validator_detail_v43.hpp"
+#line 14361 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr919;
 	goto tr908;
 tr889:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14371,7 +14371,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14375 "inc/vcf/validator_detail_v43.hpp"
+#line 14375 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr921;
@@ -14387,7 +14387,7 @@ case 648:
 		goto tr872;
 	goto tr833;
 tr921:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14396,12 +14396,12 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14400 "inc/vcf/validator_detail_v43.hpp"
+#line 14400 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr923;
 	goto tr922;
 tr923:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14410,7 +14410,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14414 "inc/vcf/validator_detail_v43.hpp"
+#line 14414 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14421,11 +14421,11 @@ case 650:
 		goto tr923;
 	goto tr922;
 tr838:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14434,7 +14434,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14438 "inc/vcf/validator_detail_v43.hpp"
+#line 14438 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14455,7 +14455,7 @@ case 651:
 		goto tr872;
 	goto tr833;
 tr924:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14464,7 +14464,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14468 "inc/vcf/validator_detail_v43.hpp"
+#line 14468 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr925;
@@ -14480,7 +14480,7 @@ case 652:
 		goto tr872;
 	goto tr833;
 tr925:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14489,7 +14489,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14493 "inc/vcf/validator_detail_v43.hpp"
+#line 14493 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr927;
 		case 45: goto tr927;
@@ -14500,7 +14500,7 @@ case 653:
 		goto tr928;
 	goto tr926;
 tr927:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14509,14 +14509,14 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14513 "inc/vcf/validator_detail_v43.hpp"
+#line 14513 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr929;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr928;
 	goto tr926;
 tr928:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14525,7 +14525,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14529 "inc/vcf/validator_detail_v43.hpp"
+#line 14529 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14539,7 +14539,7 @@ case 655:
 		goto tr928;
 	goto tr926;
 tr931:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14548,12 +14548,12 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14552 "inc/vcf/validator_detail_v43.hpp"
+#line 14552 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr926;
 tr933:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14562,7 +14562,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14566 "inc/vcf/validator_detail_v43.hpp"
+#line 14566 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14575,7 +14575,7 @@ case 657:
 		goto tr933;
 	goto tr926;
 tr932:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14584,7 +14584,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14588 "inc/vcf/validator_detail_v43.hpp"
+#line 14588 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr934;
 		case 45: goto tr934;
@@ -14593,7 +14593,7 @@ case 658:
 		goto tr935;
 	goto tr926;
 tr934:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14602,12 +14602,12 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14606 "inc/vcf/validator_detail_v43.hpp"
+#line 14606 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr935;
 	goto tr926;
 tr935:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14616,7 +14616,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14620 "inc/vcf/validator_detail_v43.hpp"
+#line 14620 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14627,7 +14627,7 @@ case 660:
 		goto tr935;
 	goto tr926;
 tr929:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14636,12 +14636,12 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14640 "inc/vcf/validator_detail_v43.hpp"
+#line 14640 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr936;
 	goto tr926;
 tr936:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14650,12 +14650,12 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14654 "inc/vcf/validator_detail_v43.hpp"
+#line 14654 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr937;
 	goto tr926;
 tr937:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14664,7 +14664,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14668 "inc/vcf/validator_detail_v43.hpp"
+#line 14668 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14673,7 +14673,7 @@ case 663:
 	}
 	goto tr926;
 tr930:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14682,12 +14682,12 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14686 "inc/vcf/validator_detail_v43.hpp"
+#line 14686 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr938;
 	goto tr926;
 tr938:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14696,16 +14696,16 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14700 "inc/vcf/validator_detail_v43.hpp"
+#line 14700 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr937;
 	goto tr926;
 tr839:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14714,7 +14714,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14718 "inc/vcf/validator_detail_v43.hpp"
+#line 14718 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14735,7 +14735,7 @@ case 666:
 		goto tr872;
 	goto tr833;
 tr939:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14744,7 +14744,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14748 "inc/vcf/validator_detail_v43.hpp"
+#line 14748 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14765,7 +14765,7 @@ case 667:
 		goto tr872;
 	goto tr833;
 tr940:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14774,7 +14774,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14778 "inc/vcf/validator_detail_v43.hpp"
+#line 14778 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14795,7 +14795,7 @@ case 668:
 		goto tr872;
 	goto tr833;
 tr941:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14804,7 +14804,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14808 "inc/vcf/validator_detail_v43.hpp"
+#line 14808 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14825,7 +14825,7 @@ case 669:
 		goto tr872;
 	goto tr833;
 tr942:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14834,7 +14834,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14838 "inc/vcf/validator_detail_v43.hpp"
+#line 14838 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr943;
@@ -14850,7 +14850,7 @@ case 670:
 		goto tr872;
 	goto tr833;
 tr943:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14859,12 +14859,12 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14863 "inc/vcf/validator_detail_v43.hpp"
+#line 14863 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr945;
 	goto tr944;
 tr945:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14873,7 +14873,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14877 "inc/vcf/validator_detail_v43.hpp"
+#line 14877 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 68: goto tr946;
 		case 80: goto tr946;
@@ -14890,7 +14890,7 @@ case 672:
 		goto tr946;
 	goto tr944;
 tr946:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14899,7 +14899,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14903 "inc/vcf/validator_detail_v43.hpp"
+#line 14903 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14910,11 +14910,11 @@ case 673:
 		goto tr945;
 	goto tr944;
 tr840:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14923,7 +14923,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14927 "inc/vcf/validator_detail_v43.hpp"
+#line 14927 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14945,7 +14945,7 @@ case 674:
 		goto tr872;
 	goto tr833;
 tr947:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14954,7 +14954,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14958 "inc/vcf/validator_detail_v43.hpp"
+#line 14958 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14974,7 +14974,7 @@ case 675:
 		goto tr872;
 	goto tr949;
 tr950:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14983,12 +14983,12 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14987 "inc/vcf/validator_detail_v43.hpp"
+#line 14987 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr952;
 	goto tr951;
 tr952:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -14997,7 +14997,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 15001 "inc/vcf/validator_detail_v43.hpp"
+#line 15001 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15006,7 +15006,7 @@ case 677:
 	}
 	goto tr951;
 tr948:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15015,7 +15015,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 15019 "inc/vcf/validator_detail_v43.hpp"
+#line 15019 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr953;
@@ -15031,7 +15031,7 @@ case 678:
 		goto tr872;
 	goto tr833;
 tr953:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15040,12 +15040,12 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 15044 "inc/vcf/validator_detail_v43.hpp"
+#line 15044 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr955;
 	goto tr954;
 tr955:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15054,7 +15054,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 15058 "inc/vcf/validator_detail_v43.hpp"
+#line 15058 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15065,11 +15065,11 @@ case 680:
 		goto tr955;
 	goto tr954;
 tr841:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15078,7 +15078,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 15082 "inc/vcf/validator_detail_v43.hpp"
+#line 15082 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15099,7 +15099,7 @@ case 681:
 		goto tr872;
 	goto tr833;
 tr956:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15108,7 +15108,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 15112 "inc/vcf/validator_detail_v43.hpp"
+#line 15112 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15129,7 +15129,7 @@ case 682:
 		goto tr872;
 	goto tr833;
 tr957:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15138,7 +15138,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 15142 "inc/vcf/validator_detail_v43.hpp"
+#line 15142 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr958;
@@ -15154,7 +15154,7 @@ case 683:
 		goto tr872;
 	goto tr833;
 tr958:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15163,12 +15163,12 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 15167 "inc/vcf/validator_detail_v43.hpp"
+#line 15167 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr960;
 	goto tr959;
 tr960:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15177,7 +15177,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 15181 "inc/vcf/validator_detail_v43.hpp"
+#line 15181 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15188,11 +15188,11 @@ case 685:
 		goto tr960;
 	goto tr959;
 tr842:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15201,7 +15201,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15205 "inc/vcf/validator_detail_v43.hpp"
+#line 15205 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15223,7 +15223,7 @@ case 686:
 		goto tr872;
 	goto tr833;
 tr961:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15232,7 +15232,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15236 "inc/vcf/validator_detail_v43.hpp"
+#line 15236 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15252,7 +15252,7 @@ case 687:
 		goto tr872;
 	goto tr963;
 tr964:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15261,12 +15261,12 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15265 "inc/vcf/validator_detail_v43.hpp"
+#line 15265 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr966;
 	goto tr965;
 tr966:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15275,7 +15275,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15279 "inc/vcf/validator_detail_v43.hpp"
+#line 15279 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15284,7 +15284,7 @@ case 689:
 	}
 	goto tr965;
 tr962:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15293,7 +15293,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15297 "inc/vcf/validator_detail_v43.hpp"
+#line 15297 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15313,7 +15313,7 @@ case 690:
 		goto tr872;
 	goto tr967;
 tr968:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15322,12 +15322,12 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15326 "inc/vcf/validator_detail_v43.hpp"
+#line 15326 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr970;
 	goto tr969;
 tr970:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15336,7 +15336,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15340 "inc/vcf/validator_detail_v43.hpp"
+#line 15340 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15345,11 +15345,11 @@ case 692:
 	}
 	goto tr969;
 tr843:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15358,7 +15358,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15362 "inc/vcf/validator_detail_v43.hpp"
+#line 15362 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15379,7 +15379,7 @@ case 693:
 		goto tr872;
 	goto tr833;
 tr971:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15388,7 +15388,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15392 "inc/vcf/validator_detail_v43.hpp"
+#line 15392 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 48: goto tr972;
@@ -15405,7 +15405,7 @@ case 694:
 		goto tr872;
 	goto tr833;
 tr972:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15414,7 +15414,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15418 "inc/vcf/validator_detail_v43.hpp"
+#line 15418 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr974;
@@ -15430,7 +15430,7 @@ case 695:
 		goto tr872;
 	goto tr833;
 tr974:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15439,12 +15439,12 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15443 "inc/vcf/validator_detail_v43.hpp"
+#line 15443 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr976;
 	goto tr975;
 tr976:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15453,7 +15453,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15457 "inc/vcf/validator_detail_v43.hpp"
+#line 15457 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15464,7 +15464,7 @@ case 697:
 		goto tr976;
 	goto tr975;
 tr973:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15473,7 +15473,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15477 "inc/vcf/validator_detail_v43.hpp"
+#line 15477 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr978;
 		case 45: goto tr978;
@@ -15484,7 +15484,7 @@ case 698:
 		goto tr979;
 	goto tr977;
 tr978:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15493,14 +15493,14 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15497 "inc/vcf/validator_detail_v43.hpp"
+#line 15497 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr980;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr979;
 	goto tr977;
 tr979:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15509,7 +15509,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15513 "inc/vcf/validator_detail_v43.hpp"
+#line 15513 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15523,7 +15523,7 @@ case 700:
 		goto tr979;
 	goto tr977;
 tr982:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15532,12 +15532,12 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15536 "inc/vcf/validator_detail_v43.hpp"
+#line 15536 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr984;
 	goto tr977;
 tr984:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15546,7 +15546,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15550 "inc/vcf/validator_detail_v43.hpp"
+#line 15550 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15559,7 +15559,7 @@ case 702:
 		goto tr984;
 	goto tr977;
 tr983:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15568,7 +15568,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15572 "inc/vcf/validator_detail_v43.hpp"
+#line 15572 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr985;
 		case 45: goto tr985;
@@ -15577,7 +15577,7 @@ case 703:
 		goto tr986;
 	goto tr977;
 tr985:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15586,12 +15586,12 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15590 "inc/vcf/validator_detail_v43.hpp"
+#line 15590 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr986;
 	goto tr977;
 tr986:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15600,7 +15600,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15604 "inc/vcf/validator_detail_v43.hpp"
+#line 15604 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15611,7 +15611,7 @@ case 705:
 		goto tr986;
 	goto tr977;
 tr980:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15620,12 +15620,12 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15624 "inc/vcf/validator_detail_v43.hpp"
+#line 15624 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr987;
 	goto tr977;
 tr987:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15634,12 +15634,12 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15638 "inc/vcf/validator_detail_v43.hpp"
+#line 15638 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr988;
 	goto tr977;
 tr988:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15648,7 +15648,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15652 "inc/vcf/validator_detail_v43.hpp"
+#line 15652 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15657,7 +15657,7 @@ case 708:
 	}
 	goto tr977;
 tr981:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15666,12 +15666,12 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15670 "inc/vcf/validator_detail_v43.hpp"
+#line 15670 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr989;
 	goto tr977;
 tr989:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15680,16 +15680,16 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15684 "inc/vcf/validator_detail_v43.hpp"
+#line 15684 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr988;
 	goto tr977;
 tr844:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15698,7 +15698,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15702 "inc/vcf/validator_detail_v43.hpp"
+#line 15702 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15719,7 +15719,7 @@ case 711:
 		goto tr872;
 	goto tr833;
 tr990:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15728,7 +15728,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15732 "inc/vcf/validator_detail_v43.hpp"
+#line 15732 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr991;
@@ -15744,7 +15744,7 @@ case 712:
 		goto tr872;
 	goto tr833;
 tr991:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15753,12 +15753,12 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15757 "inc/vcf/validator_detail_v43.hpp"
+#line 15757 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr993;
 	goto tr992;
 tr993:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15767,7 +15767,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15771 "inc/vcf/validator_detail_v43.hpp"
+#line 15771 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15778,11 +15778,11 @@ case 714:
 		goto tr993;
 	goto tr992;
 tr845:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15791,7 +15791,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15795 "inc/vcf/validator_detail_v43.hpp"
+#line 15795 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15813,7 +15813,7 @@ case 715:
 		goto tr872;
 	goto tr833;
 tr994:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15822,7 +15822,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15826 "inc/vcf/validator_detail_v43.hpp"
+#line 15826 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr996;
@@ -15838,7 +15838,7 @@ case 716:
 		goto tr872;
 	goto tr833;
 tr996:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15847,7 +15847,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15851 "inc/vcf/validator_detail_v43.hpp"
+#line 15851 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr998;
 		case 45: goto tr998;
@@ -15858,7 +15858,7 @@ case 717:
 		goto tr999;
 	goto tr997;
 tr998:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15867,14 +15867,14 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15871 "inc/vcf/validator_detail_v43.hpp"
+#line 15871 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr1000;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr999;
 	goto tr997;
 tr999:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15883,7 +15883,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15887 "inc/vcf/validator_detail_v43.hpp"
+#line 15887 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15897,7 +15897,7 @@ case 719:
 		goto tr999;
 	goto tr997;
 tr1002:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15906,12 +15906,12 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15910 "inc/vcf/validator_detail_v43.hpp"
+#line 15910 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1004;
 	goto tr997;
 tr1004:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15920,7 +15920,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15924 "inc/vcf/validator_detail_v43.hpp"
+#line 15924 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15933,7 +15933,7 @@ case 721:
 		goto tr1004;
 	goto tr997;
 tr1003:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15942,7 +15942,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15946 "inc/vcf/validator_detail_v43.hpp"
+#line 15946 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1005;
 		case 45: goto tr1005;
@@ -15951,7 +15951,7 @@ case 722:
 		goto tr1006;
 	goto tr997;
 tr1005:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15960,12 +15960,12 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15964 "inc/vcf/validator_detail_v43.hpp"
+#line 15964 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1006;
 	goto tr997;
 tr1006:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15974,7 +15974,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15978 "inc/vcf/validator_detail_v43.hpp"
+#line 15978 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15985,7 +15985,7 @@ case 724:
 		goto tr1006;
 	goto tr997;
 tr1000:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -15994,12 +15994,12 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 15998 "inc/vcf/validator_detail_v43.hpp"
+#line 15998 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr1007;
 	goto tr997;
 tr1007:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16008,12 +16008,12 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 16012 "inc/vcf/validator_detail_v43.hpp"
+#line 16012 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr1008;
 	goto tr997;
 tr1008:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16022,7 +16022,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 16026 "inc/vcf/validator_detail_v43.hpp"
+#line 16026 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16031,7 +16031,7 @@ case 727:
 	}
 	goto tr997;
 tr1001:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16040,12 +16040,12 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 16044 "inc/vcf/validator_detail_v43.hpp"
+#line 16044 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr1009;
 	goto tr997;
 tr1009:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16054,12 +16054,12 @@ st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 16058 "inc/vcf/validator_detail_v43.hpp"
+#line 16058 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr1008;
 	goto tr997;
 tr995:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16068,7 +16068,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 16072 "inc/vcf/validator_detail_v43.hpp"
+#line 16072 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16089,7 +16089,7 @@ case 730:
 		goto tr872;
 	goto tr833;
 tr1010:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16098,7 +16098,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 16102 "inc/vcf/validator_detail_v43.hpp"
+#line 16102 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16119,7 +16119,7 @@ case 731:
 		goto tr872;
 	goto tr833;
 tr1011:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16128,7 +16128,7 @@ st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 16132 "inc/vcf/validator_detail_v43.hpp"
+#line 16132 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16149,7 +16149,7 @@ case 732:
 		goto tr872;
 	goto tr833;
 tr1012:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16158,7 +16158,7 @@ st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 16162 "inc/vcf/validator_detail_v43.hpp"
+#line 16162 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16179,7 +16179,7 @@ case 733:
 		goto tr872;
 	goto tr833;
 tr1013:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16188,7 +16188,7 @@ st734:
 	if ( ++p == pe )
 		goto _test_eof734;
 case 734:
-#line 16192 "inc/vcf/validator_detail_v43.hpp"
+#line 16192 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16209,7 +16209,7 @@ case 734:
 		goto tr872;
 	goto tr833;
 tr1014:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16218,7 +16218,7 @@ st735:
 	if ( ++p == pe )
 		goto _test_eof735;
 case 735:
-#line 16222 "inc/vcf/validator_detail_v43.hpp"
+#line 16222 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16238,7 +16238,7 @@ case 735:
 		goto tr872;
 	goto tr1015;
 tr1016:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16247,12 +16247,12 @@ st736:
 	if ( ++p == pe )
 		goto _test_eof736;
 case 736:
-#line 16251 "inc/vcf/validator_detail_v43.hpp"
+#line 16251 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr1018;
 	goto tr1017;
 tr1018:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16261,7 +16261,7 @@ st737:
 	if ( ++p == pe )
 		goto _test_eof737;
 case 737:
-#line 16265 "inc/vcf/validator_detail_v43.hpp"
+#line 16265 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16270,11 +16270,11 @@ case 737:
 	}
 	goto tr1017;
 tr846:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16283,7 +16283,7 @@ st738:
 	if ( ++p == pe )
 		goto _test_eof738;
 case 738:
-#line 16287 "inc/vcf/validator_detail_v43.hpp"
+#line 16287 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16304,7 +16304,7 @@ case 738:
 		goto tr872;
 	goto tr833;
 tr1019:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16313,7 +16313,7 @@ st739:
 	if ( ++p == pe )
 		goto _test_eof739;
 case 739:
-#line 16317 "inc/vcf/validator_detail_v43.hpp"
+#line 16317 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16334,7 +16334,7 @@ case 739:
 		goto tr872;
 	goto tr833;
 tr1020:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16343,7 +16343,7 @@ st740:
 	if ( ++p == pe )
 		goto _test_eof740;
 case 740:
-#line 16347 "inc/vcf/validator_detail_v43.hpp"
+#line 16347 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16364,7 +16364,7 @@ case 740:
 		goto tr872;
 	goto tr833;
 tr1021:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16373,7 +16373,7 @@ st741:
 	if ( ++p == pe )
 		goto _test_eof741;
 case 741:
-#line 16377 "inc/vcf/validator_detail_v43.hpp"
+#line 16377 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16394,7 +16394,7 @@ case 741:
 		goto tr872;
 	goto tr833;
 tr1022:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16403,7 +16403,7 @@ st742:
 	if ( ++p == pe )
 		goto _test_eof742;
 case 742:
-#line 16407 "inc/vcf/validator_detail_v43.hpp"
+#line 16407 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16424,7 +16424,7 @@ case 742:
 		goto tr872;
 	goto tr833;
 tr1023:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16433,7 +16433,7 @@ st743:
 	if ( ++p == pe )
 		goto _test_eof743;
 case 743:
-#line 16437 "inc/vcf/validator_detail_v43.hpp"
+#line 16437 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16454,7 +16454,7 @@ case 743:
 		goto tr872;
 	goto tr833;
 tr1024:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16463,7 +16463,7 @@ st744:
 	if ( ++p == pe )
 		goto _test_eof744;
 case 744:
-#line 16467 "inc/vcf/validator_detail_v43.hpp"
+#line 16467 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16484,7 +16484,7 @@ case 744:
 		goto tr872;
 	goto tr833;
 tr1025:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16493,7 +16493,7 @@ st745:
 	if ( ++p == pe )
 		goto _test_eof745;
 case 745:
-#line 16497 "inc/vcf/validator_detail_v43.hpp"
+#line 16497 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16514,7 +16514,7 @@ case 745:
 		goto tr872;
 	goto tr833;
 tr1026:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16523,7 +16523,7 @@ st746:
 	if ( ++p == pe )
 		goto _test_eof746;
 case 746:
-#line 16527 "inc/vcf/validator_detail_v43.hpp"
+#line 16527 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16543,7 +16543,7 @@ case 746:
 		goto tr872;
 	goto tr1027;
 tr1028:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16552,12 +16552,12 @@ st747:
 	if ( ++p == pe )
 		goto _test_eof747;
 case 747:
-#line 16556 "inc/vcf/validator_detail_v43.hpp"
+#line 16556 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr1030;
 	goto tr1029;
 tr1030:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16566,7 +16566,7 @@ st748:
 	if ( ++p == pe )
 		goto _test_eof748;
 case 748:
-#line 16570 "inc/vcf/validator_detail_v43.hpp"
+#line 16570 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16575,7 +16575,7 @@ case 748:
 	}
 	goto tr1029;
 tr832:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -16584,7 +16584,7 @@ st749:
 	if ( ++p == pe )
 		goto _test_eof749;
 case 749:
-#line 16588 "inc/vcf/validator_detail_v43.hpp"
+#line 16588 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr826;
 	if ( (*p) < 65 ) {
@@ -16609,11 +16609,11 @@ case 749:
 		goto tr828;
 	goto tr825;
 tr827:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16622,7 +16622,7 @@ st750:
 	if ( ++p == pe )
 		goto _test_eof750;
 case 750:
-#line 16626 "inc/vcf/validator_detail_v43.hpp"
+#line 16626 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 58: goto st591;
@@ -16649,7 +16649,7 @@ case 750:
 		goto tr830;
 	goto tr825;
 tr823:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16658,12 +16658,12 @@ st751:
 	if ( ++p == pe )
 		goto _test_eof751;
 case 751:
-#line 16662 "inc/vcf/validator_detail_v43.hpp"
+#line 16662 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1031;
 	goto tr814;
 tr1031:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16672,7 +16672,7 @@ st752:
 	if ( ++p == pe )
 		goto _test_eof752;
 case 752:
-#line 16676 "inc/vcf/validator_detail_v43.hpp"
+#line 16676 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 69: goto tr824;
@@ -16682,7 +16682,7 @@ case 752:
 		goto tr1031;
 	goto tr814;
 tr824:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16691,7 +16691,7 @@ st753:
 	if ( ++p == pe )
 		goto _test_eof753;
 case 753:
-#line 16695 "inc/vcf/validator_detail_v43.hpp"
+#line 16695 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1032;
 		case 45: goto tr1032;
@@ -16700,7 +16700,7 @@ case 753:
 		goto tr1033;
 	goto tr814;
 tr1032:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16709,12 +16709,12 @@ st754:
 	if ( ++p == pe )
 		goto _test_eof754;
 case 754:
-#line 16713 "inc/vcf/validator_detail_v43.hpp"
+#line 16713 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1033;
 	goto tr814;
 tr1033:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16723,24 +16723,24 @@ st755:
 	if ( ++p == pe )
 		goto _test_eof755;
 case 755:
-#line 16727 "inc/vcf/validator_detail_v43.hpp"
+#line 16727 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1033;
 	goto tr814;
 tr818:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st756;
 tr821:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16749,12 +16749,12 @@ st756:
 	if ( ++p == pe )
 		goto _test_eof756;
 case 756:
-#line 16753 "inc/vcf/validator_detail_v43.hpp"
+#line 16753 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr1034;
 	goto tr814;
 tr1034:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16763,22 +16763,22 @@ st757:
 	if ( ++p == pe )
 		goto _test_eof757;
 case 757:
-#line 16767 "inc/vcf/validator_detail_v43.hpp"
+#line 16767 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr1035;
 	goto tr814;
 tr816:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st758;
 tr1035:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16787,16 +16787,16 @@ st758:
 	if ( ++p == pe )
 		goto _test_eof758;
 case 758:
-#line 16791 "inc/vcf/validator_detail_v43.hpp"
+#line 16791 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	goto tr814;
 tr819:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16805,12 +16805,12 @@ st759:
 	if ( ++p == pe )
 		goto _test_eof759;
 case 759:
-#line 16809 "inc/vcf/validator_detail_v43.hpp"
+#line 16809 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr1036;
 	goto tr814;
 tr1036:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16819,12 +16819,12 @@ st760:
 	if ( ++p == pe )
 		goto _test_eof760;
 case 760:
-#line 16823 "inc/vcf/validator_detail_v43.hpp"
+#line 16823 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr1035;
 	goto tr814;
 tr813:
-#line 39 "src/vcf/vcf_v43.ragel"
+#line 39 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_end(*this);
     }
@@ -16833,7 +16833,7 @@ st761:
 	if ( ++p == pe )
 		goto _test_eof761;
 case 761:
-#line 16837 "inc/vcf/validator_detail_v43.hpp"
+#line 16837 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr1037;
@@ -16853,17 +16853,17 @@ case 761:
 	}
 	goto tr805;
 tr1037:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st762;
 tr1061:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16872,7 +16872,7 @@ st762:
 	if ( ++p == pe )
 		goto _test_eof762;
 case 762:
-#line 16876 "inc/vcf/validator_detail_v43.hpp"
+#line 16876 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr1038;
 		case 67: goto tr1038;
@@ -16887,7 +16887,7 @@ case 762:
 	}
 	goto tr805;
 tr1038:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16896,7 +16896,7 @@ st763:
 	if ( ++p == pe )
 		goto _test_eof763;
 case 763:
-#line 16900 "inc/vcf/validator_detail_v43.hpp"
+#line 16900 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -16913,17 +16913,17 @@ case 763:
 	}
 	goto tr805;
 tr808:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st764;
 tr1039:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16932,7 +16932,7 @@ st764:
 	if ( ++p == pe )
 		goto _test_eof764;
 case 764:
-#line 16936 "inc/vcf/validator_detail_v43.hpp"
+#line 16936 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr1039;
 	if ( (*p) < 63 ) {
@@ -16963,7 +16963,7 @@ case 764:
 		goto tr1039;
 	goto tr805;
 tr1040:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -16972,7 +16972,7 @@ st765:
 	if ( ++p == pe )
 		goto _test_eof765;
 case 765:
-#line 16976 "inc/vcf/validator_detail_v43.hpp"
+#line 16976 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto tr1041;
 	if ( (*p) < 45 ) {
@@ -16985,17 +16985,17 @@ case 765:
 		goto tr1040;
 	goto tr805;
 tr809:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
 	goto st766;
 tr1042:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17004,7 +17004,7 @@ st766:
 	if ( ++p == pe )
 		goto _test_eof766;
 case 766:
-#line 17008 "inc/vcf/validator_detail_v43.hpp"
+#line 17008 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -17024,7 +17024,7 @@ case 766:
 	}
 	goto tr805;
 tr1043:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17033,7 +17033,7 @@ st767:
 	if ( ++p == pe )
 		goto _test_eof767;
 case 767:
-#line 17037 "inc/vcf/validator_detail_v43.hpp"
+#line 17037 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1045;
 		case 59: goto tr1045;
@@ -17056,7 +17056,7 @@ case 767:
 		goto tr1045;
 	goto tr805;
 tr1045:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17065,7 +17065,7 @@ st768:
 	if ( ++p == pe )
 		goto _test_eof768;
 case 768:
-#line 17069 "inc/vcf/validator_detail_v43.hpp"
+#line 17069 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1045;
 		case 58: goto tr1047;
@@ -17084,7 +17084,7 @@ case 768:
 		goto tr1045;
 	goto tr805;
 tr1047:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17093,12 +17093,12 @@ st769:
 	if ( ++p == pe )
 		goto _test_eof769;
 case 769:
-#line 17097 "inc/vcf/validator_detail_v43.hpp"
+#line 17097 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1048;
 	goto tr805;
 tr1048:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17107,14 +17107,14 @@ st770:
 	if ( ++p == pe )
 		goto _test_eof770;
 case 770:
-#line 17111 "inc/vcf/validator_detail_v43.hpp"
+#line 17111 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr1041;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1048;
 	goto tr805;
 tr1046:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17123,7 +17123,7 @@ st771:
 	if ( ++p == pe )
 		goto _test_eof771;
 case 771:
-#line 17127 "inc/vcf/validator_detail_v43.hpp"
+#line 17127 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1049;
 		case 59: goto tr1049;
@@ -17145,7 +17145,7 @@ case 771:
 		goto tr1049;
 	goto tr805;
 tr1049:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17154,7 +17154,7 @@ st772:
 	if ( ++p == pe )
 		goto _test_eof772;
 case 772:
-#line 17158 "inc/vcf/validator_detail_v43.hpp"
+#line 17158 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1049;
 		case 59: goto tr1049;
@@ -17174,7 +17174,7 @@ case 772:
 		goto tr1049;
 	goto tr805;
 tr1050:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17183,12 +17183,12 @@ st773:
 	if ( ++p == pe )
 		goto _test_eof773;
 case 773:
-#line 17187 "inc/vcf/validator_detail_v43.hpp"
+#line 17187 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1047;
 	goto tr805;
 tr1044:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17197,7 +17197,7 @@ st774:
 	if ( ++p == pe )
 		goto _test_eof774;
 case 774:
-#line 17201 "inc/vcf/validator_detail_v43.hpp"
+#line 17201 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1051;
 		case 59: goto tr1051;
@@ -17220,7 +17220,7 @@ case 774:
 		goto tr1051;
 	goto tr805;
 tr1051:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17229,7 +17229,7 @@ st775:
 	if ( ++p == pe )
 		goto _test_eof775;
 case 775:
-#line 17233 "inc/vcf/validator_detail_v43.hpp"
+#line 17233 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1051;
 		case 58: goto tr1053;
@@ -17248,7 +17248,7 @@ case 775:
 		goto tr1051;
 	goto tr805;
 tr1053:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17257,12 +17257,12 @@ st776:
 	if ( ++p == pe )
 		goto _test_eof776;
 case 776:
-#line 17261 "inc/vcf/validator_detail_v43.hpp"
+#line 17261 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1054;
 	goto tr805;
 tr1054:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17271,14 +17271,14 @@ st777:
 	if ( ++p == pe )
 		goto _test_eof777;
 case 777:
-#line 17275 "inc/vcf/validator_detail_v43.hpp"
+#line 17275 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr1041;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1054;
 	goto tr805;
 tr1052:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17287,7 +17287,7 @@ st778:
 	if ( ++p == pe )
 		goto _test_eof778;
 case 778:
-#line 17291 "inc/vcf/validator_detail_v43.hpp"
+#line 17291 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1055;
 		case 59: goto tr1055;
@@ -17309,7 +17309,7 @@ case 778:
 		goto tr1055;
 	goto tr805;
 tr1055:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17318,7 +17318,7 @@ st779:
 	if ( ++p == pe )
 		goto _test_eof779;
 case 779:
-#line 17322 "inc/vcf/validator_detail_v43.hpp"
+#line 17322 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1055;
 		case 59: goto tr1055;
@@ -17338,7 +17338,7 @@ case 779:
 		goto tr1055;
 	goto tr805;
 tr1056:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17347,16 +17347,16 @@ st780:
 	if ( ++p == pe )
 		goto _test_eof780;
 case 780:
-#line 17351 "inc/vcf/validator_detail_v43.hpp"
+#line 17351 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1053;
 	goto tr805;
 tr810:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17365,7 +17365,7 @@ st781:
 	if ( ++p == pe )
 		goto _test_eof781;
 case 781:
-#line 17369 "inc/vcf/validator_detail_v43.hpp"
+#line 17369 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1057;
 		case 59: goto tr1057;
@@ -17388,7 +17388,7 @@ case 781:
 		goto tr1057;
 	goto tr805;
 tr1057:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17397,7 +17397,7 @@ st782:
 	if ( ++p == pe )
 		goto _test_eof782;
 case 782:
-#line 17401 "inc/vcf/validator_detail_v43.hpp"
+#line 17401 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1057;
 		case 58: goto tr1059;
@@ -17416,7 +17416,7 @@ case 782:
 		goto tr1057;
 	goto tr805;
 tr1059:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17425,12 +17425,12 @@ st783:
 	if ( ++p == pe )
 		goto _test_eof783;
 case 783:
-#line 17429 "inc/vcf/validator_detail_v43.hpp"
+#line 17429 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1060;
 	goto tr805;
 tr1060:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17439,14 +17439,14 @@ st784:
 	if ( ++p == pe )
 		goto _test_eof784;
 case 784:
-#line 17443 "inc/vcf/validator_detail_v43.hpp"
+#line 17443 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr1061;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1060;
 	goto tr805;
 tr1058:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17455,7 +17455,7 @@ st785:
 	if ( ++p == pe )
 		goto _test_eof785;
 case 785:
-#line 17459 "inc/vcf/validator_detail_v43.hpp"
+#line 17459 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1062;
 		case 59: goto tr1062;
@@ -17477,7 +17477,7 @@ case 785:
 		goto tr1062;
 	goto tr805;
 tr1062:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17486,7 +17486,7 @@ st786:
 	if ( ++p == pe )
 		goto _test_eof786;
 case 786:
-#line 17490 "inc/vcf/validator_detail_v43.hpp"
+#line 17490 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1062;
 		case 59: goto tr1062;
@@ -17506,7 +17506,7 @@ case 786:
 		goto tr1062;
 	goto tr805;
 tr1063:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17515,16 +17515,16 @@ st787:
 	if ( ++p == pe )
 		goto _test_eof787;
 case 787:
-#line 17519 "inc/vcf/validator_detail_v43.hpp"
+#line 17519 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1059;
 	goto tr805;
 tr811:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17533,7 +17533,7 @@ st788:
 	if ( ++p == pe )
 		goto _test_eof788;
 case 788:
-#line 17537 "inc/vcf/validator_detail_v43.hpp"
+#line 17537 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1064;
 		case 59: goto tr1064;
@@ -17556,7 +17556,7 @@ case 788:
 		goto tr1064;
 	goto tr805;
 tr1064:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17565,7 +17565,7 @@ st789:
 	if ( ++p == pe )
 		goto _test_eof789;
 case 789:
-#line 17569 "inc/vcf/validator_detail_v43.hpp"
+#line 17569 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1064;
 		case 58: goto tr1066;
@@ -17584,7 +17584,7 @@ case 789:
 		goto tr1064;
 	goto tr805;
 tr1066:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17593,12 +17593,12 @@ st790:
 	if ( ++p == pe )
 		goto _test_eof790;
 case 790:
-#line 17597 "inc/vcf/validator_detail_v43.hpp"
+#line 17597 "../inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1067;
 	goto tr805;
 tr1067:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17607,14 +17607,14 @@ st791:
 	if ( ++p == pe )
 		goto _test_eof791;
 case 791:
-#line 17611 "inc/vcf/validator_detail_v43.hpp"
+#line 17611 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr1061;
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1067;
 	goto tr805;
 tr1065:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17623,7 +17623,7 @@ st792:
 	if ( ++p == pe )
 		goto _test_eof792;
 case 792:
-#line 17627 "inc/vcf/validator_detail_v43.hpp"
+#line 17627 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1068;
 		case 59: goto tr1068;
@@ -17645,7 +17645,7 @@ case 792:
 		goto tr1068;
 	goto tr805;
 tr1068:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17654,7 +17654,7 @@ st793:
 	if ( ++p == pe )
 		goto _test_eof793;
 case 793:
-#line 17658 "inc/vcf/validator_detail_v43.hpp"
+#line 17658 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1068;
 		case 59: goto tr1068;
@@ -17674,7 +17674,7 @@ case 793:
 		goto tr1068;
 	goto tr805;
 tr1069:
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17683,16 +17683,16 @@ st794:
 	if ( ++p == pe )
 		goto _test_eof794;
 case 794:
-#line 17687 "inc/vcf/validator_detail_v43.hpp"
+#line 17687 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1066;
 	goto tr805;
 tr807:
-#line 31 "src/vcf/vcf_v43.ragel"
+#line 31 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_begin(*this);
     }
-#line 35 "src/vcf/vcf_v43.ragel"
+#line 35 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_token_char(*this, *p);
     }
@@ -17701,7 +17701,7 @@ st795:
 	if ( ++p == pe )
 		goto _test_eof795;
 case 795:
-#line 17705 "inc/vcf/validator_detail_v43.hpp"
+#line 17705 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 65: goto tr1038;
@@ -17717,11 +17717,11 @@ case 795:
 	}
 	goto tr805;
 tr773:
-#line 200 "src/vcf/vcf_v43.ragel"
+#line 200 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -17733,15 +17733,15 @@ tr773:
     }
 	goto st796;
 tr785:
-#line 196 "src/vcf/vcf_v43.ragel"
+#line 196 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_sample_name(*this);
     }
-#line 200 "src/vcf/vcf_v43.ragel"
+#line 200 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_header_line(*this);
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -17756,12 +17756,12 @@ st796:
 	if ( ++p == pe )
 		goto _test_eof796;
 case 796:
-#line 17760 "inc/vcf/validator_detail_v43.hpp"
+#line 17760 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st800;
 	goto tr774;
 tr23:
-#line 99 "src/vcf/vcf_v43.ragel"
+#line 99 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
@@ -17770,7 +17770,7 @@ tr23:
           p--; {goto st798;}
         }
     }
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -17785,12 +17785,12 @@ st797:
 	if ( ++p == pe )
 		goto _test_eof797;
 case 797:
-#line 17789 "inc/vcf/validator_detail_v43.hpp"
+#line 17789 "../inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
 tr1074:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -17805,14 +17805,14 @@ st798:
 	if ( ++p == pe )
 		goto _test_eof798;
 case 798:
-#line 17809 "inc/vcf/validator_detail_v43.hpp"
+#line 17809 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1073;
 		case 13: goto tr1074;
 	}
 	goto st798;
 tr1073:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -17822,17 +17822,17 @@ tr1073:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 907 "src/vcf/vcf_v43.ragel"
+#line 907 "../src/vcf/vcf_v43.ragel"
 	{ {goto st28;} }
 	goto st803;
 st803:
 	if ( ++p == pe )
 		goto _test_eof803;
 case 803:
-#line 17833 "inc/vcf/validator_detail_v43.hpp"
+#line 17833 "../inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 tr1077:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -17847,14 +17847,14 @@ st799:
 	if ( ++p == pe )
 		goto _test_eof799;
 case 799:
-#line 17851 "inc/vcf/validator_detail_v43.hpp"
+#line 17851 "../inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1076;
 		case 13: goto tr1077;
 	}
 	goto st799;
 tr1076:
-#line 43 "src/vcf/vcf_v43.ragel"
+#line 43 "../src/vcf/vcf_v43.ragel"
 	{
         ParsePolicy::handle_newline(*this);
         ++n_lines;
@@ -17864,14 +17864,14 @@ tr1076:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 908 "src/vcf/vcf_v43.ragel"
+#line 908 "../src/vcf/vcf_v43.ragel"
 	{ {goto st802;} }
 	goto st804;
 st804:
 	if ( ++p == pe )
 		goto _test_eof804;
 case 804:
-#line 17875 "inc/vcf/validator_detail_v43.hpp"
+#line 17875 "../inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -18696,7 +18696,7 @@ case 804:
 	case 12: 
 	case 13: 
 	case 797: 
-#line 60 "src/vcf/vcf_v43.ragel"
+#line 60 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st798;}
@@ -18750,14 +18750,14 @@ case 804:
 	case 71: 
 	case 72: 
 	case 73: 
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	break;
 	case 800: 
-#line 70 "src/vcf/vcf_v43.ragel"
+#line 70 "../src/vcf/vcf_v43.ragel"
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
@@ -18776,7 +18776,7 @@ case 804:
 	case 575: 
 	case 576: 
 	case 796: 
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -18791,7 +18791,7 @@ case 804:
     }
 	break;
 	case 602: 
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -18805,13 +18805,13 @@ case 804:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 237 "src/vcf/vcf_v43.ragel"
+#line 237 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         p--; {goto st798;}
     }
-#line 60 "src/vcf/vcf_v43.ragel"
+#line 60 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st798;}
@@ -18839,12 +18839,12 @@ case 804:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -18858,12 +18858,12 @@ case 804:
 	case 446: 
 	case 447: 
 	case 448: 
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 256 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -18898,12 +18898,12 @@ case 804:
 	case 496: 
 	case 497: 
 	case 498: 
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 262 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -18933,12 +18933,12 @@ case 804:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -18980,12 +18980,12 @@ case 804:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19026,12 +19026,12 @@ case 804:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19071,12 +19071,12 @@ case 804:
 	case 403: 
 	case 404: 
 	case 405: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19093,12 +19093,12 @@ case 804:
 	case 507: 
 	case 508: 
 	case 509: 
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 327 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19136,12 +19136,12 @@ case 804:
 	case 348: 
 	case 349: 
 	case 351: 
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19176,12 +19176,12 @@ case 804:
 	case 438: 
 	case 439: 
 	case 440: 
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 354 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19224,7 +19224,7 @@ case 804:
 	case 565: 
 	case 566: 
 	case 567: 
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 376 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -19238,7 +19238,7 @@ case 804:
         
         p--; {goto st799;}
     }
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -19256,12 +19256,12 @@ case 804:
 	case 599: 
 	case 600: 
 	case 601: 
-#line 393 "src/vcf/vcf_v43.ragel"
+#line 393 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19269,12 +19269,12 @@ case 804:
 	break;
 	case 579: 
 	case 580: 
-#line 399 "src/vcf/vcf_v43.ragel"
+#line 399 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19282,12 +19282,12 @@ case 804:
 	break;
 	case 581: 
 	case 582: 
-#line 405 "src/vcf/vcf_v43.ragel"
+#line 405 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19295,12 +19295,12 @@ case 804:
 	break;
 	case 583: 
 	case 584: 
-#line 411 "src/vcf/vcf_v43.ragel"
+#line 411 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19343,12 +19343,12 @@ case 804:
 	case 793: 
 	case 794: 
 	case 795: 
-#line 417 "src/vcf/vcf_v43.ragel"
+#line 417 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19367,12 +19367,12 @@ case 804:
 	case 758: 
 	case 759: 
 	case 760: 
-#line 423 "src/vcf/vcf_v43.ragel"
+#line 423 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19383,24 +19383,24 @@ case 804:
 	case 592: 
 	case 749: 
 	case 750: 
-#line 429 "src/vcf/vcf_v43.ragel"
+#line 429 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 594: 
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19408,12 +19408,12 @@ case 804:
 	break;
 	case 595: 
 	case 596: 
-#line 619 "src/vcf/vcf_v43.ragel"
+#line 619 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19421,14 +19421,14 @@ case 804:
 	break;
 	case 598: 
 	case 603: 
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 625 "../src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -19436,12 +19436,12 @@ case 804:
 	break;
 	case 23: 
 	case 28: 
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 376 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -19455,7 +19455,7 @@ case 804:
         
         p--; {goto st799;}
     }
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -19472,35 +19472,35 @@ case 804:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 249 "src/vcf/vcf_v43.ragel"
+#line 249 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	break;
 	case 122: 
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19509,17 +19509,17 @@ case 804:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 279 "src/vcf/vcf_v43.ragel"
+#line 279 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19528,17 +19528,17 @@ case 804:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 295 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19546,17 +19546,17 @@ case 804:
 	break;
 	case 199: 
 	case 200: 
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 300 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19564,17 +19564,17 @@ case 804:
 	break;
 	case 265: 
 	case 266: 
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 300 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19583,17 +19583,17 @@ case 804:
 	case 406: 
 	case 407: 
 	case 408: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 311 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19605,17 +19605,17 @@ case 804:
 	case 384: 
 	case 385: 
 	case 386: 
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 316 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19632,17 +19632,17 @@ case 804:
 	case 395: 
 	case 396: 
 	case 397: 
-#line 321 "src/vcf/vcf_v43.ragel"
+#line 321 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19650,17 +19650,17 @@ case 804:
 	break;
 	case 324: 
 	case 325: 
-#line 338 "src/vcf/vcf_v43.ragel"
+#line 338 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19673,17 +19673,17 @@ case 804:
 	case 335: 
 	case 336: 
 	case 337: 
-#line 343 "src/vcf/vcf_v43.ragel"
+#line 343 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19691,17 +19691,17 @@ case 804:
 	break;
 	case 347: 
 	case 350: 
-#line 348 "src/vcf/vcf_v43.ragel"
+#line 348 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19710,17 +19710,17 @@ case 804:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19728,17 +19728,17 @@ case 804:
 	break;
 	case 478: 
 	case 479: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 262 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19750,17 +19750,17 @@ case 804:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19772,17 +19772,17 @@ case 804:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19794,17 +19794,17 @@ case 804:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19813,17 +19813,17 @@ case 804:
 	case 364: 
 	case 365: 
 	case 366: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19832,17 +19832,17 @@ case 804:
 	case 314: 
 	case 315: 
 	case 316: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19851,17 +19851,17 @@ case 804:
 	case 419: 
 	case 420: 
 	case 421: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 354 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19881,17 +19881,17 @@ case 804:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19911,17 +19911,17 @@ case 804:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19941,17 +19941,17 @@ case 804:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -19971,17 +19971,17 @@ case 804:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20006,17 +20006,17 @@ case 804:
 	case 465: 
 	case 466: 
 	case 467: 
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 370 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 256 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20043,17 +20043,17 @@ case 804:
 	case 528: 
 	case 529: 
 	case 530: 
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 370 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 327 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20107,17 +20107,17 @@ case 804:
 	case 743: 
 	case 744: 
 	case 745: 
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20125,17 +20125,17 @@ case 804:
 	break;
 	case 613: 
 	case 614: 
-#line 445 "src/vcf/vcf_v43.ragel"
+#line 445 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20143,7 +20143,7 @@ case 804:
 	break;
 	case 620: 
 	case 621: 
-#line 450 "src/vcf/vcf_v43.ragel"
+#line 450 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20151,12 +20151,12 @@ case 804:
                 "AA"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20164,7 +20164,7 @@ case 804:
 	break;
 	case 623: 
 	case 624: 
-#line 458 "src/vcf/vcf_v43.ragel"
+#line 458 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20172,12 +20172,12 @@ case 804:
                 "AC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20185,7 +20185,7 @@ case 804:
 	break;
 	case 626: 
 	case 627: 
-#line 466 "src/vcf/vcf_v43.ragel"
+#line 466 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20193,12 +20193,12 @@ case 804:
                 "AD"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20206,7 +20206,7 @@ case 804:
 	break;
 	case 629: 
 	case 630: 
-#line 474 "src/vcf/vcf_v43.ragel"
+#line 474 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20214,12 +20214,12 @@ case 804:
                 "ADF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20227,7 +20227,7 @@ case 804:
 	break;
 	case 632: 
 	case 633: 
-#line 482 "src/vcf/vcf_v43.ragel"
+#line 482 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20235,12 +20235,12 @@ case 804:
                 "ADR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20259,7 +20259,7 @@ case 804:
 	case 645: 
 	case 646: 
 	case 647: 
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 490 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20267,12 +20267,12 @@ case 804:
                 "AF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20280,7 +20280,7 @@ case 804:
 	break;
 	case 649: 
 	case 650: 
-#line 498 "src/vcf/vcf_v43.ragel"
+#line 498 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20288,12 +20288,12 @@ case 804:
                 "AN"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20312,7 +20312,7 @@ case 804:
 	case 663: 
 	case 664: 
 	case 665: 
-#line 506 "src/vcf/vcf_v43.ragel"
+#line 506 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20320,12 +20320,12 @@ case 804:
                 "BQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20334,7 +20334,7 @@ case 804:
 	case 671: 
 	case 672: 
 	case 673: 
-#line 514 "src/vcf/vcf_v43.ragel"
+#line 514 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20342,12 +20342,12 @@ case 804:
                 "CIGAR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20355,7 +20355,7 @@ case 804:
 	break;
 	case 676: 
 	case 677: 
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 522 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20363,12 +20363,12 @@ case 804:
                 "DB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20376,7 +20376,7 @@ case 804:
 	break;
 	case 679: 
 	case 680: 
-#line 530 "src/vcf/vcf_v43.ragel"
+#line 530 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20384,12 +20384,12 @@ case 804:
                 "DP"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20397,7 +20397,7 @@ case 804:
 	break;
 	case 684: 
 	case 685: 
-#line 538 "src/vcf/vcf_v43.ragel"
+#line 538 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20405,12 +20405,12 @@ case 804:
                 "END"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20418,7 +20418,7 @@ case 804:
 	break;
 	case 688: 
 	case 689: 
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 546 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20426,12 +20426,12 @@ case 804:
                 "H2"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20439,7 +20439,7 @@ case 804:
 	break;
 	case 691: 
 	case 692: 
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 554 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20447,12 +20447,12 @@ case 804:
                 "H3"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20471,7 +20471,7 @@ case 804:
 	case 708: 
 	case 709: 
 	case 710: 
-#line 562 "src/vcf/vcf_v43.ragel"
+#line 562 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20479,12 +20479,12 @@ case 804:
                 "MQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20492,7 +20492,7 @@ case 804:
 	break;
 	case 696: 
 	case 697: 
-#line 570 "src/vcf/vcf_v43.ragel"
+#line 570 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20500,12 +20500,12 @@ case 804:
                 "MQ0"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20513,7 +20513,7 @@ case 804:
 	break;
 	case 713: 
 	case 714: 
-#line 578 "src/vcf/vcf_v43.ragel"
+#line 578 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20521,12 +20521,12 @@ case 804:
                 "NS"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20545,7 +20545,7 @@ case 804:
 	case 727: 
 	case 728: 
 	case 729: 
-#line 586 "src/vcf/vcf_v43.ragel"
+#line 586 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20553,12 +20553,12 @@ case 804:
                 "SB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20566,7 +20566,7 @@ case 804:
 	break;
 	case 736: 
 	case 737: 
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 594 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20574,12 +20574,12 @@ case 804:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20587,7 +20587,7 @@ case 804:
 	break;
 	case 747: 
 	case 748: 
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 602 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20595,12 +20595,12 @@ case 804:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20608,7 +20608,7 @@ case 804:
 	break;
 	case 616: 
 	case 617: 
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 610 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20616,12 +20616,12 @@ case 804:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
@@ -20631,38 +20631,38 @@ case 804:
 	case 604: 
 	case 605: 
 	case 606: 
-#line 632 "src/vcf/vcf_v43.ragel"
+#line 632 "../src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 625 "../src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
         ErrorPolicy::handle_error(*this, new SamplesBodyError{n_lines, message_stream.str()});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 22: 
-#line 60 "src/vcf/vcf_v43.ragel"
+#line 60 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FileformatError{n_lines});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 376 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -20676,7 +20676,7 @@ case 804:
         
         p--; {goto st799;}
     }
-#line 78 "src/vcf/vcf_v43.ragel"
+#line 78 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines});
         
@@ -20693,22 +20693,22 @@ case 804:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20717,22 +20717,22 @@ case 804:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20741,22 +20741,22 @@ case 804:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20765,22 +20765,22 @@ case 804:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20789,22 +20789,22 @@ case 804:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20813,22 +20813,22 @@ case 804:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20837,22 +20837,22 @@ case 804:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
@@ -20861,29 +20861,29 @@ case 804:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 365 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 360 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	break;
 	case 675: 
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 522 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20891,24 +20891,24 @@ case 804:
                 "DB"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 687: 
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 546 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20916,24 +20916,24 @@ case 804:
                 "H2"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 690: 
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 554 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20941,24 +20941,24 @@ case 804:
                 "H3"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 735: 
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 594 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20966,24 +20966,24 @@ case 804:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 746: 
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 602 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20991,24 +20991,24 @@ case 804:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 615: 
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 610 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -21016,87 +21016,87 @@ case 804:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 440 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 435 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
     }
-#line 91 "src/vcf/vcf_v43.ragel"
+#line 91 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines});
         p--; {goto st799;}
     }
 	break;
 	case 24: 
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 244 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 268 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 274 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 290 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 256 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 262 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 333 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 354 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 306 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 327 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
     }
-#line 65 "src/vcf/vcf_v43.ragel"
+#line 65 "../src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
 	break;
-#line 21093 "inc/vcf/validator_detail_v43.hpp"
+#line 21093 "../inc/vcf/validator_detail_v43.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 937 "src/vcf/vcf_v43.ragel"
+#line 937 "../src/vcf/vcf_v43.ragel"
 
     }
     

--- a/src/vcf/parsing_state.cpp
+++ b/src/vcf/parsing_state.cpp
@@ -23,8 +23,7 @@ namespace ebi
 
     ParsingState::ParsingState(std::shared_ptr<Source> source)
     : n_lines{1}, n_columns{1}, n_batches{0}, cs{0}, m_is_valid{true}, 
-      source{source}, record{},
-      errors{}, warnings{},
+      source{source}, errors{}, warnings{}, record{},
       undefined_metadata{}
     {
     }
@@ -39,14 +38,9 @@ namespace ebi
         source->meta_entries.emplace(meta.id, meta);
     }
     
-    void ParsingState::set_record(std::unique_ptr<Record> record)
+    void ParsingState::set_record(Record record)
     {
-        this->record = std::move(record);
-    }
-
-    void ParsingState::unset_record()
-    {
-        record.release();
+        this->record = record;
     }
 
     void ParsingState::add_error(std::unique_ptr<Error> error)
@@ -54,18 +48,15 @@ namespace ebi
         errors.push_back(std::move(error));
     }
     
-    void ParsingState::clear_errors()
-    {
-        errors.clear();
-    }
-
     void ParsingState::add_warning(std::unique_ptr<Error> error)
     {
         warnings.push_back(std::move(error));
     }
 
-    void ParsingState::clear_warnings()
+    void ParsingState::clear()
     {
+        record = Record{};
+        errors.clear();
         warnings.clear();
     }
 

--- a/src/vcf/store_parse_policy.cpp
+++ b/src/vcf/store_parse_policy.cpp
@@ -194,7 +194,7 @@ namespace ebi
         auto samples = m_line_tokens.find("SAMPLES") != m_line_tokens.end() ?
                        m_line_tokens["SAMPLES"] : std::vector<std::string>{};
 
-        state.set_record(std::unique_ptr<Record>{new Record{
+        state.set_record(Record{
                 state.n_lines,
                 m_line_tokens["CHROM"][0],
                 position,
@@ -207,7 +207,7 @@ namespace ebi
                 format,
                 samples,
                 state.source
-        }});
+        });
 
         check_sorted(state, position);
     }

--- a/src/vcf/validator.cpp
+++ b/src/vcf/validator.cpp
@@ -21,8 +21,7 @@ namespace ebi
   namespace vcf
   {
 
-    ParserImpl::ParserImpl(std::shared_ptr<Source> source
-    )
+    ParserImpl::ParserImpl(std::shared_ptr<Source> source)
     : ParsingState{source}
     {
         
@@ -34,9 +33,7 @@ namespace ebi
         char const * pe = &text[0] + text.size();
         char const * eof = nullptr;
 
-        unset_record();
-        clear_errors();
-        clear_warnings();
+        clear();
         parse_buffer(p, pe, eof);
     }
 
@@ -46,18 +43,14 @@ namespace ebi
         char const * pe = text.data() + text.size();
         char const * eof = nullptr;
 
-        unset_record();
-        clear_errors();
-        clear_warnings();
+        clear();
         parse_buffer(p, pe, eof);
     }
 
     void ParserImpl::end()
     {
         char const * empty = "";
-        unset_record();
-        clear_errors();
-        clear_warnings();
+        clear();
         parse_buffer(empty, empty, empty);
     }
 

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -200,14 +200,14 @@
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                     ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -200,14 +200,14 @@
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                 ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -212,14 +212,14 @@
             // Handle all columns and build record
             ParsePolicy::handle_body_line(*this);
 
-            auto duplicated_errors = previous_records.check_duplicates(*record);
+            auto duplicated_errors = previous_records.check_duplicates(record);
             for(auto &error_ptr : duplicated_errors) {
                 ErrorPolicy::handle_error(*this, error_ptr.release());
             }
 
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
-                OptionalPolicy::optional_check_body_entry(*this, *record);
+                OptionalPolicy::optional_check_body_entry(*this, record);
             } catch (MetaSectionError *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             } catch (BodySectionError *warn) {


### PR DESCRIPTION
Replaced the `unique_ptr<Record>` attribute of `ParsingState` with a plain object. This made necessary to implement the default constructor for the `Record` class.

Some small refactoring to the `ParsingState` class, grouping all the attribute "clearing" methods into one.