### PR TITLE
EVA-470 Summary report independent from checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set (MOD_VCF_SOURCES
         inc/vcf/report_reader.hpp
         inc/vcf/report_writer.hpp
         inc/vcf/sqlite_report.hpp
+        inc/vcf/summary_report_writer.hpp
         inc/vcf/validator_detail_v41.hpp
         inc/vcf/validator_detail_v42.hpp
         inc/vcf/validator_detail_v43.hpp

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -253,6 +253,55 @@ namespace odb
     callback (database&, const object_type&, callback_event);
   };
 
+  // NoMetaDefinitionError
+  //
+  template <>
+  struct class_traits< ::ebi::vcf::NoMetaDefinitionError >
+  {
+    static const class_kind kind = class_object;
+  };
+
+  template <>
+  class access::object_traits< ::ebi::vcf::NoMetaDefinitionError >
+  {
+    public:
+    typedef ::ebi::vcf::NoMetaDefinitionError object_type;
+    typedef ::ebi::vcf::NoMetaDefinitionError* pointer_type;
+    typedef odb::pointer_traits<pointer_type> pointer_traits;
+
+    static const bool polymorphic = true;
+
+    typedef ::ebi::vcf::Error root_type;
+    typedef ::ebi::vcf::Error base_type;
+    typedef object_traits<root_type>::discriminator_type discriminator_type;
+    typedef polymorphic_concrete_info<root_type> info_type;
+
+    static const std::size_t depth = 2UL;
+
+    typedef object_traits< ::ebi::vcf::Error >::id_type id_type;
+
+    static const bool auto_id = false;
+
+    static const bool abstract = false;
+
+    static id_type
+    id (const object_type&);
+
+    typedef
+    no_op_pointer_cache_traits<object_traits<root_type>::pointer_type>
+    pointer_cache_traits;
+
+    typedef
+    no_op_reference_cache_traits<root_type>
+    reference_cache_traits;
+
+    static void
+    callback (database&, object_type&, callback_event);
+
+    static void
+    callback (database&, const object_type&, callback_event);
+  };
+
   // FileformatError
   //
   template <>
@@ -1804,6 +1853,230 @@ namespace odb
   template <>
   class access::object_traits_impl< ::ebi::vcf::BodySectionError, id_common >:
     public access::object_traits_impl< ::ebi::vcf::BodySectionError, id_sqlite >
+  {
+  };
+
+  // NoMetaDefinitionError
+  //
+  template <typename A>
+  struct query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::Error, id_sqlite, typename A::base_traits >
+  {
+    // Error
+    //
+    typedef query_columns< ::ebi::vcf::Error, id_sqlite, typename A::base_traits > Error;
+
+    // id
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        long unsigned int,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    id_type_;
+
+    static const id_type_ id;
+
+    // column
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    column_type_;
+
+    static const column_type_ column;
+
+    // field
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    field_type_;
+
+    static const field_type_ field;
+  };
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >::id_type_
+  query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >::
+  id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >::column_type_
+  query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >::
+  column (A::table_name, "\"column\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >::
+  field (A::table_name, "\"field\"", 0);
+
+  template <typename A>
+  struct pointer_query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::NoMetaDefinitionError, id_sqlite, A >
+  {
+  };
+
+  template <>
+  class access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >:
+    public access::object_traits< ::ebi::vcf::NoMetaDefinitionError >
+  {
+    public:
+    typedef polymorphic_entry<object_type, id_sqlite> entry_type;
+    typedef object_traits_impl<root_type, id_sqlite> root_traits;
+    typedef object_traits_impl<base_type, id_sqlite> base_traits;
+
+    typedef root_traits::id_image_type id_image_type;
+
+    static const info_type info;
+
+    struct image_type
+    {
+      base_traits::image_type* base;
+
+      // id_
+      //
+      long long id_value;
+      bool id_null;
+
+      // column
+      //
+      details::buffer column_value;
+      std::size_t column_size;
+      bool column_null;
+
+      // field
+      //
+      details::buffer field_value;
+      std::size_t field_size;
+      bool field_null;
+
+      std::size_t version;
+    };
+
+    struct extra_statement_cache_type;
+
+    using object_traits<object_type>::id;
+
+    static bool
+    grow (image_type&,
+          bool*,
+          std::size_t = depth);
+
+    static void
+    bind (sqlite::bind*,
+          const sqlite::bind* id,
+          std::size_t id_size,
+          image_type&,
+          sqlite::statement_kind);
+
+    static void
+    bind (sqlite::bind*, id_image_type&);
+
+    static bool
+    init (image_type&,
+          const object_type&,
+          sqlite::statement_kind);
+
+    static void
+    init (object_type&,
+          const image_type&,
+          database*,
+          std::size_t = depth);
+
+    static void
+    init (id_image_type&, const id_type&);
+
+    static bool
+    check_version (const std::size_t*, const image_type&);
+
+    static void
+    update_version (std::size_t*, const image_type&, sqlite::binding*);
+
+    typedef
+    sqlite::polymorphic_derived_object_statements<object_type>
+    statements_type;
+
+    typedef
+    sqlite::polymorphic_root_object_statements<root_type>
+    root_statements_type;
+
+    typedef sqlite::query_base query_base_type;
+
+    static const std::size_t column_count = 3UL;
+    static const std::size_t id_column_count = 1UL;
+    static const std::size_t inverse_column_count = 0UL;
+    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t managed_optimistic_column_count = 0UL;
+
+    static const std::size_t separate_load_column_count = 0UL;
+    static const std::size_t separate_update_column_count = 0UL;
+
+    static const bool versioned = false;
+
+    static const char persist_statement[];
+    static const char* const find_statements[depth];
+    static const std::size_t find_column_counts[depth];
+    static const char update_statement[];
+    static const char erase_statement[];
+    static const char query_statement[];
+    static const char erase_query_statement[];
+
+    static const char table_name[];
+
+    static void
+    persist (database&, object_type&, bool top = true, bool dyn = true);
+
+    static pointer_type
+    find (database&, const id_type&);
+
+    static bool
+    find (database&, const id_type&, object_type&, bool dyn = true);
+
+    static bool
+    reload (database&, object_type&, bool dyn = true);
+
+    static void
+    update (database&, const object_type&, bool top = true, bool dyn = true);
+
+    static void
+    erase (database&, const id_type&, bool top = true, bool dyn = true);
+
+    static void
+    erase (database&, const object_type&, bool top = true, bool dyn = true);
+
+    static result<object_type>
+    query (database&, const query_base_type&);
+
+    static unsigned long long
+    erase_query (database&, const query_base_type&);
+
+    public:
+    static bool
+    find_ (statements_type&,
+           const id_type*,
+           std::size_t = depth);
+
+    static void
+    load_ (statements_type&,
+           object_type&,
+           bool reload,
+           std::size_t = depth);
+
+    static void
+    load_ (database&, root_type&, std::size_t);
+  };
+
+  template <>
+  class access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_common >:
+    public access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >
   {
   };
 
@@ -4372,6 +4645,8 @@ namespace odb
   // HeaderSectionError
   //
   // BodySectionError
+  //
+  // NoMetaDefinitionError
   //
   // FileformatError
   //

--- a/inc/vcf/error-odb.ipp
+++ b/inc/vcf/error-odb.ipp
@@ -132,6 +132,35 @@ namespace odb
     ODB_POTENTIALLY_UNUSED (e);
   }
 
+  // NoMetaDefinitionError
+  //
+
+  inline
+  access::object_traits< ::ebi::vcf::NoMetaDefinitionError >::id_type
+  access::object_traits< ::ebi::vcf::NoMetaDefinitionError >::
+  id (const object_type& o)
+  {
+    return object_traits< ::ebi::vcf::Error >::id (o);
+  }
+
+  inline
+  void access::object_traits< ::ebi::vcf::NoMetaDefinitionError >::
+  callback (database& db, object_type& x, callback_event e)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (x);
+    ODB_POTENTIALLY_UNUSED (e);
+  }
+
+  inline
+  void access::object_traits< ::ebi::vcf::NoMetaDefinitionError >::
+  callback (database& db, const object_type& x, callback_event e)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (x);
+    ODB_POTENTIALLY_UNUSED (e);
+  }
+
   // FileformatError
   //
 
@@ -659,6 +688,42 @@ namespace odb
 
   inline
   void access::object_traits_impl< ::ebi::vcf::BodySectionError, id_sqlite >::
+  update_version (std::size_t* v, const image_type& i, sqlite::binding* b)
+  {
+    v[0UL] = i.version;
+    v[1UL] = i.base->version;
+    b[0UL].version++;
+    b[1UL].version++;
+  }
+
+  // NoMetaDefinitionError
+  //
+
+  inline
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  bind (sqlite::bind* b, id_image_type& i)
+  {
+    object_traits_impl< ::ebi::vcf::Error, id_sqlite >::bind (b, i);
+  }
+
+  inline
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  init (id_image_type& i, const id_type& id)
+  {
+    object_traits_impl< ::ebi::vcf::Error, id_sqlite >::init (i, id);
+  }
+
+  inline
+  bool access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  check_version (const std::size_t* v, const image_type& i)
+  {
+    return 
+      v[0UL] != i.version ||
+      v[1UL] != i.base->version;
+  }
+
+  inline
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
   update_version (std::size_t* v, const image_type& i, sqlite::binding* b)
   {
     v[0UL] = i.version;

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -183,8 +183,11 @@ namespace ebi
         friend class odb::access;
         NoMetaDefinitionError() {}
       public:
-        NoMetaDefinitionError(size_t line, std::string message, std::string column, std::string field)
-                : Error{line, field  + " from column " + column + " was not defined in meta section"} { }
+        NoMetaDefinitionError(size_t line,
+                              const std::string &message,
+                              const std::string &column,
+                              const std::string &field)
+                : Error{line, message}, column{column}, field{field} {}
         virtual ErrorCode get_code() const override { return ErrorCode::body_section; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
         std::string column;

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -179,9 +179,6 @@ namespace ebi
     #pragma db object
     struct NoMetaDefinitionError : public Error
     {
-      private:
-        friend class odb::access;
-        NoMetaDefinitionError() {}
       public:
         NoMetaDefinitionError(size_t line,
                               const std::string &message,
@@ -192,6 +189,9 @@ namespace ebi
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
         std::string column;
         std::string field;
+      private:
+        friend class odb::access;
+        NoMetaDefinitionError() {}
     };
 
     // inheritance siblings about detailed errors
@@ -303,9 +303,6 @@ namespace ebi
     #pragma db object
     struct SamplesFieldBodyError : public BodySectionError
     {
-      private:
-        friend class odb::access;
-        SamplesFieldBodyError() {}  // necessary for ODB
       public:
         SamplesFieldBodyError(size_t line,
                               const std::string &message,
@@ -314,7 +311,7 @@ namespace ebi
                 : BodySectionError{line, message}, field{field}, field_cardinality{field_cardinality} {
             if (field.empty()) {
                 throw std::invalid_argument{"SamplesFieldBodyError: field should not be an empty string. Use "
-                                               "SamplesBodyError for unknown errors in the samples columns"};
+                                                    "SamplesBodyError for unknown errors in the samples columns"};
             }
         }
         virtual ErrorCode get_code() const override { return ErrorCode::samples_field_body; }
@@ -322,6 +319,9 @@ namespace ebi
 
         std::string field;
         long field_cardinality;    // [0, inf): valid number of values. -1: unknown amount of values
+      private:
+        friend class odb::access;
+        SamplesFieldBodyError() {}  // necessary for ODB
     };
     #pragma db object
     struct NormalizationError : public BodySectionError

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -33,6 +33,7 @@ namespace ebi
         meta_section,
         header_section,
         body_section,
+        no_meta_definition,
         fileformat,
         chromosome_body,
         position_body,
@@ -55,6 +56,7 @@ namespace ebi
     struct MetaSectionError;
     struct HeaderSectionError;
     struct BodySectionError;
+    struct NoMetaDefinitionError;
     struct FileformatError;
     struct ChromosomeBodyError;
     struct PositionBodyError;
@@ -74,10 +76,12 @@ namespace ebi
 
     class ErrorVisitor {
       public:
+        virtual ~ErrorVisitor() {};
         virtual void visit(Error& error) = 0;
         virtual void visit(MetaSectionError &error) = 0;
         virtual void visit(HeaderSectionError &error) = 0;
         virtual void visit(BodySectionError &error) = 0;
+        virtual void visit(NoMetaDefinitionError &error) = 0;
         virtual void visit(FileformatError &error) = 0;
         virtual void visit(ChromosomeBodyError &error) = 0;
         virtual void visit(PositionBodyError &error) = 0;
@@ -170,6 +174,21 @@ namespace ebi
         BodySectionError(size_t line) : BodySectionError{line, "Error in body section"} { }
         virtual ErrorCode get_code() const override { return ErrorCode::body_section; }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
+    };
+
+    #pragma db object
+    struct NoMetaDefinitionError : public Error
+    {
+      private:
+        friend class odb::access;
+        NoMetaDefinitionError() {}
+      public:
+        NoMetaDefinitionError(size_t line, std::string message, std::string column, std::string field)
+                : Error{line, field  + " from column " + column + " was not defined in meta section"} { }
+        virtual ErrorCode get_code() const override { return ErrorCode::body_section; }
+        virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
+        std::string column;
+        std::string field;
     };
 
     // inheritance siblings about detailed errors

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -70,6 +70,11 @@ namespace ebi
             util::writeline(output, *line);
             ignored_errors++;
         }
+        virtual void visit(NoMetaDefinitionError &error)
+        {
+            util::writeline(output, *line);
+            ignored_errors++;
+        }
         virtual void visit(FileformatError &error) override
         {
             util::writeline(output, *line);

--- a/inc/vcf/parsing_state.hpp
+++ b/inc/vcf/parsing_state.hpp
@@ -46,8 +46,7 @@ namespace ebi
         std::vector<std::unique_ptr<Error>> warnings;
 
         std::multimap<std::string, std::string> defined_metadata;
-        std::multimap<std::string, std::string> undefined_metadata;
-        
+
         ParsingState(std::shared_ptr<Source> source);
         virtual ~ParsingState() = default;
 
@@ -67,10 +66,6 @@ namespace ebi
         bool is_well_defined_meta(std::string const & meta_type, std::string const & id) const;
         
         void add_well_defined_meta(std::string const & meta_type, std::string const & id);
-        
-        bool is_bad_defined_meta(std::string const & meta_type, std::string const & id) const;
-        
-        void add_bad_defined_meta(std::string const & meta_type, std::string const & id);
     };
   }
 }

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -110,20 +110,23 @@ namespace ebi
     class SummaryReportWriter : public ReportWriter
     {
       public:
+        SummaryReportWriter(std::ostream &out) : out(out) {}
+
         virtual void write_error(Error &error)
         {
-            std::cout << error.what() << std::endl;
+            out << error.what() << std::endl;
         }
 
         virtual void write_warning(Error &error)
         {
             if (summary.should_write_report(error)) {
-                std::cout << error.what() << " (warning)" << std::endl;
+                out << error.what() << " (warning)" << std::endl;
             }
         }
 
       private:
         SummaryTracker summary;
+        std::ostream &out;
     };
   }
 }

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VCF_SUMMARY_REPORT_WRITER_HPP
+#define VCF_SUMMARY_REPORT_WRITER_HPP
+
+#include <map>
+#include "report_writer.hpp"
+
+namespace ebi
+{
+  namespace vcf
+  {
+    class ReportVisitor : public ErrorVisitor
+    {
+      public:
+        ReportVisitor() : undefined_metadata{}, skip(false) {}
+
+        virtual void visit(Error &error) {}
+        virtual void visit(MetaSectionError &error) {}
+        virtual void visit(HeaderSectionError &error) {}
+        virtual void visit(BodySectionError &error) {}
+        virtual void visit(NoMetaDefinitionError &error)
+        {
+            if (is_bad_defined_meta(error.column, error.field)) {
+                skip = true;
+            } else {
+                add_bad_defined_meta(error.column, error.field);
+                skip = false;
+            }
+        }
+        virtual void visit(FileformatError &error) {}
+        virtual void visit(ChromosomeBodyError &error) {}
+        virtual void visit(PositionBodyError &error) {}
+        virtual void visit(IdBodyError &error) {}
+        virtual void visit(ReferenceAlleleBodyError &error) {}
+        virtual void visit(AlternateAllelesBodyError &error) {}
+        virtual void visit(QualityBodyError &error) {}
+        virtual void visit(FilterBodyError &error) {}
+        virtual void visit(InfoBodyError &error) {}
+        virtual void visit(FormatBodyError &error) {}
+        virtual void visit(SamplesBodyError &error) {}
+        virtual void visit(SamplesFieldBodyError &error) {}
+        virtual void visit(NormalizationError &error) {}
+        virtual void visit(DuplicationError &error) {}
+
+        bool should_skip_report() { return skip; }
+
+      private:
+        bool is_bad_defined_meta(std::string const & meta_type, std::string const & id) const
+        {
+            typedef std::multimap<std::string,std::string>::const_iterator iter;
+            std::pair<iter, iter> range = undefined_metadata.equal_range(meta_type);
+            for (auto & current = range.first; current != range.second; ++current) {
+                if (current->second == id) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void add_bad_defined_meta(std::string const & meta_type, std::string const & id)
+        {
+            undefined_metadata.emplace(meta_type, id);
+        }
+
+        std::multimap<std::string, std::string> undefined_metadata;
+        bool skip;
+    };
+
+
+    class SummaryReportWriter : public ReportWriter
+    {
+      public:
+        virtual void write_error(Error &error)
+        {
+          std::cout << error.what() << std::endl;
+        }
+
+        virtual void write_warning(Error &error)
+        {
+            error.apply_visitor(visitor);
+            if (not visitor.should_skip_report()) {
+                std::cout << error.what() << " (warning)" << std::endl;
+            }
+        }
+
+      private:
+        ReportVisitor visitor;
+    };
+  }
+}
+
+#endif // VCF_SUMMARY_REPORT_WRITER_HPP

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -87,7 +87,7 @@ namespace ebi
       public:
         virtual void write_error(Error &error)
         {
-          std::cout << error.what() << std::endl;
+            std::cout << error.what() << std::endl;
         }
 
         virtual void write_warning(Error &error)

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -43,7 +43,7 @@ namespace ebi
     class SummaryTracker : public ErrorVisitor
     {
       public:
-        SummaryTracker() : undefined_metadata{}, skip(false) {}
+        SummaryTracker() : already_reported{}, skip{false} {}
 
         bool should_write_report(Error &error)
         {
@@ -84,7 +84,7 @@ namespace ebi
         bool is_already_reported(std::string const &meta_type, std::string const &id) const
         {
             typedef std::multimap<std::string,std::string>::const_iterator iter;
-            std::pair<iter, iter> range = undefined_metadata.equal_range(meta_type);
+            std::pair<iter, iter> range = already_reported.equal_range(meta_type);
             for (auto & current = range.first; current != range.second; ++current) {
                 if (current->second == id) {
                     return true;
@@ -95,10 +95,10 @@ namespace ebi
 
         void add_already_reported(std::string const &meta_type, std::string const &id)
         {
-            undefined_metadata.emplace(meta_type, id);
+            already_reported.emplace(meta_type, id);
         }
 
-        std::multimap<std::string, std::string> undefined_metadata;
+        std::multimap<std::string, std::string> already_reported;
         bool skip;
     };
 

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 819 "src/vcf/vcf_v41.ragel"
+#line 817 "src/vcf/vcf_v41.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v41_en_meta_section_skip = 652;
 static const int vcf_v41_en_body_section_skip = 653;
 
 
-#line 825 "src/vcf/vcf_v41.ragel"
+#line 823 "src/vcf/vcf_v41.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v41_start;
 	}
 
-#line 839 "src/vcf/vcf_v41.ragel"
+#line 837 "src/vcf/vcf_v41.ragel"
 
     }
 
@@ -84,7 +84,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 225 "src/vcf/vcf_v41.ragel"
+#line 223 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
@@ -107,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 336 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -115,7 +115,7 @@ tr24:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -128,7 +128,7 @@ tr24:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -141,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 336 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -149,7 +149,7 @@ tr26:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -162,7 +162,7 @@ tr26:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -170,47 +170,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 242 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 248 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 292 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 298 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -229,7 +229,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -241,13 +241,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -259,12 +259,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -276,12 +276,12 @@ tr152:
     }
 	goto st0;
 tr162:
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -293,7 +293,7 @@ tr162:
     }
 	goto st0;
 tr165:
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -305,12 +305,12 @@ tr165:
     }
 	goto st0;
 tr175:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -322,12 +322,12 @@ tr175:
     }
 	goto st0;
 tr194:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -339,7 +339,7 @@ tr194:
     }
 	goto st0;
 tr204:
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -351,12 +351,12 @@ tr204:
     }
 	goto st0;
 tr214:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -368,12 +368,12 @@ tr214:
     }
 	goto st0;
 tr227:
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -385,12 +385,12 @@ tr227:
     }
 	goto st0;
 tr236:
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 286 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -402,12 +402,12 @@ tr236:
     }
 	goto st0;
 tr253:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -419,7 +419,7 @@ tr253:
     }
 	goto st0;
 tr264:
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -431,12 +431,12 @@ tr264:
     }
 	goto st0;
 tr273:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -448,12 +448,12 @@ tr273:
     }
 	goto st0;
 tr286:
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -465,12 +465,12 @@ tr286:
     }
 	goto st0;
 tr295:
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 286 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -482,12 +482,12 @@ tr295:
     }
 	goto st0;
 tr312:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -499,7 +499,7 @@ tr312:
     }
 	goto st0;
 tr323:
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 292 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -511,12 +511,12 @@ tr323:
     }
 	goto st0;
 tr333:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 292 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -528,7 +528,7 @@ tr333:
     }
 	goto st0;
 tr345:
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -540,12 +540,12 @@ tr345:
     }
 	goto st0;
 tr356:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -557,17 +557,17 @@ tr356:
     }
 	goto st0;
 tr361:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -579,12 +579,12 @@ tr361:
     }
 	goto st0;
 tr363:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -596,17 +596,17 @@ tr363:
     }
 	goto st0;
 tr373:
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -618,12 +618,12 @@ tr373:
     }
 	goto st0;
 tr376:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -635,17 +635,17 @@ tr376:
     }
 	goto st0;
 tr386:
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -657,12 +657,12 @@ tr386:
     }
 	goto st0;
 tr389:
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -674,7 +674,7 @@ tr389:
     }
 	goto st0;
 tr412:
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 242 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -686,12 +686,12 @@ tr412:
     }
 	goto st0;
 tr421:
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 242 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -703,7 +703,7 @@ tr421:
     }
 	goto st0;
 tr442:
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 248 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -715,12 +715,12 @@ tr442:
     }
 	goto st0;
 tr453:
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 248 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -732,7 +732,7 @@ tr453:
     }
 	goto st0;
 tr491:
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 298 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -744,12 +744,12 @@ tr491:
     }
 	goto st0;
 tr503:
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 298 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -761,7 +761,7 @@ tr503:
     }
 	goto st0;
 tr526:
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 336 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -769,7 +769,7 @@ tr526:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -782,7 +782,7 @@ tr526:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -797,7 +797,7 @@ tr566:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -805,7 +805,7 @@ tr566:
     }
 	goto st0;
 tr581:
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 353 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
@@ -817,7 +817,7 @@ tr581:
     }
 	goto st0;
 tr584:
-#line 361 "src/vcf/vcf_v41.ragel"
+#line 359 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st653;}
@@ -829,7 +829,7 @@ tr584:
     }
 	goto st0;
 tr588:
-#line 367 "src/vcf/vcf_v41.ragel"
+#line 365 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st653;}
@@ -841,7 +841,7 @@ tr588:
     }
 	goto st0;
 tr593:
-#line 373 "src/vcf/vcf_v41.ragel"
+#line 371 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st653;}
@@ -853,7 +853,7 @@ tr593:
     }
 	goto st0;
 tr597:
-#line 379 "src/vcf/vcf_v41.ragel"
+#line 377 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st653;}
@@ -865,7 +865,7 @@ tr597:
     }
 	goto st0;
 tr606:
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 383 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st653;}
@@ -877,7 +877,7 @@ tr606:
     }
 	goto st0;
 tr617:
-#line 391 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st653;}
@@ -889,12 +889,12 @@ tr617:
     }
 	goto st0;
 tr625:
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -906,7 +906,7 @@ tr625:
     }
 	goto st0;
 tr647:
-#line 557 "src/vcf/vcf_v41.ragel"
+#line 555 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st653;}
@@ -918,14 +918,14 @@ tr647:
     }
 	goto st0;
 tr652:
-#line 570 "src/vcf/vcf_v41.ragel"
+#line 568 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 561 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -939,7 +939,7 @@ tr652:
     }
 	goto st0;
 tr656:
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 561 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -960,12 +960,12 @@ tr663:
     }
 	goto st0;
 tr672:
-#line 407 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -977,7 +977,7 @@ tr672:
     }
 	goto st0;
 tr674:
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 546 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -985,12 +985,12 @@ tr674:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1002,7 +1002,7 @@ tr674:
     }
 	goto st0;
 tr676:
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 546 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1010,7 +1010,7 @@ tr676:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1022,7 +1022,7 @@ tr676:
     }
 	goto st0;
 tr683:
-#line 412 "src/vcf/vcf_v41.ragel"
+#line 410 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1030,7 +1030,7 @@ tr683:
                 "AA"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1042,7 +1042,7 @@ tr683:
     }
 	goto st0;
 tr686:
-#line 420 "src/vcf/vcf_v41.ragel"
+#line 418 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1050,7 +1050,7 @@ tr686:
                 "AC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1062,7 +1062,7 @@ tr686:
     }
 	goto st0;
 tr689:
-#line 428 "src/vcf/vcf_v41.ragel"
+#line 426 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1070,7 +1070,7 @@ tr689:
                 "AF"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1082,7 +1082,7 @@ tr689:
     }
 	goto st0;
 tr703:
-#line 436 "src/vcf/vcf_v41.ragel"
+#line 434 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1090,7 +1090,7 @@ tr703:
                 "AN"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1102,7 +1102,7 @@ tr703:
     }
 	goto st0;
 tr707:
-#line 444 "src/vcf/vcf_v41.ragel"
+#line 442 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1110,7 +1110,7 @@ tr707:
                 "BQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1122,7 +1122,7 @@ tr707:
     }
 	goto st0;
 tr725:
-#line 452 "src/vcf/vcf_v41.ragel"
+#line 450 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1130,7 +1130,7 @@ tr725:
                 "CIGAR"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1142,7 +1142,7 @@ tr725:
     }
 	goto st0;
 tr730:
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 458 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1150,12 +1150,12 @@ tr730:
                 "DB"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1167,7 +1167,7 @@ tr730:
     }
 	goto st0;
 tr732:
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 458 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1175,7 +1175,7 @@ tr732:
                 "DB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1187,7 +1187,7 @@ tr732:
     }
 	goto st0;
 tr735:
-#line 468 "src/vcf/vcf_v41.ragel"
+#line 466 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1195,7 +1195,7 @@ tr735:
                 "DP"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1207,7 +1207,7 @@ tr735:
     }
 	goto st0;
 tr740:
-#line 476 "src/vcf/vcf_v41.ragel"
+#line 474 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1215,7 +1215,7 @@ tr740:
                 "END"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1227,7 +1227,7 @@ tr740:
     }
 	goto st0;
 tr744:
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 482 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1235,12 +1235,12 @@ tr744:
                 "H2"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1252,7 +1252,7 @@ tr744:
     }
 	goto st0;
 tr746:
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 482 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1260,7 +1260,7 @@ tr746:
                 "H2"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1272,7 +1272,7 @@ tr746:
     }
 	goto st0;
 tr748:
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 490 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1280,12 +1280,12 @@ tr748:
                 "H3"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1297,7 +1297,7 @@ tr748:
     }
 	goto st0;
 tr750:
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 490 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1305,7 +1305,7 @@ tr750:
                 "H3"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1317,7 +1317,7 @@ tr750:
     }
 	goto st0;
 tr756:
-#line 508 "src/vcf/vcf_v41.ragel"
+#line 506 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1325,7 +1325,7 @@ tr756:
                 "MQ0"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1337,7 +1337,7 @@ tr756:
     }
 	goto st0;
 tr758:
-#line 500 "src/vcf/vcf_v41.ragel"
+#line 498 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1345,7 +1345,7 @@ tr758:
                 "MQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1357,7 +1357,7 @@ tr758:
     }
 	goto st0;
 tr773:
-#line 516 "src/vcf/vcf_v41.ragel"
+#line 514 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1365,7 +1365,7 @@ tr773:
                 "NS"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1377,7 +1377,7 @@ tr773:
     }
 	goto st0;
 tr778:
-#line 524 "src/vcf/vcf_v41.ragel"
+#line 522 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1385,7 +1385,7 @@ tr778:
                 "SB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1397,7 +1397,7 @@ tr778:
     }
 	goto st0;
 tr796:
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 530 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1405,12 +1405,12 @@ tr796:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1422,7 +1422,7 @@ tr796:
     }
 	goto st0;
 tr798:
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 530 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1430,7 +1430,7 @@ tr798:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1442,7 +1442,7 @@ tr798:
     }
 	goto st0;
 tr808:
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 538 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1450,12 +1450,12 @@ tr808:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1467,7 +1467,7 @@ tr808:
     }
 	goto st0;
 tr810:
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 538 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1475,7 +1475,7 @@ tr810:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -1494,13 +1494,13 @@ tr859:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st653;}
     }
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 353 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
@@ -1715,7 +1715,7 @@ tr22:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           p--; {goto st652;}
         }
@@ -1849,7 +1849,7 @@ tr45:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -1869,7 +1869,7 @@ tr55:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -1901,7 +1901,7 @@ tr46:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -1921,7 +1921,7 @@ tr56:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -6790,7 +6790,7 @@ tr438:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -8011,7 +8011,7 @@ tr522:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -8567,7 +8567,7 @@ tr860:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -8609,7 +8609,7 @@ tr861:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -8653,7 +8653,7 @@ tr862:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -9401,12 +9401,10 @@ tr643:
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -9425,7 +9423,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 9429 "inc/vcf/validator_detail_v41.hpp"
+#line 9427 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr864;
 		case 13: goto tr865;
@@ -9445,7 +9443,7 @@ tr863:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -9454,7 +9452,7 @@ st462:
 	if ( ++p == pe )
 		goto _test_eof462;
 case 462:
-#line 9458 "inc/vcf/validator_detail_v41.hpp"
+#line 9456 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr659;
@@ -9484,7 +9482,7 @@ st463:
 	if ( ++p == pe )
 		goto _test_eof463;
 case 463:
-#line 9488 "inc/vcf/validator_detail_v41.hpp"
+#line 9486 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr660;
 		case 62: goto tr661;
@@ -9508,7 +9506,7 @@ st464:
 	if ( ++p == pe )
 		goto _test_eof464;
 case 464:
-#line 9512 "inc/vcf/validator_detail_v41.hpp"
+#line 9510 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr662;
 	goto tr581;
@@ -9535,12 +9533,10 @@ tr644:
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -9559,7 +9555,7 @@ st465:
 	if ( ++p == pe )
 		goto _test_eof465;
 case 465:
-#line 9563 "inc/vcf/validator_detail_v41.hpp"
+#line 9559 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st656;
 	goto tr663;
@@ -9573,7 +9569,7 @@ st466:
 	if ( ++p == pe )
 		goto _test_eof466;
 case 466:
-#line 9577 "inc/vcf/validator_detail_v41.hpp"
+#line 9573 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr657;
@@ -9600,7 +9596,7 @@ st467:
 	if ( ++p == pe )
 		goto _test_eof467;
 case 467:
-#line 9604 "inc/vcf/validator_detail_v41.hpp"
+#line 9600 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9622,7 +9618,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 9626 "inc/vcf/validator_detail_v41.hpp"
+#line 9622 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9659,7 +9655,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 9663 "inc/vcf/validator_detail_v41.hpp"
+#line 9659 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr649;
 		case 10: goto tr643;
@@ -9687,7 +9683,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 9691 "inc/vcf/validator_detail_v41.hpp"
+#line 9687 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 49: goto tr629;
 		case 58: goto tr626;
@@ -9738,7 +9734,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 9742 "inc/vcf/validator_detail_v41.hpp"
+#line 9738 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9760,7 +9756,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 9764 "inc/vcf/validator_detail_v41.hpp"
+#line 9760 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9782,7 +9778,7 @@ st473:
 	if ( ++p == pe )
 		goto _test_eof473;
 case 473:
-#line 9786 "inc/vcf/validator_detail_v41.hpp"
+#line 9782 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9804,7 +9800,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 9808 "inc/vcf/validator_detail_v41.hpp"
+#line 9804 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9826,7 +9822,7 @@ st475:
 	if ( ++p == pe )
 		goto _test_eof475;
 case 475:
-#line 9830 "inc/vcf/validator_detail_v41.hpp"
+#line 9826 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr673;
@@ -9843,7 +9839,7 @@ st476:
 	if ( ++p == pe )
 		goto _test_eof476;
 case 476:
-#line 9847 "inc/vcf/validator_detail_v41.hpp"
+#line 9843 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9863,7 +9859,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 9867 "inc/vcf/validator_detail_v41.hpp"
+#line 9863 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9884,7 +9880,7 @@ st478:
 	if ( ++p == pe )
 		goto _test_eof478;
 case 478:
-#line 9888 "inc/vcf/validator_detail_v41.hpp"
+#line 9884 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr677;
 	goto tr676;
@@ -9898,7 +9894,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 9902 "inc/vcf/validator_detail_v41.hpp"
+#line 9898 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9920,7 +9916,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 9924 "inc/vcf/validator_detail_v41.hpp"
+#line 9920 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -9945,7 +9941,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 9949 "inc/vcf/validator_detail_v41.hpp"
+#line 9945 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr682;
 	if ( (*p) > 58 ) {
@@ -9964,7 +9960,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 9968 "inc/vcf/validator_detail_v41.hpp"
+#line 9964 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr684;
 	if ( (*p) < 45 ) {
@@ -9986,7 +9982,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 9990 "inc/vcf/validator_detail_v41.hpp"
+#line 9986 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10012,7 +10008,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10016 "inc/vcf/validator_detail_v41.hpp"
+#line 10012 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr685;
 	if ( (*p) > 58 ) {
@@ -10031,7 +10027,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10035 "inc/vcf/validator_detail_v41.hpp"
+#line 10031 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr687;
 	goto tr686;
@@ -10045,7 +10041,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 10049 "inc/vcf/validator_detail_v41.hpp"
+#line 10045 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10066,7 +10062,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 10070 "inc/vcf/validator_detail_v41.hpp"
+#line 10066 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr688;
 	if ( (*p) > 58 ) {
@@ -10085,7 +10081,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 10089 "inc/vcf/validator_detail_v41.hpp"
+#line 10085 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr690;
 		case 45: goto tr690;
@@ -10105,7 +10101,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 10109 "inc/vcf/validator_detail_v41.hpp"
+#line 10105 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr692;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10121,7 +10117,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10125 "inc/vcf/validator_detail_v41.hpp"
+#line 10121 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10145,7 +10141,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 10149 "inc/vcf/validator_detail_v41.hpp"
+#line 10145 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr696;
 	goto tr689;
@@ -10159,7 +10155,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 10163 "inc/vcf/validator_detail_v41.hpp"
+#line 10159 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10182,7 +10178,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 10186 "inc/vcf/validator_detail_v41.hpp"
+#line 10182 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr697;
 		case 45: goto tr697;
@@ -10200,7 +10196,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 10204 "inc/vcf/validator_detail_v41.hpp"
+#line 10200 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr698;
 	goto tr689;
@@ -10214,7 +10210,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10218 "inc/vcf/validator_detail_v41.hpp"
+#line 10214 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10235,7 +10231,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10239 "inc/vcf/validator_detail_v41.hpp"
+#line 10235 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr699;
 	goto tr689;
@@ -10249,7 +10245,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10253 "inc/vcf/validator_detail_v41.hpp"
+#line 10249 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr700;
 	goto tr689;
@@ -10263,7 +10259,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10267 "inc/vcf/validator_detail_v41.hpp"
+#line 10263 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10282,7 +10278,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10286 "inc/vcf/validator_detail_v41.hpp"
+#line 10282 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr701;
 	goto tr689;
@@ -10296,7 +10292,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10300 "inc/vcf/validator_detail_v41.hpp"
+#line 10296 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr700;
 	goto tr689;
@@ -10310,7 +10306,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 10314 "inc/vcf/validator_detail_v41.hpp"
+#line 10310 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr702;
 	if ( (*p) > 58 ) {
@@ -10329,7 +10325,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10333 "inc/vcf/validator_detail_v41.hpp"
+#line 10329 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr704;
 	goto tr703;
@@ -10343,7 +10339,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 10347 "inc/vcf/validator_detail_v41.hpp"
+#line 10343 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10367,7 +10363,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 10371 "inc/vcf/validator_detail_v41.hpp"
+#line 10367 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10389,7 +10385,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 10393 "inc/vcf/validator_detail_v41.hpp"
+#line 10389 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr706;
 	if ( (*p) > 58 ) {
@@ -10408,7 +10404,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 10412 "inc/vcf/validator_detail_v41.hpp"
+#line 10408 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr708;
 		case 45: goto tr708;
@@ -10428,7 +10424,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 10432 "inc/vcf/validator_detail_v41.hpp"
+#line 10428 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr710;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10444,7 +10440,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 10448 "inc/vcf/validator_detail_v41.hpp"
+#line 10444 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10467,7 +10463,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10471 "inc/vcf/validator_detail_v41.hpp"
+#line 10467 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr714;
 	goto tr707;
@@ -10481,7 +10477,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10485 "inc/vcf/validator_detail_v41.hpp"
+#line 10481 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10503,7 +10499,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 10507 "inc/vcf/validator_detail_v41.hpp"
+#line 10503 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr715;
 		case 45: goto tr715;
@@ -10521,7 +10517,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 10525 "inc/vcf/validator_detail_v41.hpp"
+#line 10521 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr716;
 	goto tr707;
@@ -10535,7 +10531,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 10539 "inc/vcf/validator_detail_v41.hpp"
+#line 10535 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10555,7 +10551,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 10559 "inc/vcf/validator_detail_v41.hpp"
+#line 10555 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr717;
 	goto tr707;
@@ -10569,7 +10565,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 10573 "inc/vcf/validator_detail_v41.hpp"
+#line 10569 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr718;
 	goto tr707;
@@ -10583,7 +10579,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 10587 "inc/vcf/validator_detail_v41.hpp"
+#line 10583 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10601,7 +10597,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 10605 "inc/vcf/validator_detail_v41.hpp"
+#line 10601 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr719;
 	goto tr707;
@@ -10615,7 +10611,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 10619 "inc/vcf/validator_detail_v41.hpp"
+#line 10615 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr718;
 	goto tr707;
@@ -10633,7 +10629,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 10637 "inc/vcf/validator_detail_v41.hpp"
+#line 10633 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10655,7 +10651,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 10659 "inc/vcf/validator_detail_v41.hpp"
+#line 10655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10677,7 +10673,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 10681 "inc/vcf/validator_detail_v41.hpp"
+#line 10677 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10699,7 +10695,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 10703 "inc/vcf/validator_detail_v41.hpp"
+#line 10699 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10721,7 +10717,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 10725 "inc/vcf/validator_detail_v41.hpp"
+#line 10721 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr724;
 	if ( (*p) > 58 ) {
@@ -10740,7 +10736,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 10744 "inc/vcf/validator_detail_v41.hpp"
+#line 10740 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr726;
 	goto tr725;
@@ -10754,7 +10750,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 10758 "inc/vcf/validator_detail_v41.hpp"
+#line 10754 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 68: goto tr727;
 		case 80: goto tr727;
@@ -10780,7 +10776,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 10784 "inc/vcf/validator_detail_v41.hpp"
+#line 10780 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10804,7 +10800,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 10808 "inc/vcf/validator_detail_v41.hpp"
+#line 10804 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10827,7 +10823,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 10831 "inc/vcf/validator_detail_v41.hpp"
+#line 10827 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10848,7 +10844,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 10852 "inc/vcf/validator_detail_v41.hpp"
+#line 10848 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr733;
 	goto tr732;
@@ -10862,7 +10858,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 10866 "inc/vcf/validator_detail_v41.hpp"
+#line 10862 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10880,7 +10876,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 10884 "inc/vcf/validator_detail_v41.hpp"
+#line 10880 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr734;
 	if ( (*p) > 58 ) {
@@ -10899,7 +10895,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 10903 "inc/vcf/validator_detail_v41.hpp"
+#line 10899 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr736;
 	goto tr735;
@@ -10913,7 +10909,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 10917 "inc/vcf/validator_detail_v41.hpp"
+#line 10913 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10937,7 +10933,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 10941 "inc/vcf/validator_detail_v41.hpp"
+#line 10937 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10959,7 +10955,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 10963 "inc/vcf/validator_detail_v41.hpp"
+#line 10959 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -10981,7 +10977,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 10985 "inc/vcf/validator_detail_v41.hpp"
+#line 10981 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr739;
 	if ( (*p) > 58 ) {
@@ -11000,7 +10996,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 11004 "inc/vcf/validator_detail_v41.hpp"
+#line 11000 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr741;
 	goto tr740;
@@ -11014,7 +11010,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 11018 "inc/vcf/validator_detail_v41.hpp"
+#line 11014 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11038,7 +11034,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 11042 "inc/vcf/validator_detail_v41.hpp"
+#line 11038 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11061,7 +11057,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 11065 "inc/vcf/validator_detail_v41.hpp"
+#line 11061 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11082,7 +11078,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 11086 "inc/vcf/validator_detail_v41.hpp"
+#line 11082 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr747;
 	goto tr746;
@@ -11096,7 +11092,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 11100 "inc/vcf/validator_detail_v41.hpp"
+#line 11096 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11114,7 +11110,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 11118 "inc/vcf/validator_detail_v41.hpp"
+#line 11114 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11135,7 +11131,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 11139 "inc/vcf/validator_detail_v41.hpp"
+#line 11135 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr751;
 	goto tr750;
@@ -11149,7 +11145,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 11153 "inc/vcf/validator_detail_v41.hpp"
+#line 11149 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11171,7 +11167,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 11175 "inc/vcf/validator_detail_v41.hpp"
+#line 11171 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11193,7 +11189,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 11197 "inc/vcf/validator_detail_v41.hpp"
+#line 11193 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 48: goto tr753;
 		case 61: goto tr754;
@@ -11214,7 +11210,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 11218 "inc/vcf/validator_detail_v41.hpp"
+#line 11214 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr755;
 	if ( (*p) > 58 ) {
@@ -11233,7 +11229,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 11237 "inc/vcf/validator_detail_v41.hpp"
+#line 11233 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr757;
 	goto tr756;
@@ -11247,7 +11243,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 11251 "inc/vcf/validator_detail_v41.hpp"
+#line 11247 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11267,7 +11263,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 11271 "inc/vcf/validator_detail_v41.hpp"
+#line 11267 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr759;
 		case 45: goto tr759;
@@ -11287,7 +11283,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 11291 "inc/vcf/validator_detail_v41.hpp"
+#line 11287 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr761;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11303,7 +11299,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 11307 "inc/vcf/validator_detail_v41.hpp"
+#line 11303 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11326,7 +11322,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 11330 "inc/vcf/validator_detail_v41.hpp"
+#line 11326 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr765;
 	goto tr758;
@@ -11340,7 +11336,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 11344 "inc/vcf/validator_detail_v41.hpp"
+#line 11340 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11362,7 +11358,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 11366 "inc/vcf/validator_detail_v41.hpp"
+#line 11362 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr766;
 		case 45: goto tr766;
@@ -11380,7 +11376,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 11384 "inc/vcf/validator_detail_v41.hpp"
+#line 11380 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr767;
 	goto tr758;
@@ -11394,7 +11390,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 11398 "inc/vcf/validator_detail_v41.hpp"
+#line 11394 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11414,7 +11410,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 11418 "inc/vcf/validator_detail_v41.hpp"
+#line 11414 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr768;
 	goto tr758;
@@ -11428,7 +11424,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 11432 "inc/vcf/validator_detail_v41.hpp"
+#line 11428 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr769;
 	goto tr758;
@@ -11442,7 +11438,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 11446 "inc/vcf/validator_detail_v41.hpp"
+#line 11442 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11460,7 +11456,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 11464 "inc/vcf/validator_detail_v41.hpp"
+#line 11460 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr770;
 	goto tr758;
@@ -11474,7 +11470,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 11478 "inc/vcf/validator_detail_v41.hpp"
+#line 11474 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr769;
 	goto tr758;
@@ -11492,7 +11488,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 11496 "inc/vcf/validator_detail_v41.hpp"
+#line 11492 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11514,7 +11510,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 11518 "inc/vcf/validator_detail_v41.hpp"
+#line 11514 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr772;
 	if ( (*p) > 58 ) {
@@ -11533,7 +11529,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 11537 "inc/vcf/validator_detail_v41.hpp"
+#line 11533 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr774;
 	goto tr773;
@@ -11547,7 +11543,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 11551 "inc/vcf/validator_detail_v41.hpp"
+#line 11547 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11571,7 +11567,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 11575 "inc/vcf/validator_detail_v41.hpp"
+#line 11571 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11594,7 +11590,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 11598 "inc/vcf/validator_detail_v41.hpp"
+#line 11594 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr777;
 	if ( (*p) > 58 ) {
@@ -11613,7 +11609,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 11617 "inc/vcf/validator_detail_v41.hpp"
+#line 11613 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr779;
 		case 45: goto tr779;
@@ -11633,7 +11629,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 11637 "inc/vcf/validator_detail_v41.hpp"
+#line 11633 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr781;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11649,7 +11645,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 11653 "inc/vcf/validator_detail_v41.hpp"
+#line 11649 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11672,7 +11668,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 11676 "inc/vcf/validator_detail_v41.hpp"
+#line 11672 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr785;
 	goto tr778;
@@ -11686,7 +11682,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 11690 "inc/vcf/validator_detail_v41.hpp"
+#line 11686 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11708,7 +11704,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 11712 "inc/vcf/validator_detail_v41.hpp"
+#line 11708 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr786;
 		case 45: goto tr786;
@@ -11726,7 +11722,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 11730 "inc/vcf/validator_detail_v41.hpp"
+#line 11726 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr787;
 	goto tr778;
@@ -11740,7 +11736,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 11744 "inc/vcf/validator_detail_v41.hpp"
+#line 11740 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11760,7 +11756,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 11764 "inc/vcf/validator_detail_v41.hpp"
+#line 11760 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr788;
 	goto tr778;
@@ -11774,7 +11770,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 11778 "inc/vcf/validator_detail_v41.hpp"
+#line 11774 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr789;
 	goto tr778;
@@ -11788,7 +11784,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 11792 "inc/vcf/validator_detail_v41.hpp"
+#line 11788 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11806,7 +11802,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 11810 "inc/vcf/validator_detail_v41.hpp"
+#line 11806 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr790;
 	goto tr778;
@@ -11820,7 +11816,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 11824 "inc/vcf/validator_detail_v41.hpp"
+#line 11820 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr789;
 	goto tr778;
@@ -11834,7 +11830,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 11838 "inc/vcf/validator_detail_v41.hpp"
+#line 11834 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11856,7 +11852,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 11860 "inc/vcf/validator_detail_v41.hpp"
+#line 11856 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11878,7 +11874,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 11882 "inc/vcf/validator_detail_v41.hpp"
+#line 11878 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11900,7 +11896,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 11904 "inc/vcf/validator_detail_v41.hpp"
+#line 11900 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11922,7 +11918,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 11926 "inc/vcf/validator_detail_v41.hpp"
+#line 11922 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11944,7 +11940,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 11948 "inc/vcf/validator_detail_v41.hpp"
+#line 11944 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -11965,7 +11961,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 11969 "inc/vcf/validator_detail_v41.hpp"
+#line 11965 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr799;
 	goto tr798;
@@ -11979,7 +11975,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 11983 "inc/vcf/validator_detail_v41.hpp"
+#line 11979 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12001,7 +11997,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12005 "inc/vcf/validator_detail_v41.hpp"
+#line 12001 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12023,7 +12019,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12027 "inc/vcf/validator_detail_v41.hpp"
+#line 12023 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12045,7 +12041,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12049 "inc/vcf/validator_detail_v41.hpp"
+#line 12045 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12067,7 +12063,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 12071 "inc/vcf/validator_detail_v41.hpp"
+#line 12067 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12089,7 +12085,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 12093 "inc/vcf/validator_detail_v41.hpp"
+#line 12089 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12111,7 +12107,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 12115 "inc/vcf/validator_detail_v41.hpp"
+#line 12111 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12133,7 +12129,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 12137 "inc/vcf/validator_detail_v41.hpp"
+#line 12133 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12155,7 +12151,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 12159 "inc/vcf/validator_detail_v41.hpp"
+#line 12155 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12177,7 +12173,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 12181 "inc/vcf/validator_detail_v41.hpp"
+#line 12177 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12198,7 +12194,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 12202 "inc/vcf/validator_detail_v41.hpp"
+#line 12198 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr811;
 	goto tr810;
@@ -12212,7 +12208,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 12216 "inc/vcf/validator_detail_v41.hpp"
+#line 12212 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12234,7 +12230,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 12238 "inc/vcf/validator_detail_v41.hpp"
+#line 12234 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr642;
 		case 10: goto tr643;
@@ -12273,7 +12269,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 12277 "inc/vcf/validator_detail_v41.hpp"
+#line 12273 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr618;
 	if ( (*p) < 65 ) {
@@ -12311,7 +12307,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 12315 "inc/vcf/validator_detail_v41.hpp"
+#line 12311 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 58: goto st453;
@@ -12347,7 +12343,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 12351 "inc/vcf/validator_detail_v41.hpp"
+#line 12347 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr812;
 	goto tr606;
@@ -12361,7 +12357,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 12365 "inc/vcf/validator_detail_v41.hpp"
+#line 12361 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 69: goto tr616;
@@ -12380,7 +12376,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 12384 "inc/vcf/validator_detail_v41.hpp"
+#line 12380 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr813;
 		case 45: goto tr813;
@@ -12398,7 +12394,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 12402 "inc/vcf/validator_detail_v41.hpp"
+#line 12398 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr814;
 	goto tr606;
@@ -12412,7 +12408,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 12416 "inc/vcf/validator_detail_v41.hpp"
+#line 12412 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12438,7 +12434,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 12442 "inc/vcf/validator_detail_v41.hpp"
+#line 12438 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr815;
 	goto tr606;
@@ -12452,7 +12448,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 12456 "inc/vcf/validator_detail_v41.hpp"
+#line 12452 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr816;
 	goto tr606;
@@ -12476,7 +12472,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 12480 "inc/vcf/validator_detail_v41.hpp"
+#line 12476 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	goto tr606;
@@ -12494,7 +12490,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 12498 "inc/vcf/validator_detail_v41.hpp"
+#line 12494 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr817;
 	goto tr606;
@@ -12508,7 +12504,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 12512 "inc/vcf/validator_detail_v41.hpp"
+#line 12508 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr816;
 	goto tr606;
@@ -12522,7 +12518,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 12526 "inc/vcf/validator_detail_v41.hpp"
+#line 12522 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr818;
@@ -12561,7 +12557,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 12565 "inc/vcf/validator_detail_v41.hpp"
+#line 12561 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr819;
 		case 67: goto tr819;
@@ -12585,7 +12581,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 12589 "inc/vcf/validator_detail_v41.hpp"
+#line 12585 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12621,7 +12617,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 12625 "inc/vcf/validator_detail_v41.hpp"
+#line 12621 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr820;
 	if ( (*p) < 63 ) {
@@ -12661,7 +12657,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 12665 "inc/vcf/validator_detail_v41.hpp"
+#line 12661 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto tr822;
 	if ( (*p) < 45 ) {
@@ -12693,7 +12689,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 12697 "inc/vcf/validator_detail_v41.hpp"
+#line 12693 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12722,7 +12718,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 12726 "inc/vcf/validator_detail_v41.hpp"
+#line 12722 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr827;
 	if ( (*p) < 65 ) {
@@ -12744,7 +12740,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 12748 "inc/vcf/validator_detail_v41.hpp"
+#line 12744 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr828;
 		case 61: goto tr826;
@@ -12768,7 +12764,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 12772 "inc/vcf/validator_detail_v41.hpp"
+#line 12768 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr829;
 	goto tr597;
@@ -12782,7 +12778,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 12786 "inc/vcf/validator_detail_v41.hpp"
+#line 12782 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12798,7 +12794,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 12802 "inc/vcf/validator_detail_v41.hpp"
+#line 12798 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr830;
@@ -12818,7 +12814,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 12822 "inc/vcf/validator_detail_v41.hpp"
+#line 12818 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr830;
 		case 62: goto tr831;
@@ -12842,7 +12838,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 12846 "inc/vcf/validator_detail_v41.hpp"
+#line 12842 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr828;
 	goto tr597;
@@ -12856,7 +12852,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 12860 "inc/vcf/validator_detail_v41.hpp"
+#line 12856 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr833;
 	if ( (*p) < 65 ) {
@@ -12878,7 +12874,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 12882 "inc/vcf/validator_detail_v41.hpp"
+#line 12878 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr834;
 		case 61: goto tr832;
@@ -12902,7 +12898,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 12906 "inc/vcf/validator_detail_v41.hpp"
+#line 12902 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr597;
@@ -12916,7 +12912,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 12920 "inc/vcf/validator_detail_v41.hpp"
+#line 12916 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12932,7 +12928,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 12936 "inc/vcf/validator_detail_v41.hpp"
+#line 12932 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr836;
@@ -12952,7 +12948,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 12956 "inc/vcf/validator_detail_v41.hpp"
+#line 12952 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr836;
 		case 62: goto tr837;
@@ -12976,7 +12972,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 12980 "inc/vcf/validator_detail_v41.hpp"
+#line 12976 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr834;
 	goto tr597;
@@ -12994,7 +12990,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 12998 "inc/vcf/validator_detail_v41.hpp"
+#line 12994 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr839;
 	if ( (*p) < 65 ) {
@@ -13016,7 +13012,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13020 "inc/vcf/validator_detail_v41.hpp"
+#line 13016 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr840;
 		case 61: goto tr838;
@@ -13040,7 +13036,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 13044 "inc/vcf/validator_detail_v41.hpp"
+#line 13040 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr841;
 	goto tr597;
@@ -13054,7 +13050,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 13058 "inc/vcf/validator_detail_v41.hpp"
+#line 13054 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr842;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13070,7 +13066,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 13074 "inc/vcf/validator_detail_v41.hpp"
+#line 13070 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr843;
@@ -13090,7 +13086,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 13094 "inc/vcf/validator_detail_v41.hpp"
+#line 13090 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr843;
 		case 62: goto tr844;
@@ -13114,7 +13110,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 13118 "inc/vcf/validator_detail_v41.hpp"
+#line 13114 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr840;
 	goto tr597;
@@ -13132,7 +13128,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 13136 "inc/vcf/validator_detail_v41.hpp"
+#line 13132 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr846;
 	if ( (*p) < 65 ) {
@@ -13154,7 +13150,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 13158 "inc/vcf/validator_detail_v41.hpp"
+#line 13154 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr847;
 		case 61: goto tr845;
@@ -13178,7 +13174,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 13182 "inc/vcf/validator_detail_v41.hpp"
+#line 13178 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr848;
 	goto tr597;
@@ -13192,7 +13188,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 13196 "inc/vcf/validator_detail_v41.hpp"
+#line 13192 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr842;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13208,7 +13204,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 13212 "inc/vcf/validator_detail_v41.hpp"
+#line 13208 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr849;
@@ -13228,7 +13224,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 13232 "inc/vcf/validator_detail_v41.hpp"
+#line 13228 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr849;
 		case 62: goto tr850;
@@ -13252,7 +13248,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 13256 "inc/vcf/validator_detail_v41.hpp"
+#line 13252 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr847;
 	goto tr597;
@@ -13270,7 +13266,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 13274 "inc/vcf/validator_detail_v41.hpp"
+#line 13270 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 65: goto tr819;
@@ -13325,7 +13321,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 13329 "inc/vcf/validator_detail_v41.hpp"
+#line 13325 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st654;
 	goto tr566;
@@ -13334,7 +13330,7 @@ tr23:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           p--; {goto st652;}
         }
@@ -13354,7 +13350,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 13358 "inc/vcf/validator_detail_v41.hpp"
+#line 13354 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -13374,7 +13370,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 13378 "inc/vcf/validator_detail_v41.hpp"
+#line 13374 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr854;
 		case 13: goto tr855;
@@ -13391,14 +13387,14 @@ tr854:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 817 "src/vcf/vcf_v41.ragel"
+#line 815 "src/vcf/vcf_v41.ragel"
 	{ {goto st28;} }
 	goto st657;
 st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 13402 "inc/vcf/validator_detail_v41.hpp"
+#line 13398 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 tr858:
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -13416,7 +13412,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 13420 "inc/vcf/validator_detail_v41.hpp"
+#line 13416 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr857;
 		case 13: goto tr858;
@@ -13433,14 +13429,14 @@ tr857:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 818 "src/vcf/vcf_v41.ragel"
+#line 816 "src/vcf/vcf_v41.ragel"
 	{ {goto st656;} }
 	goto st658;
 st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 13444 "inc/vcf/validator_detail_v41.hpp"
+#line 13440 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -14184,7 +14180,7 @@ case 658:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -14206,7 +14202,7 @@ case 658:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -14228,7 +14224,7 @@ case 658:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 225 "src/vcf/vcf_v41.ragel"
+#line 223 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
@@ -14261,7 +14257,7 @@ case 658:
 	case 95: 
 	case 96: 
 	case 100: 
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -14280,7 +14276,7 @@ case 658:
 	case 308: 
 	case 309: 
 	case 310: 
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 242 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -14320,7 +14316,7 @@ case 658:
 	case 358: 
 	case 359: 
 	case 360: 
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 248 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -14354,7 +14350,7 @@ case 658:
 	case 128: 
 	case 129: 
 	case 133: 
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -14400,7 +14396,7 @@ case 658:
 	case 176: 
 	case 177: 
 	case 181: 
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14445,7 +14441,7 @@ case 658:
 	case 224: 
 	case 225: 
 	case 229: 
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -14466,7 +14462,7 @@ case 658:
 	case 241: 
 	case 242: 
 	case 249: 
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 292 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -14488,7 +14484,7 @@ case 658:
 	case 369: 
 	case 370: 
 	case 371: 
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 298 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -14510,7 +14506,7 @@ case 658:
 	case 258: 
 	case 259: 
 	case 299: 
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -14558,7 +14554,7 @@ case 658:
 	case 427: 
 	case 428: 
 	case 429: 
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 336 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14566,7 +14562,7 @@ case 658:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -14579,7 +14575,7 @@ case 658:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -14590,7 +14586,7 @@ case 658:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 355 "src/vcf/vcf_v41.ragel"
+#line 353 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st653;}
@@ -14603,7 +14599,7 @@ case 658:
 	break;
 	case 441: 
 	case 442: 
-#line 361 "src/vcf/vcf_v41.ragel"
+#line 359 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st653;}
@@ -14616,7 +14612,7 @@ case 658:
 	break;
 	case 443: 
 	case 444: 
-#line 367 "src/vcf/vcf_v41.ragel"
+#line 365 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st653;}
@@ -14629,7 +14625,7 @@ case 658:
 	break;
 	case 445: 
 	case 446: 
-#line 373 "src/vcf/vcf_v41.ragel"
+#line 371 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st653;}
@@ -14677,7 +14673,7 @@ case 658:
 	case 647: 
 	case 648: 
 	case 649: 
-#line 379 "src/vcf/vcf_v41.ragel"
+#line 377 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st653;}
@@ -14701,7 +14697,7 @@ case 658:
 	case 612: 
 	case 613: 
 	case 614: 
-#line 385 "src/vcf/vcf_v41.ragel"
+#line 383 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st653;}
@@ -14717,7 +14713,7 @@ case 658:
 	case 454: 
 	case 603: 
 	case 604: 
-#line 391 "src/vcf/vcf_v41.ragel"
+#line 389 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st653;}
@@ -14730,7 +14726,7 @@ case 658:
 	break;
 	case 458: 
 	case 459: 
-#line 557 "src/vcf/vcf_v41.ragel"
+#line 555 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st653;}
@@ -14743,7 +14739,7 @@ case 658:
 	break;
 	case 461: 
 	case 466: 
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 561 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -14763,7 +14759,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 336 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14771,7 +14767,7 @@ case 658:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -14784,7 +14780,7 @@ case 658:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -14794,13 +14790,13 @@ case 658:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 237 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -14812,12 +14808,12 @@ case 658:
     }
 	break;
 	case 104: 
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14831,12 +14827,12 @@ case 658:
 	case 156: 
 	case 157: 
 	case 185: 
-#line 267 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14850,12 +14846,12 @@ case 658:
 	case 204: 
 	case 205: 
 	case 233: 
-#line 283 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -14868,12 +14864,12 @@ case 658:
 	break;
 	case 163: 
 	case 164: 
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 286 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -14886,12 +14882,12 @@ case 658:
 	break;
 	case 211: 
 	case 212: 
-#line 288 "src/vcf/vcf_v41.ragel"
+#line 286 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -14911,12 +14907,12 @@ case 658:
 	case 269: 
 	case 270: 
 	case 271: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -14936,12 +14932,12 @@ case 658:
 	case 279: 
 	case 280: 
 	case 281: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -14954,12 +14950,12 @@ case 658:
 	break;
 	case 340: 
 	case 341: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 248 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
@@ -14973,12 +14969,12 @@ case 658:
 	case 114: 
 	case 115: 
 	case 116: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -14992,12 +14988,12 @@ case 658:
 	case 146: 
 	case 147: 
 	case 148: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -15011,12 +15007,12 @@ case 658:
 	case 194: 
 	case 195: 
 	case 196: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -15033,12 +15029,12 @@ case 658:
 	case 246: 
 	case 247: 
 	case 248: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 292 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
@@ -15051,12 +15047,12 @@ case 658:
 	break;
 	case 260: 
 	case 261: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15073,12 +15069,12 @@ case 658:
 	case 101: 
 	case 102: 
 	case 103: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
@@ -15095,12 +15091,12 @@ case 658:
 	case 134: 
 	case 135: 
 	case 136: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
@@ -15117,12 +15113,12 @@ case 658:
 	case 182: 
 	case 183: 
 	case 184: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
@@ -15139,12 +15135,12 @@ case 658:
 	case 230: 
 	case 231: 
 	case 232: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
@@ -15174,12 +15170,12 @@ case 658:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15209,12 +15205,12 @@ case 658:
 	case 327: 
 	case 328: 
 	case 329: 
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 242 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
@@ -15246,12 +15242,12 @@ case 658:
 	case 390: 
 	case 391: 
 	case 392: 
-#line 332 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 298 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -15309,12 +15305,12 @@ case 658:
 	case 597: 
 	case 598: 
 	case 602: 
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15327,12 +15323,12 @@ case 658:
 	break;
 	case 475: 
 	case 476: 
-#line 407 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15345,7 +15341,7 @@ case 658:
 	break;
 	case 482: 
 	case 483: 
-#line 412 "src/vcf/vcf_v41.ragel"
+#line 410 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15353,7 +15349,7 @@ case 658:
                 "AA"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15366,7 +15362,7 @@ case 658:
 	break;
 	case 485: 
 	case 486: 
-#line 420 "src/vcf/vcf_v41.ragel"
+#line 418 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15374,7 +15370,7 @@ case 658:
                 "AC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15398,7 +15394,7 @@ case 658:
 	case 498: 
 	case 499: 
 	case 500: 
-#line 428 "src/vcf/vcf_v41.ragel"
+#line 426 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15406,7 +15402,7 @@ case 658:
                 "AF"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15419,7 +15415,7 @@ case 658:
 	break;
 	case 502: 
 	case 503: 
-#line 436 "src/vcf/vcf_v41.ragel"
+#line 434 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15427,7 +15423,7 @@ case 658:
                 "AN"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15451,7 +15447,7 @@ case 658:
 	case 516: 
 	case 517: 
 	case 518: 
-#line 444 "src/vcf/vcf_v41.ragel"
+#line 442 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15459,7 +15455,7 @@ case 658:
                 "BQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15473,7 +15469,7 @@ case 658:
 	case 524: 
 	case 525: 
 	case 526: 
-#line 452 "src/vcf/vcf_v41.ragel"
+#line 450 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15481,7 +15477,7 @@ case 658:
                 "CIGAR"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15494,7 +15490,7 @@ case 658:
 	break;
 	case 529: 
 	case 530: 
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 458 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15502,7 +15498,7 @@ case 658:
                 "DB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15515,7 +15511,7 @@ case 658:
 	break;
 	case 532: 
 	case 533: 
-#line 468 "src/vcf/vcf_v41.ragel"
+#line 466 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15523,7 +15519,7 @@ case 658:
                 "DP"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15536,7 +15532,7 @@ case 658:
 	break;
 	case 537: 
 	case 538: 
-#line 476 "src/vcf/vcf_v41.ragel"
+#line 474 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15544,7 +15540,7 @@ case 658:
                 "END"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15557,7 +15553,7 @@ case 658:
 	break;
 	case 541: 
 	case 542: 
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 482 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15565,7 +15561,7 @@ case 658:
                 "H2"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15578,7 +15574,7 @@ case 658:
 	break;
 	case 544: 
 	case 545: 
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 490 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15586,7 +15582,7 @@ case 658:
                 "H3"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15610,7 +15606,7 @@ case 658:
 	case 561: 
 	case 562: 
 	case 563: 
-#line 500 "src/vcf/vcf_v41.ragel"
+#line 498 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15618,7 +15614,7 @@ case 658:
                 "MQ"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15631,7 +15627,7 @@ case 658:
 	break;
 	case 549: 
 	case 550: 
-#line 508 "src/vcf/vcf_v41.ragel"
+#line 506 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15639,7 +15635,7 @@ case 658:
                 "MQ0"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15652,7 +15648,7 @@ case 658:
 	break;
 	case 566: 
 	case 567: 
-#line 516 "src/vcf/vcf_v41.ragel"
+#line 514 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15660,7 +15656,7 @@ case 658:
                 "NS"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15684,7 +15680,7 @@ case 658:
 	case 580: 
 	case 581: 
 	case 582: 
-#line 524 "src/vcf/vcf_v41.ragel"
+#line 522 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15692,7 +15688,7 @@ case 658:
                 "SB"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15705,7 +15701,7 @@ case 658:
 	break;
 	case 589: 
 	case 590: 
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 530 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15713,7 +15709,7 @@ case 658:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15726,7 +15722,7 @@ case 658:
 	break;
 	case 600: 
 	case 601: 
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 538 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15734,7 +15730,7 @@ case 658:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15747,7 +15743,7 @@ case 658:
 	break;
 	case 478: 
 	case 479: 
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 546 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15755,7 +15751,7 @@ case 658:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15770,14 +15766,14 @@ case 658:
 	case 467: 
 	case 468: 
 	case 469: 
-#line 570 "src/vcf/vcf_v41.ragel"
+#line 568 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st653;}
     }
-#line 563 "src/vcf/vcf_v41.ragel"
+#line 561 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -15801,7 +15797,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st652;}
     }
-#line 338 "src/vcf/vcf_v41.ragel"
+#line 336 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -15809,7 +15805,7 @@ case 658:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -15822,7 +15818,7 @@ case 658:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -15830,17 +15826,17 @@ case 658:
     }
 	break;
 	case 272: 
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15852,17 +15848,17 @@ case 658:
     }
 	break;
 	case 282: 
-#line 316 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 327 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15874,17 +15870,17 @@ case 658:
     }
 	break;
 	case 262: 
-#line 322 "src/vcf/vcf_v41.ragel"
+#line 320 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st652;}
     }
-#line 311 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
@@ -15896,7 +15892,7 @@ case 658:
     }
 	break;
 	case 528: 
-#line 460 "src/vcf/vcf_v41.ragel"
+#line 458 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15904,12 +15900,12 @@ case 658:
                 "DB"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15921,7 +15917,7 @@ case 658:
     }
 	break;
 	case 540: 
-#line 484 "src/vcf/vcf_v41.ragel"
+#line 482 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15929,12 +15925,12 @@ case 658:
                 "H2"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15946,7 +15942,7 @@ case 658:
     }
 	break;
 	case 543: 
-#line 492 "src/vcf/vcf_v41.ragel"
+#line 490 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15954,12 +15950,12 @@ case 658:
                 "H3"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15971,7 +15967,7 @@ case 658:
     }
 	break;
 	case 588: 
-#line 532 "src/vcf/vcf_v41.ragel"
+#line 530 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15979,12 +15975,12 @@ case 658:
                 "SOMATIC"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -15996,7 +15992,7 @@ case 658:
     }
 	break;
 	case 599: 
-#line 540 "src/vcf/vcf_v41.ragel"
+#line 538 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -16004,12 +16000,12 @@ case 658:
                 "VALIDATED"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -16021,7 +16017,7 @@ case 658:
     }
 	break;
 	case 477: 
-#line 548 "src/vcf/vcf_v41.ragel"
+#line 546 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -16029,12 +16025,12 @@ case 658:
                 "1000G"});
         p--; {goto st653;}
     }
-#line 402 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st653;}
     }
-#line 397 "src/vcf/vcf_v41.ragel"
+#line 395 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st653;}
@@ -16046,47 +16042,47 @@ case 658:
     }
 	break;
 	case 24: 
-#line 232 "src/vcf/vcf_v41.ragel"
+#line 230 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st652;}
     }
-#line 256 "src/vcf/vcf_v41.ragel"
+#line 254 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st652;}
     }
-#line 262 "src/vcf/vcf_v41.ragel"
+#line 260 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st652;}
     }
-#line 278 "src/vcf/vcf_v41.ragel"
+#line 276 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st652;}
     }
-#line 244 "src/vcf/vcf_v41.ragel"
+#line 242 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st652;}
     }
-#line 250 "src/vcf/vcf_v41.ragel"
+#line 248 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st652;}
     }
-#line 306 "src/vcf/vcf_v41.ragel"
+#line 304 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st652;}
     }
-#line 294 "src/vcf/vcf_v41.ragel"
+#line 292 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st652;}
     }
-#line 300 "src/vcf/vcf_v41.ragel"
+#line 298 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st652;}
@@ -16097,14 +16093,14 @@ case 658:
         p--; {goto st652;}
     }
 	break;
-#line 16101 "inc/vcf/validator_detail_v41.hpp"
+#line 16097 "inc/vcf/validator_detail_v41.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 847 "src/vcf/vcf_v41.ragel"
+#line 845 "src/vcf/vcf_v41.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 823 "src/vcf/vcf_v42.ragel"
+#line 821 "src/vcf/vcf_v42.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v42_en_meta_section_skip = 724;
 static const int vcf_v42_en_body_section_skip = 725;
 
 
-#line 829 "src/vcf/vcf_v42.ragel"
+#line 827 "src/vcf/vcf_v42.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v42_start;
 	}
 
-#line 843 "src/vcf/vcf_v42.ragel"
+#line 841 "src/vcf/vcf_v42.ragel"
 
     }
 
@@ -84,7 +84,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 225 "src/vcf/vcf_v42.ragel"
+#line 223 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
@@ -107,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 336 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -115,7 +115,7 @@ tr24:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -128,7 +128,7 @@ tr24:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -141,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 336 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -149,7 +149,7 @@ tr26:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -162,7 +162,7 @@ tr26:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -170,47 +170,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 242 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 248 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 292 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 298 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -229,7 +229,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -241,13 +241,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 237 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -259,12 +259,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -276,12 +276,12 @@ tr152:
     }
 	goto st0;
 tr161:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -293,17 +293,17 @@ tr161:
     }
 	goto st0;
 tr175:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -315,17 +315,17 @@ tr175:
     }
 	goto st0;
 tr187:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -337,12 +337,12 @@ tr187:
     }
 	goto st0;
 tr193:
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -354,7 +354,7 @@ tr193:
     }
 	goto st0;
 tr196:
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -366,12 +366,12 @@ tr196:
     }
 	goto st0;
 tr206:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -383,12 +383,12 @@ tr206:
     }
 	goto st0;
 tr225:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -400,17 +400,17 @@ tr225:
     }
 	goto st0;
 tr247:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -422,17 +422,17 @@ tr247:
     }
 	goto st0;
 tr259:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -444,7 +444,7 @@ tr259:
     }
 	goto st0;
 tr265:
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -456,12 +456,12 @@ tr265:
     }
 	goto st0;
 tr275:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -473,12 +473,12 @@ tr275:
     }
 	goto st0;
 tr288:
-#line 267 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -490,12 +490,12 @@ tr288:
     }
 	goto st0;
 tr297:
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 286 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -507,12 +507,12 @@ tr297:
     }
 	goto st0;
 tr314:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -524,17 +524,17 @@ tr314:
     }
 	goto st0;
 tr336:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -546,17 +546,17 @@ tr336:
     }
 	goto st0;
 tr348:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -568,7 +568,7 @@ tr348:
     }
 	goto st0;
 tr355:
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -580,12 +580,12 @@ tr355:
     }
 	goto st0;
 tr364:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -597,12 +597,12 @@ tr364:
     }
 	goto st0;
 tr377:
-#line 283 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -614,12 +614,12 @@ tr377:
     }
 	goto st0;
 tr386:
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 286 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -631,12 +631,12 @@ tr386:
     }
 	goto st0;
 tr403:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -648,17 +648,17 @@ tr403:
     }
 	goto st0;
 tr425:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -670,17 +670,17 @@ tr425:
     }
 	goto st0;
 tr437:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -692,7 +692,7 @@ tr437:
     }
 	goto st0;
 tr444:
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 292 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -704,12 +704,12 @@ tr444:
     }
 	goto st0;
 tr454:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 292 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -721,7 +721,7 @@ tr454:
     }
 	goto st0;
 tr466:
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -733,12 +733,12 @@ tr466:
     }
 	goto st0;
 tr477:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -750,17 +750,17 @@ tr477:
     }
 	goto st0;
 tr482:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -772,12 +772,12 @@ tr482:
     }
 	goto st0;
 tr484:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -789,17 +789,17 @@ tr484:
     }
 	goto st0;
 tr494:
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -811,12 +811,12 @@ tr494:
     }
 	goto st0;
 tr497:
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -828,17 +828,17 @@ tr497:
     }
 	goto st0;
 tr507:
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -850,12 +850,12 @@ tr507:
     }
 	goto st0;
 tr510:
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -867,7 +867,7 @@ tr510:
     }
 	goto st0;
 tr533:
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 242 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -879,12 +879,12 @@ tr533:
     }
 	goto st0;
 tr542:
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 242 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -896,7 +896,7 @@ tr542:
     }
 	goto st0;
 tr563:
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 248 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -908,12 +908,12 @@ tr563:
     }
 	goto st0;
 tr574:
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 248 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -925,7 +925,7 @@ tr574:
     }
 	goto st0;
 tr612:
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 298 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -937,12 +937,12 @@ tr612:
     }
 	goto st0;
 tr624:
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 298 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -954,7 +954,7 @@ tr624:
     }
 	goto st0;
 tr647:
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 336 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -962,7 +962,7 @@ tr647:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -975,7 +975,7 @@ tr647:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -990,7 +990,7 @@ tr687:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -998,7 +998,7 @@ tr687:
     }
 	goto st0;
 tr702:
-#line 355 "src/vcf/vcf_v42.ragel"
+#line 353 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
@@ -1010,7 +1010,7 @@ tr702:
     }
 	goto st0;
 tr705:
-#line 361 "src/vcf/vcf_v42.ragel"
+#line 359 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st725;}
@@ -1022,7 +1022,7 @@ tr705:
     }
 	goto st0;
 tr709:
-#line 367 "src/vcf/vcf_v42.ragel"
+#line 365 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st725;}
@@ -1034,7 +1034,7 @@ tr709:
     }
 	goto st0;
 tr714:
-#line 373 "src/vcf/vcf_v42.ragel"
+#line 371 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st725;}
@@ -1046,7 +1046,7 @@ tr714:
     }
 	goto st0;
 tr718:
-#line 379 "src/vcf/vcf_v42.ragel"
+#line 377 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st725;}
@@ -1058,7 +1058,7 @@ tr718:
     }
 	goto st0;
 tr727:
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 383 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st725;}
@@ -1070,7 +1070,7 @@ tr727:
     }
 	goto st0;
 tr738:
-#line 391 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st725;}
@@ -1082,12 +1082,12 @@ tr738:
     }
 	goto st0;
 tr746:
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1099,7 +1099,7 @@ tr746:
     }
 	goto st0;
 tr768:
-#line 557 "src/vcf/vcf_v42.ragel"
+#line 555 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st725;}
@@ -1111,14 +1111,14 @@ tr768:
     }
 	goto st0;
 tr773:
-#line 570 "src/vcf/vcf_v42.ragel"
+#line 568 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 561 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1132,7 +1132,7 @@ tr773:
     }
 	goto st0;
 tr777:
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 561 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1153,12 +1153,12 @@ tr784:
     }
 	goto st0;
 tr793:
-#line 407 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1170,7 +1170,7 @@ tr793:
     }
 	goto st0;
 tr795:
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 546 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1178,12 +1178,12 @@ tr795:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1195,7 +1195,7 @@ tr795:
     }
 	goto st0;
 tr797:
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 546 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1203,7 +1203,7 @@ tr797:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1215,7 +1215,7 @@ tr797:
     }
 	goto st0;
 tr804:
-#line 412 "src/vcf/vcf_v42.ragel"
+#line 410 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1223,7 +1223,7 @@ tr804:
                 "AA"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1235,7 +1235,7 @@ tr804:
     }
 	goto st0;
 tr807:
-#line 420 "src/vcf/vcf_v42.ragel"
+#line 418 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1243,7 +1243,7 @@ tr807:
                 "AC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1255,7 +1255,7 @@ tr807:
     }
 	goto st0;
 tr810:
-#line 428 "src/vcf/vcf_v42.ragel"
+#line 426 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1263,7 +1263,7 @@ tr810:
                 "AF"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1275,7 +1275,7 @@ tr810:
     }
 	goto st0;
 tr824:
-#line 436 "src/vcf/vcf_v42.ragel"
+#line 434 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1283,7 +1283,7 @@ tr824:
                 "AN"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1295,7 +1295,7 @@ tr824:
     }
 	goto st0;
 tr828:
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 442 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1303,7 +1303,7 @@ tr828:
                 "BQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1315,7 +1315,7 @@ tr828:
     }
 	goto st0;
 tr846:
-#line 452 "src/vcf/vcf_v42.ragel"
+#line 450 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1323,7 +1323,7 @@ tr846:
                 "CIGAR"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1335,7 +1335,7 @@ tr846:
     }
 	goto st0;
 tr851:
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 458 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1343,12 +1343,12 @@ tr851:
                 "DB"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1360,7 +1360,7 @@ tr851:
     }
 	goto st0;
 tr853:
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 458 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1368,7 +1368,7 @@ tr853:
                 "DB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1380,7 +1380,7 @@ tr853:
     }
 	goto st0;
 tr856:
-#line 468 "src/vcf/vcf_v42.ragel"
+#line 466 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1388,7 +1388,7 @@ tr856:
                 "DP"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1400,7 +1400,7 @@ tr856:
     }
 	goto st0;
 tr861:
-#line 476 "src/vcf/vcf_v42.ragel"
+#line 474 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1408,7 +1408,7 @@ tr861:
                 "END"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1420,7 +1420,7 @@ tr861:
     }
 	goto st0;
 tr865:
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 482 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1428,12 +1428,12 @@ tr865:
                 "H2"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1445,7 +1445,7 @@ tr865:
     }
 	goto st0;
 tr867:
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 482 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1453,7 +1453,7 @@ tr867:
                 "H2"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1465,7 +1465,7 @@ tr867:
     }
 	goto st0;
 tr869:
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 490 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1473,12 +1473,12 @@ tr869:
                 "H3"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1490,7 +1490,7 @@ tr869:
     }
 	goto st0;
 tr871:
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 490 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1498,7 +1498,7 @@ tr871:
                 "H3"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1510,7 +1510,7 @@ tr871:
     }
 	goto st0;
 tr877:
-#line 508 "src/vcf/vcf_v42.ragel"
+#line 506 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1518,7 +1518,7 @@ tr877:
                 "MQ0"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1530,7 +1530,7 @@ tr877:
     }
 	goto st0;
 tr879:
-#line 500 "src/vcf/vcf_v42.ragel"
+#line 498 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1538,7 +1538,7 @@ tr879:
                 "MQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1550,7 +1550,7 @@ tr879:
     }
 	goto st0;
 tr894:
-#line 516 "src/vcf/vcf_v42.ragel"
+#line 514 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1558,7 +1558,7 @@ tr894:
                 "NS"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1570,7 +1570,7 @@ tr894:
     }
 	goto st0;
 tr899:
-#line 524 "src/vcf/vcf_v42.ragel"
+#line 522 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1578,7 +1578,7 @@ tr899:
                 "SB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1590,7 +1590,7 @@ tr899:
     }
 	goto st0;
 tr917:
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 530 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1598,12 +1598,12 @@ tr917:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1615,7 +1615,7 @@ tr917:
     }
 	goto st0;
 tr919:
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 530 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1623,7 +1623,7 @@ tr919:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1635,7 +1635,7 @@ tr919:
     }
 	goto st0;
 tr929:
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 538 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1643,12 +1643,12 @@ tr929:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1660,7 +1660,7 @@ tr929:
     }
 	goto st0;
 tr931:
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 538 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1668,7 +1668,7 @@ tr931:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -1687,13 +1687,13 @@ tr980:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st725;}
     }
-#line 355 "src/vcf/vcf_v42.ragel"
+#line 353 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
@@ -1908,7 +1908,7 @@ tr22:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           p--; {goto st724;}
         }
@@ -2042,7 +2042,7 @@ tr45:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -2062,7 +2062,7 @@ tr55:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -2094,7 +2094,7 @@ tr46:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -2114,7 +2114,7 @@ tr56:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -9281,7 +9281,7 @@ tr559:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -10502,7 +10502,7 @@ tr643:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -11058,7 +11058,7 @@ tr981:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -11100,7 +11100,7 @@ tr982:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -11144,7 +11144,7 @@ tr983:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -11892,12 +11892,10 @@ tr764:
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -11916,7 +11914,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 11920 "inc/vcf/validator_detail_v42.hpp"
+#line 11918 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr985;
 		case 13: goto tr986;
@@ -11936,7 +11934,7 @@ tr984:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -11945,7 +11943,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 11949 "inc/vcf/validator_detail_v42.hpp"
+#line 11947 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr780;
@@ -11975,7 +11973,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 11979 "inc/vcf/validator_detail_v42.hpp"
+#line 11977 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr781;
 		case 62: goto tr782;
@@ -11999,7 +11997,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12003 "inc/vcf/validator_detail_v42.hpp"
+#line 12001 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr783;
 	goto tr702;
@@ -12026,12 +12024,10 @@ tr765:
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -12050,7 +12046,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12054 "inc/vcf/validator_detail_v42.hpp"
+#line 12050 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st728;
 	goto tr784;
@@ -12064,7 +12060,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12068 "inc/vcf/validator_detail_v42.hpp"
+#line 12064 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr778;
@@ -12091,7 +12087,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12095 "inc/vcf/validator_detail_v42.hpp"
+#line 12091 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12113,7 +12109,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12117 "inc/vcf/validator_detail_v42.hpp"
+#line 12113 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12150,7 +12146,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12154 "inc/vcf/validator_detail_v42.hpp"
+#line 12150 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr770;
 		case 10: goto tr764;
@@ -12178,7 +12174,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12182 "inc/vcf/validator_detail_v42.hpp"
+#line 12178 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 49: goto tr750;
 		case 58: goto tr747;
@@ -12229,7 +12225,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12233 "inc/vcf/validator_detail_v42.hpp"
+#line 12229 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12251,7 +12247,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12255 "inc/vcf/validator_detail_v42.hpp"
+#line 12251 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12273,7 +12269,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12277 "inc/vcf/validator_detail_v42.hpp"
+#line 12273 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12295,7 +12291,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12299 "inc/vcf/validator_detail_v42.hpp"
+#line 12295 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12317,7 +12313,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12321 "inc/vcf/validator_detail_v42.hpp"
+#line 12317 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr794;
@@ -12334,7 +12330,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12338 "inc/vcf/validator_detail_v42.hpp"
+#line 12334 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12354,7 +12350,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12358 "inc/vcf/validator_detail_v42.hpp"
+#line 12354 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12375,7 +12371,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12379 "inc/vcf/validator_detail_v42.hpp"
+#line 12375 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr798;
 	goto tr797;
@@ -12389,7 +12385,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12393 "inc/vcf/validator_detail_v42.hpp"
+#line 12389 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12411,7 +12407,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12415 "inc/vcf/validator_detail_v42.hpp"
+#line 12411 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12436,7 +12432,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12440 "inc/vcf/validator_detail_v42.hpp"
+#line 12436 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr803;
 	if ( (*p) > 58 ) {
@@ -12455,7 +12451,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12459 "inc/vcf/validator_detail_v42.hpp"
+#line 12455 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr805;
 	if ( (*p) < 45 ) {
@@ -12477,7 +12473,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12481 "inc/vcf/validator_detail_v42.hpp"
+#line 12477 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12503,7 +12499,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12507 "inc/vcf/validator_detail_v42.hpp"
+#line 12503 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr806;
 	if ( (*p) > 58 ) {
@@ -12522,7 +12518,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12526 "inc/vcf/validator_detail_v42.hpp"
+#line 12522 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr808;
 	goto tr807;
@@ -12536,7 +12532,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12540 "inc/vcf/validator_detail_v42.hpp"
+#line 12536 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12557,7 +12553,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12561 "inc/vcf/validator_detail_v42.hpp"
+#line 12557 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr809;
 	if ( (*p) > 58 ) {
@@ -12576,7 +12572,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12580 "inc/vcf/validator_detail_v42.hpp"
+#line 12576 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr811;
 		case 45: goto tr811;
@@ -12596,7 +12592,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 12600 "inc/vcf/validator_detail_v42.hpp"
+#line 12596 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr813;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12612,7 +12608,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 12616 "inc/vcf/validator_detail_v42.hpp"
+#line 12612 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12636,7 +12632,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12640 "inc/vcf/validator_detail_v42.hpp"
+#line 12636 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr817;
 	goto tr810;
@@ -12650,7 +12646,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 12654 "inc/vcf/validator_detail_v42.hpp"
+#line 12650 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12673,7 +12669,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 12677 "inc/vcf/validator_detail_v42.hpp"
+#line 12673 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr818;
 		case 45: goto tr818;
@@ -12691,7 +12687,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 12695 "inc/vcf/validator_detail_v42.hpp"
+#line 12691 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr819;
 	goto tr810;
@@ -12705,7 +12701,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 12709 "inc/vcf/validator_detail_v42.hpp"
+#line 12705 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12726,7 +12722,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12730 "inc/vcf/validator_detail_v42.hpp"
+#line 12726 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr820;
 	goto tr810;
@@ -12740,7 +12736,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 12744 "inc/vcf/validator_detail_v42.hpp"
+#line 12740 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr821;
 	goto tr810;
@@ -12754,7 +12750,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 12758 "inc/vcf/validator_detail_v42.hpp"
+#line 12754 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12773,7 +12769,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 12777 "inc/vcf/validator_detail_v42.hpp"
+#line 12773 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr822;
 	goto tr810;
@@ -12787,7 +12783,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 12791 "inc/vcf/validator_detail_v42.hpp"
+#line 12787 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr821;
 	goto tr810;
@@ -12801,7 +12797,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 12805 "inc/vcf/validator_detail_v42.hpp"
+#line 12801 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr823;
 	if ( (*p) > 58 ) {
@@ -12820,7 +12816,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 12824 "inc/vcf/validator_detail_v42.hpp"
+#line 12820 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr825;
 	goto tr824;
@@ -12834,7 +12830,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12838 "inc/vcf/validator_detail_v42.hpp"
+#line 12834 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12858,7 +12854,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12862 "inc/vcf/validator_detail_v42.hpp"
+#line 12858 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12880,7 +12876,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12884 "inc/vcf/validator_detail_v42.hpp"
+#line 12880 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr827;
 	if ( (*p) > 58 ) {
@@ -12899,7 +12895,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12903 "inc/vcf/validator_detail_v42.hpp"
+#line 12899 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr829;
 		case 45: goto tr829;
@@ -12919,7 +12915,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12923 "inc/vcf/validator_detail_v42.hpp"
+#line 12919 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr831;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12935,7 +12931,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12939 "inc/vcf/validator_detail_v42.hpp"
+#line 12935 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12958,7 +12954,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12962 "inc/vcf/validator_detail_v42.hpp"
+#line 12958 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr835;
 	goto tr828;
@@ -12972,7 +12968,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12976 "inc/vcf/validator_detail_v42.hpp"
+#line 12972 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -12994,7 +12990,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12998 "inc/vcf/validator_detail_v42.hpp"
+#line 12994 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr836;
 		case 45: goto tr836;
@@ -13012,7 +13008,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 13016 "inc/vcf/validator_detail_v42.hpp"
+#line 13012 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr837;
 	goto tr828;
@@ -13026,7 +13022,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 13030 "inc/vcf/validator_detail_v42.hpp"
+#line 13026 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13046,7 +13042,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 13050 "inc/vcf/validator_detail_v42.hpp"
+#line 13046 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr838;
 	goto tr828;
@@ -13060,7 +13056,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 13064 "inc/vcf/validator_detail_v42.hpp"
+#line 13060 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr839;
 	goto tr828;
@@ -13074,7 +13070,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 13078 "inc/vcf/validator_detail_v42.hpp"
+#line 13074 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13092,7 +13088,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 13096 "inc/vcf/validator_detail_v42.hpp"
+#line 13092 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr840;
 	goto tr828;
@@ -13106,7 +13102,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 13110 "inc/vcf/validator_detail_v42.hpp"
+#line 13106 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr839;
 	goto tr828;
@@ -13124,7 +13120,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 13128 "inc/vcf/validator_detail_v42.hpp"
+#line 13124 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13146,7 +13142,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 13150 "inc/vcf/validator_detail_v42.hpp"
+#line 13146 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13168,7 +13164,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 13172 "inc/vcf/validator_detail_v42.hpp"
+#line 13168 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13190,7 +13186,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13194 "inc/vcf/validator_detail_v42.hpp"
+#line 13190 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13212,7 +13208,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13216 "inc/vcf/validator_detail_v42.hpp"
+#line 13212 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr845;
 	if ( (*p) > 58 ) {
@@ -13231,7 +13227,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13235 "inc/vcf/validator_detail_v42.hpp"
+#line 13231 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr847;
 	goto tr846;
@@ -13245,7 +13241,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13249 "inc/vcf/validator_detail_v42.hpp"
+#line 13245 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 68: goto tr848;
 		case 80: goto tr848;
@@ -13271,7 +13267,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13275 "inc/vcf/validator_detail_v42.hpp"
+#line 13271 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13295,7 +13291,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13299 "inc/vcf/validator_detail_v42.hpp"
+#line 13295 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13318,7 +13314,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13322 "inc/vcf/validator_detail_v42.hpp"
+#line 13318 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13339,7 +13335,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13343 "inc/vcf/validator_detail_v42.hpp"
+#line 13339 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr854;
 	goto tr853;
@@ -13353,7 +13349,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13357 "inc/vcf/validator_detail_v42.hpp"
+#line 13353 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13371,7 +13367,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13375 "inc/vcf/validator_detail_v42.hpp"
+#line 13371 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr855;
 	if ( (*p) > 58 ) {
@@ -13390,7 +13386,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13394 "inc/vcf/validator_detail_v42.hpp"
+#line 13390 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr857;
 	goto tr856;
@@ -13404,7 +13400,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13408 "inc/vcf/validator_detail_v42.hpp"
+#line 13404 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13428,7 +13424,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13432 "inc/vcf/validator_detail_v42.hpp"
+#line 13428 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13450,7 +13446,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13454 "inc/vcf/validator_detail_v42.hpp"
+#line 13450 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13472,7 +13468,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13476 "inc/vcf/validator_detail_v42.hpp"
+#line 13472 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr860;
 	if ( (*p) > 58 ) {
@@ -13491,7 +13487,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13495 "inc/vcf/validator_detail_v42.hpp"
+#line 13491 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr862;
 	goto tr861;
@@ -13505,7 +13501,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13509 "inc/vcf/validator_detail_v42.hpp"
+#line 13505 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13529,7 +13525,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13533 "inc/vcf/validator_detail_v42.hpp"
+#line 13529 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13552,7 +13548,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13556 "inc/vcf/validator_detail_v42.hpp"
+#line 13552 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13573,7 +13569,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13577 "inc/vcf/validator_detail_v42.hpp"
+#line 13573 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr868;
 	goto tr867;
@@ -13587,7 +13583,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13591 "inc/vcf/validator_detail_v42.hpp"
+#line 13587 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13605,7 +13601,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13609 "inc/vcf/validator_detail_v42.hpp"
+#line 13605 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13626,7 +13622,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13630 "inc/vcf/validator_detail_v42.hpp"
+#line 13626 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr872;
 	goto tr871;
@@ -13640,7 +13636,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13644 "inc/vcf/validator_detail_v42.hpp"
+#line 13640 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13662,7 +13658,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13666 "inc/vcf/validator_detail_v42.hpp"
+#line 13662 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13684,7 +13680,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13688 "inc/vcf/validator_detail_v42.hpp"
+#line 13684 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 48: goto tr874;
 		case 61: goto tr875;
@@ -13705,7 +13701,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13709 "inc/vcf/validator_detail_v42.hpp"
+#line 13705 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr876;
 	if ( (*p) > 58 ) {
@@ -13724,7 +13720,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13728 "inc/vcf/validator_detail_v42.hpp"
+#line 13724 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr878;
 	goto tr877;
@@ -13738,7 +13734,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13742 "inc/vcf/validator_detail_v42.hpp"
+#line 13738 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13758,7 +13754,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13762 "inc/vcf/validator_detail_v42.hpp"
+#line 13758 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr880;
 		case 45: goto tr880;
@@ -13778,7 +13774,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13782 "inc/vcf/validator_detail_v42.hpp"
+#line 13778 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr882;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13794,7 +13790,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13798 "inc/vcf/validator_detail_v42.hpp"
+#line 13794 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13817,7 +13813,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13821 "inc/vcf/validator_detail_v42.hpp"
+#line 13817 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr886;
 	goto tr879;
@@ -13831,7 +13827,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13835 "inc/vcf/validator_detail_v42.hpp"
+#line 13831 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13853,7 +13849,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 13857 "inc/vcf/validator_detail_v42.hpp"
+#line 13853 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr887;
 		case 45: goto tr887;
@@ -13871,7 +13867,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 13875 "inc/vcf/validator_detail_v42.hpp"
+#line 13871 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr888;
 	goto tr879;
@@ -13885,7 +13881,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 13889 "inc/vcf/validator_detail_v42.hpp"
+#line 13885 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13905,7 +13901,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 13909 "inc/vcf/validator_detail_v42.hpp"
+#line 13905 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr889;
 	goto tr879;
@@ -13919,7 +13915,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 13923 "inc/vcf/validator_detail_v42.hpp"
+#line 13919 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr890;
 	goto tr879;
@@ -13933,7 +13929,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 13937 "inc/vcf/validator_detail_v42.hpp"
+#line 13933 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -13951,7 +13947,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 13955 "inc/vcf/validator_detail_v42.hpp"
+#line 13951 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr891;
 	goto tr879;
@@ -13965,7 +13961,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 13969 "inc/vcf/validator_detail_v42.hpp"
+#line 13965 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr890;
 	goto tr879;
@@ -13983,7 +13979,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 13987 "inc/vcf/validator_detail_v42.hpp"
+#line 13983 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14005,7 +14001,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14009 "inc/vcf/validator_detail_v42.hpp"
+#line 14005 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr893;
 	if ( (*p) > 58 ) {
@@ -14024,7 +14020,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14028 "inc/vcf/validator_detail_v42.hpp"
+#line 14024 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr895;
 	goto tr894;
@@ -14038,7 +14034,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14042 "inc/vcf/validator_detail_v42.hpp"
+#line 14038 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14062,7 +14058,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14066 "inc/vcf/validator_detail_v42.hpp"
+#line 14062 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14085,7 +14081,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14089 "inc/vcf/validator_detail_v42.hpp"
+#line 14085 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr898;
 	if ( (*p) > 58 ) {
@@ -14104,7 +14100,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14108 "inc/vcf/validator_detail_v42.hpp"
+#line 14104 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr900;
 		case 45: goto tr900;
@@ -14124,7 +14120,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14128 "inc/vcf/validator_detail_v42.hpp"
+#line 14124 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr902;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14140,7 +14136,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14144 "inc/vcf/validator_detail_v42.hpp"
+#line 14140 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14163,7 +14159,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14167 "inc/vcf/validator_detail_v42.hpp"
+#line 14163 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr906;
 	goto tr899;
@@ -14177,7 +14173,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14181 "inc/vcf/validator_detail_v42.hpp"
+#line 14177 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14199,7 +14195,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14203 "inc/vcf/validator_detail_v42.hpp"
+#line 14199 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr907;
 		case 45: goto tr907;
@@ -14217,7 +14213,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14221 "inc/vcf/validator_detail_v42.hpp"
+#line 14217 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr908;
 	goto tr899;
@@ -14231,7 +14227,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14235 "inc/vcf/validator_detail_v42.hpp"
+#line 14231 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14251,7 +14247,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14255 "inc/vcf/validator_detail_v42.hpp"
+#line 14251 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr909;
 	goto tr899;
@@ -14265,7 +14261,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14269 "inc/vcf/validator_detail_v42.hpp"
+#line 14265 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr910;
 	goto tr899;
@@ -14279,7 +14275,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14283 "inc/vcf/validator_detail_v42.hpp"
+#line 14279 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14297,7 +14293,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14301 "inc/vcf/validator_detail_v42.hpp"
+#line 14297 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr911;
 	goto tr899;
@@ -14311,7 +14307,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14315 "inc/vcf/validator_detail_v42.hpp"
+#line 14311 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr910;
 	goto tr899;
@@ -14325,7 +14321,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14329 "inc/vcf/validator_detail_v42.hpp"
+#line 14325 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14347,7 +14343,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14351 "inc/vcf/validator_detail_v42.hpp"
+#line 14347 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14369,7 +14365,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14373 "inc/vcf/validator_detail_v42.hpp"
+#line 14369 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14391,7 +14387,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14395 "inc/vcf/validator_detail_v42.hpp"
+#line 14391 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14413,7 +14409,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14417 "inc/vcf/validator_detail_v42.hpp"
+#line 14413 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14435,7 +14431,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14439 "inc/vcf/validator_detail_v42.hpp"
+#line 14435 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14456,7 +14452,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14460 "inc/vcf/validator_detail_v42.hpp"
+#line 14456 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr920;
 	goto tr919;
@@ -14470,7 +14466,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14474 "inc/vcf/validator_detail_v42.hpp"
+#line 14470 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14492,7 +14488,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14496 "inc/vcf/validator_detail_v42.hpp"
+#line 14492 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14514,7 +14510,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14518 "inc/vcf/validator_detail_v42.hpp"
+#line 14514 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14536,7 +14532,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14540 "inc/vcf/validator_detail_v42.hpp"
+#line 14536 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14558,7 +14554,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14562 "inc/vcf/validator_detail_v42.hpp"
+#line 14558 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14580,7 +14576,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14584 "inc/vcf/validator_detail_v42.hpp"
+#line 14580 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14602,7 +14598,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14606 "inc/vcf/validator_detail_v42.hpp"
+#line 14602 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14624,7 +14620,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14628 "inc/vcf/validator_detail_v42.hpp"
+#line 14624 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14646,7 +14642,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14650 "inc/vcf/validator_detail_v42.hpp"
+#line 14646 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14668,7 +14664,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14672 "inc/vcf/validator_detail_v42.hpp"
+#line 14668 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14689,7 +14685,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14693 "inc/vcf/validator_detail_v42.hpp"
+#line 14689 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr932;
 	goto tr931;
@@ -14703,7 +14699,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14707 "inc/vcf/validator_detail_v42.hpp"
+#line 14703 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14725,7 +14721,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14729 "inc/vcf/validator_detail_v42.hpp"
+#line 14725 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr763;
 		case 10: goto tr764;
@@ -14764,7 +14760,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14768 "inc/vcf/validator_detail_v42.hpp"
+#line 14764 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr739;
 	if ( (*p) < 65 ) {
@@ -14802,7 +14798,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14806 "inc/vcf/validator_detail_v42.hpp"
+#line 14802 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 58: goto st525;
@@ -14838,7 +14834,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 14842 "inc/vcf/validator_detail_v42.hpp"
+#line 14838 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr727;
@@ -14852,7 +14848,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 14856 "inc/vcf/validator_detail_v42.hpp"
+#line 14852 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 69: goto tr737;
@@ -14871,7 +14867,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 14875 "inc/vcf/validator_detail_v42.hpp"
+#line 14871 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr934;
 		case 45: goto tr934;
@@ -14889,7 +14885,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 14893 "inc/vcf/validator_detail_v42.hpp"
+#line 14889 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr935;
 	goto tr727;
@@ -14903,7 +14899,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 14907 "inc/vcf/validator_detail_v42.hpp"
+#line 14903 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14929,7 +14925,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 14933 "inc/vcf/validator_detail_v42.hpp"
+#line 14929 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr936;
 	goto tr727;
@@ -14943,7 +14939,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 14947 "inc/vcf/validator_detail_v42.hpp"
+#line 14943 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr937;
 	goto tr727;
@@ -14967,7 +14963,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 14971 "inc/vcf/validator_detail_v42.hpp"
+#line 14967 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	goto tr727;
@@ -14985,7 +14981,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 14989 "inc/vcf/validator_detail_v42.hpp"
+#line 14985 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr938;
 	goto tr727;
@@ -14999,7 +14995,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15003 "inc/vcf/validator_detail_v42.hpp"
+#line 14999 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr937;
 	goto tr727;
@@ -15013,7 +15009,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15017 "inc/vcf/validator_detail_v42.hpp"
+#line 15013 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr939;
@@ -15052,7 +15048,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15056 "inc/vcf/validator_detail_v42.hpp"
+#line 15052 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr940;
 		case 67: goto tr940;
@@ -15076,7 +15072,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15080 "inc/vcf/validator_detail_v42.hpp"
+#line 15076 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15112,7 +15108,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15116 "inc/vcf/validator_detail_v42.hpp"
+#line 15112 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr941;
 	if ( (*p) < 63 ) {
@@ -15152,7 +15148,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15156 "inc/vcf/validator_detail_v42.hpp"
+#line 15152 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto tr943;
 	if ( (*p) < 45 ) {
@@ -15184,7 +15180,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15188 "inc/vcf/validator_detail_v42.hpp"
+#line 15184 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15213,7 +15209,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15217 "inc/vcf/validator_detail_v42.hpp"
+#line 15213 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr948;
 	if ( (*p) < 65 ) {
@@ -15235,7 +15231,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15239 "inc/vcf/validator_detail_v42.hpp"
+#line 15235 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr949;
 		case 61: goto tr947;
@@ -15259,7 +15255,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15263 "inc/vcf/validator_detail_v42.hpp"
+#line 15259 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr950;
 	goto tr718;
@@ -15273,7 +15269,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15277 "inc/vcf/validator_detail_v42.hpp"
+#line 15273 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr943;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15289,7 +15285,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15293 "inc/vcf/validator_detail_v42.hpp"
+#line 15289 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr951;
@@ -15309,7 +15305,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15313 "inc/vcf/validator_detail_v42.hpp"
+#line 15309 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr951;
 		case 62: goto tr952;
@@ -15333,7 +15329,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15337 "inc/vcf/validator_detail_v42.hpp"
+#line 15333 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr949;
 	goto tr718;
@@ -15347,7 +15343,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15351 "inc/vcf/validator_detail_v42.hpp"
+#line 15347 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr954;
 	if ( (*p) < 65 ) {
@@ -15369,7 +15365,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15373 "inc/vcf/validator_detail_v42.hpp"
+#line 15369 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr955;
 		case 61: goto tr953;
@@ -15393,7 +15389,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15397 "inc/vcf/validator_detail_v42.hpp"
+#line 15393 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr718;
@@ -15407,7 +15403,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15411 "inc/vcf/validator_detail_v42.hpp"
+#line 15407 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr943;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15423,7 +15419,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15427 "inc/vcf/validator_detail_v42.hpp"
+#line 15423 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr957;
@@ -15443,7 +15439,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15447 "inc/vcf/validator_detail_v42.hpp"
+#line 15443 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr957;
 		case 62: goto tr958;
@@ -15467,7 +15463,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15471 "inc/vcf/validator_detail_v42.hpp"
+#line 15467 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr955;
 	goto tr718;
@@ -15485,7 +15481,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15489 "inc/vcf/validator_detail_v42.hpp"
+#line 15485 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr960;
 	if ( (*p) < 65 ) {
@@ -15507,7 +15503,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15511 "inc/vcf/validator_detail_v42.hpp"
+#line 15507 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr961;
 		case 61: goto tr959;
@@ -15531,7 +15527,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15535 "inc/vcf/validator_detail_v42.hpp"
+#line 15531 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr962;
 	goto tr718;
@@ -15545,7 +15541,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15549 "inc/vcf/validator_detail_v42.hpp"
+#line 15545 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr963;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15561,7 +15557,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15565 "inc/vcf/validator_detail_v42.hpp"
+#line 15561 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr964;
@@ -15581,7 +15577,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15585 "inc/vcf/validator_detail_v42.hpp"
+#line 15581 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr964;
 		case 62: goto tr965;
@@ -15605,7 +15601,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15609 "inc/vcf/validator_detail_v42.hpp"
+#line 15605 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr961;
 	goto tr718;
@@ -15623,7 +15619,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15627 "inc/vcf/validator_detail_v42.hpp"
+#line 15623 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr967;
 	if ( (*p) < 65 ) {
@@ -15645,7 +15641,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15649 "inc/vcf/validator_detail_v42.hpp"
+#line 15645 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr968;
 		case 61: goto tr966;
@@ -15669,7 +15665,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15673 "inc/vcf/validator_detail_v42.hpp"
+#line 15669 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr969;
 	goto tr718;
@@ -15683,7 +15679,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15687 "inc/vcf/validator_detail_v42.hpp"
+#line 15683 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr963;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15699,7 +15695,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15703 "inc/vcf/validator_detail_v42.hpp"
+#line 15699 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr970;
@@ -15719,7 +15715,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15723 "inc/vcf/validator_detail_v42.hpp"
+#line 15719 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr970;
 		case 62: goto tr971;
@@ -15743,7 +15739,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15747 "inc/vcf/validator_detail_v42.hpp"
+#line 15743 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr968;
 	goto tr718;
@@ -15761,7 +15757,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15765 "inc/vcf/validator_detail_v42.hpp"
+#line 15761 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 65: goto tr940;
@@ -15816,7 +15812,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15820 "inc/vcf/validator_detail_v42.hpp"
+#line 15816 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st726;
 	goto tr687;
@@ -15825,7 +15821,7 @@ tr23:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           p--; {goto st724;}
         }
@@ -15845,7 +15841,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15849 "inc/vcf/validator_detail_v42.hpp"
+#line 15845 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -15865,7 +15861,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15869 "inc/vcf/validator_detail_v42.hpp"
+#line 15865 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr975;
 		case 13: goto tr976;
@@ -15882,14 +15878,14 @@ tr975:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 821 "src/vcf/vcf_v42.ragel"
+#line 819 "src/vcf/vcf_v42.ragel"
 	{ {goto st28;} }
 	goto st729;
 st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 15893 "inc/vcf/validator_detail_v42.hpp"
+#line 15889 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 tr979:
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -15907,7 +15903,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 15911 "inc/vcf/validator_detail_v42.hpp"
+#line 15907 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr978;
 		case 13: goto tr979;
@@ -15924,14 +15920,14 @@ tr978:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 822 "src/vcf/vcf_v42.ragel"
+#line 820 "src/vcf/vcf_v42.ragel"
 	{ {goto st728;} }
 	goto st730;
 st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 15935 "inc/vcf/validator_detail_v42.hpp"
+#line 15931 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -16747,7 +16743,7 @@ case 730:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -16769,7 +16765,7 @@ case 730:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -16791,7 +16787,7 @@ case 730:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 225 "src/vcf/vcf_v42.ragel"
+#line 223 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
@@ -16825,7 +16821,7 @@ case 730:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -16844,7 +16840,7 @@ case 730:
 	case 380: 
 	case 381: 
 	case 382: 
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 242 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -16884,7 +16880,7 @@ case 730:
 	case 430: 
 	case 431: 
 	case 432: 
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 248 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -16919,7 +16915,7 @@ case 730:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -16966,7 +16962,7 @@ case 730:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17012,7 +17008,7 @@ case 730:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17033,7 +17029,7 @@ case 730:
 	case 313: 
 	case 314: 
 	case 321: 
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 292 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -17055,7 +17051,7 @@ case 730:
 	case 441: 
 	case 442: 
 	case 443: 
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 298 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -17077,7 +17073,7 @@ case 730:
 	case 330: 
 	case 331: 
 	case 371: 
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17125,7 +17121,7 @@ case 730:
 	case 499: 
 	case 500: 
 	case 501: 
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 336 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17133,7 +17129,7 @@ case 730:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -17146,7 +17142,7 @@ case 730:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -17157,7 +17153,7 @@ case 730:
 	case 534: 
 	case 535: 
 	case 536: 
-#line 355 "src/vcf/vcf_v42.ragel"
+#line 353 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st725;}
@@ -17170,7 +17166,7 @@ case 730:
 	break;
 	case 513: 
 	case 514: 
-#line 361 "src/vcf/vcf_v42.ragel"
+#line 359 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st725;}
@@ -17183,7 +17179,7 @@ case 730:
 	break;
 	case 515: 
 	case 516: 
-#line 367 "src/vcf/vcf_v42.ragel"
+#line 365 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st725;}
@@ -17196,7 +17192,7 @@ case 730:
 	break;
 	case 517: 
 	case 518: 
-#line 373 "src/vcf/vcf_v42.ragel"
+#line 371 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st725;}
@@ -17244,7 +17240,7 @@ case 730:
 	case 719: 
 	case 720: 
 	case 721: 
-#line 379 "src/vcf/vcf_v42.ragel"
+#line 377 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st725;}
@@ -17268,7 +17264,7 @@ case 730:
 	case 684: 
 	case 685: 
 	case 686: 
-#line 385 "src/vcf/vcf_v42.ragel"
+#line 383 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st725;}
@@ -17284,7 +17280,7 @@ case 730:
 	case 526: 
 	case 675: 
 	case 676: 
-#line 391 "src/vcf/vcf_v42.ragel"
+#line 389 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st725;}
@@ -17297,7 +17293,7 @@ case 730:
 	break;
 	case 530: 
 	case 531: 
-#line 557 "src/vcf/vcf_v42.ragel"
+#line 555 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st725;}
@@ -17310,7 +17306,7 @@ case 730:
 	break;
 	case 533: 
 	case 538: 
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 561 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -17330,7 +17326,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 336 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17338,7 +17334,7 @@ case 730:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -17351,7 +17347,7 @@ case 730:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -17361,13 +17357,13 @@ case 730:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 237 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -17379,12 +17375,12 @@ case 730:
     }
 	break;
 	case 122: 
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17398,12 +17394,12 @@ case 730:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 267 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17417,12 +17413,12 @@ case 730:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 283 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17435,12 +17431,12 @@ case 730:
 	break;
 	case 199: 
 	case 200: 
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 286 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17453,12 +17449,12 @@ case 730:
 	break;
 	case 265: 
 	case 266: 
-#line 288 "src/vcf/vcf_v42.ragel"
+#line 286 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17478,12 +17474,12 @@ case 730:
 	case 341: 
 	case 342: 
 	case 343: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17503,12 +17499,12 @@ case 730:
 	case 351: 
 	case 352: 
 	case 353: 
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17522,12 +17518,12 @@ case 730:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -17540,12 +17536,12 @@ case 730:
 	break;
 	case 412: 
 	case 413: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 248 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
@@ -17562,12 +17558,12 @@ case 730:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -17584,12 +17580,12 @@ case 730:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17606,12 +17602,12 @@ case 730:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17628,12 +17624,12 @@ case 730:
 	case 318: 
 	case 319: 
 	case 320: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 292 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
@@ -17646,12 +17642,12 @@ case 730:
 	break;
 	case 332: 
 	case 333: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17676,12 +17672,12 @@ case 730:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -17706,12 +17702,12 @@ case 730:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -17736,12 +17732,12 @@ case 730:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -17766,12 +17762,12 @@ case 730:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -17801,12 +17797,12 @@ case 730:
 	case 372: 
 	case 373: 
 	case 374: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -17836,12 +17832,12 @@ case 730:
 	case 399: 
 	case 400: 
 	case 401: 
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 242 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
@@ -17873,12 +17869,12 @@ case 730:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 332 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 298 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -17936,12 +17932,12 @@ case 730:
 	case 669: 
 	case 670: 
 	case 674: 
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -17954,12 +17950,12 @@ case 730:
 	break;
 	case 547: 
 	case 548: 
-#line 407 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -17972,7 +17968,7 @@ case 730:
 	break;
 	case 554: 
 	case 555: 
-#line 412 "src/vcf/vcf_v42.ragel"
+#line 410 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -17980,7 +17976,7 @@ case 730:
                 "AA"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -17993,7 +17989,7 @@ case 730:
 	break;
 	case 557: 
 	case 558: 
-#line 420 "src/vcf/vcf_v42.ragel"
+#line 418 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18001,7 +17997,7 @@ case 730:
                 "AC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18025,7 +18021,7 @@ case 730:
 	case 570: 
 	case 571: 
 	case 572: 
-#line 428 "src/vcf/vcf_v42.ragel"
+#line 426 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18033,7 +18029,7 @@ case 730:
                 "AF"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18046,7 +18042,7 @@ case 730:
 	break;
 	case 574: 
 	case 575: 
-#line 436 "src/vcf/vcf_v42.ragel"
+#line 434 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18054,7 +18050,7 @@ case 730:
                 "AN"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18078,7 +18074,7 @@ case 730:
 	case 588: 
 	case 589: 
 	case 590: 
-#line 444 "src/vcf/vcf_v42.ragel"
+#line 442 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18086,7 +18082,7 @@ case 730:
                 "BQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18100,7 +18096,7 @@ case 730:
 	case 596: 
 	case 597: 
 	case 598: 
-#line 452 "src/vcf/vcf_v42.ragel"
+#line 450 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18108,7 +18104,7 @@ case 730:
                 "CIGAR"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18121,7 +18117,7 @@ case 730:
 	break;
 	case 601: 
 	case 602: 
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 458 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18129,7 +18125,7 @@ case 730:
                 "DB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18142,7 +18138,7 @@ case 730:
 	break;
 	case 604: 
 	case 605: 
-#line 468 "src/vcf/vcf_v42.ragel"
+#line 466 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18150,7 +18146,7 @@ case 730:
                 "DP"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18163,7 +18159,7 @@ case 730:
 	break;
 	case 609: 
 	case 610: 
-#line 476 "src/vcf/vcf_v42.ragel"
+#line 474 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18171,7 +18167,7 @@ case 730:
                 "END"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18184,7 +18180,7 @@ case 730:
 	break;
 	case 613: 
 	case 614: 
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 482 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18192,7 +18188,7 @@ case 730:
                 "H2"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18205,7 +18201,7 @@ case 730:
 	break;
 	case 616: 
 	case 617: 
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 490 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18213,7 +18209,7 @@ case 730:
                 "H3"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18237,7 +18233,7 @@ case 730:
 	case 633: 
 	case 634: 
 	case 635: 
-#line 500 "src/vcf/vcf_v42.ragel"
+#line 498 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18245,7 +18241,7 @@ case 730:
                 "MQ"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18258,7 +18254,7 @@ case 730:
 	break;
 	case 621: 
 	case 622: 
-#line 508 "src/vcf/vcf_v42.ragel"
+#line 506 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18266,7 +18262,7 @@ case 730:
                 "MQ0"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18279,7 +18275,7 @@ case 730:
 	break;
 	case 638: 
 	case 639: 
-#line 516 "src/vcf/vcf_v42.ragel"
+#line 514 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18287,7 +18283,7 @@ case 730:
                 "NS"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18311,7 +18307,7 @@ case 730:
 	case 652: 
 	case 653: 
 	case 654: 
-#line 524 "src/vcf/vcf_v42.ragel"
+#line 522 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18319,7 +18315,7 @@ case 730:
                 "SB"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18332,7 +18328,7 @@ case 730:
 	break;
 	case 661: 
 	case 662: 
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 530 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18340,7 +18336,7 @@ case 730:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18353,7 +18349,7 @@ case 730:
 	break;
 	case 672: 
 	case 673: 
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 538 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18361,7 +18357,7 @@ case 730:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18374,7 +18370,7 @@ case 730:
 	break;
 	case 550: 
 	case 551: 
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 546 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18382,7 +18378,7 @@ case 730:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18397,14 +18393,14 @@ case 730:
 	case 539: 
 	case 540: 
 	case 541: 
-#line 570 "src/vcf/vcf_v42.ragel"
+#line 568 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st725;}
     }
-#line 563 "src/vcf/vcf_v42.ragel"
+#line 561 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -18428,7 +18424,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st724;}
     }
-#line 338 "src/vcf/vcf_v42.ragel"
+#line 336 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -18436,7 +18432,7 @@ case 730:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -18449,7 +18445,7 @@ case 730:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -18457,17 +18453,17 @@ case 730:
     }
 	break;
 	case 344: 
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -18479,17 +18475,17 @@ case 730:
     }
 	break;
 	case 354: 
-#line 316 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -18501,17 +18497,17 @@ case 730:
     }
 	break;
 	case 334: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 311 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
@@ -18525,17 +18521,17 @@ case 730:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -18549,17 +18545,17 @@ case 730:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -18573,17 +18569,17 @@ case 730:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -18597,17 +18593,17 @@ case 730:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -18621,17 +18617,17 @@ case 730:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
@@ -18645,17 +18641,17 @@ case 730:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
@@ -18669,17 +18665,17 @@ case 730:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
@@ -18693,17 +18689,17 @@ case 730:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 327 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st724;}
     }
-#line 322 "src/vcf/vcf_v42.ragel"
+#line 320 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
@@ -18715,7 +18711,7 @@ case 730:
     }
 	break;
 	case 600: 
-#line 460 "src/vcf/vcf_v42.ragel"
+#line 458 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18723,12 +18719,12 @@ case 730:
                 "DB"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18740,7 +18736,7 @@ case 730:
     }
 	break;
 	case 612: 
-#line 484 "src/vcf/vcf_v42.ragel"
+#line 482 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18748,12 +18744,12 @@ case 730:
                 "H2"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18765,7 +18761,7 @@ case 730:
     }
 	break;
 	case 615: 
-#line 492 "src/vcf/vcf_v42.ragel"
+#line 490 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18773,12 +18769,12 @@ case 730:
                 "H3"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18790,7 +18786,7 @@ case 730:
     }
 	break;
 	case 660: 
-#line 532 "src/vcf/vcf_v42.ragel"
+#line 530 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18798,12 +18794,12 @@ case 730:
                 "SOMATIC"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18815,7 +18811,7 @@ case 730:
     }
 	break;
 	case 671: 
-#line 540 "src/vcf/vcf_v42.ragel"
+#line 538 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18823,12 +18819,12 @@ case 730:
                 "VALIDATED"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18840,7 +18836,7 @@ case 730:
     }
 	break;
 	case 549: 
-#line 548 "src/vcf/vcf_v42.ragel"
+#line 546 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18848,12 +18844,12 @@ case 730:
                 "1000G"});
         p--; {goto st725;}
     }
-#line 402 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st725;}
     }
-#line 397 "src/vcf/vcf_v42.ragel"
+#line 395 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st725;}
@@ -18865,47 +18861,47 @@ case 730:
     }
 	break;
 	case 24: 
-#line 232 "src/vcf/vcf_v42.ragel"
+#line 230 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st724;}
     }
-#line 256 "src/vcf/vcf_v42.ragel"
+#line 254 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st724;}
     }
-#line 262 "src/vcf/vcf_v42.ragel"
+#line 260 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st724;}
     }
-#line 278 "src/vcf/vcf_v42.ragel"
+#line 276 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st724;}
     }
-#line 244 "src/vcf/vcf_v42.ragel"
+#line 242 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st724;}
     }
-#line 250 "src/vcf/vcf_v42.ragel"
+#line 248 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st724;}
     }
-#line 306 "src/vcf/vcf_v42.ragel"
+#line 304 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st724;}
     }
-#line 294 "src/vcf/vcf_v42.ragel"
+#line 292 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st724;}
     }
-#line 300 "src/vcf/vcf_v42.ragel"
+#line 298 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st724;}
@@ -18916,14 +18912,14 @@ case 730:
         p--; {goto st724;}
     }
 	break;
-#line 18920 "inc/vcf/validator_detail_v42.hpp"
+#line 18916 "inc/vcf/validator_detail_v42.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 851 "src/vcf/vcf_v42.ragel"
+#line 849 "src/vcf/vcf_v42.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 909 "src/vcf/vcf_v43.ragel"
+#line 907 "src/vcf/vcf_v43.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v43_en_meta_section_skip = 798;
 static const int vcf_v43_en_body_section_skip = 799;
 
 
-#line 915 "src/vcf/vcf_v43.ragel"
+#line 913 "src/vcf/vcf_v43.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v43_start;
 	}
 
-#line 929 "src/vcf/vcf_v43.ragel"
+#line 927 "src/vcf/vcf_v43.ragel"
 
     }
 
@@ -84,7 +84,7 @@ tr0:
     }
 	goto st0;
 tr14:
-#line 237 "src/vcf/vcf_v43.ragel"
+#line 235 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
@@ -107,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -115,7 +115,7 @@ tr24:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -128,7 +128,7 @@ tr24:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -141,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -149,7 +149,7 @@ tr26:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -162,7 +162,7 @@ tr26:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -170,52 +170,52 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 254 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 260 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 352 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 325 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -234,7 +234,7 @@ tr40:
     }
 	goto st0;
 tr126:
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -246,13 +246,13 @@ tr126:
     }
 	goto st0;
 tr134:
-#line 249 "src/vcf/vcf_v43.ragel"
+#line 247 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -264,12 +264,12 @@ tr134:
     }
 	goto st0;
 tr153:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -281,12 +281,12 @@ tr153:
     }
 	goto st0;
 tr162:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -298,17 +298,17 @@ tr162:
     }
 	goto st0;
 tr176:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -320,17 +320,17 @@ tr176:
     }
 	goto st0;
 tr188:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -342,12 +342,12 @@ tr188:
     }
 	goto st0;
 tr194:
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -359,7 +359,7 @@ tr194:
     }
 	goto st0;
 tr197:
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -371,12 +371,12 @@ tr197:
     }
 	goto st0;
 tr207:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -388,12 +388,12 @@ tr207:
     }
 	goto st0;
 tr226:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -405,17 +405,17 @@ tr226:
     }
 	goto st0;
 tr248:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -427,17 +427,17 @@ tr248:
     }
 	goto st0;
 tr260:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -449,7 +449,7 @@ tr260:
     }
 	goto st0;
 tr266:
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -461,12 +461,12 @@ tr266:
     }
 	goto st0;
 tr276:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -478,12 +478,12 @@ tr276:
     }
 	goto st0;
 tr289:
-#line 279 "src/vcf/vcf_v43.ragel"
+#line 277 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -495,12 +495,12 @@ tr289:
     }
 	goto st0;
 tr298:
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 298 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -512,12 +512,12 @@ tr298:
     }
 	goto st0;
 tr315:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -529,17 +529,17 @@ tr315:
     }
 	goto st0;
 tr337:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -551,17 +551,17 @@ tr337:
     }
 	goto st0;
 tr349:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -573,7 +573,7 @@ tr349:
     }
 	goto st0;
 tr356:
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -585,12 +585,12 @@ tr356:
     }
 	goto st0;
 tr365:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -602,12 +602,12 @@ tr365:
     }
 	goto st0;
 tr378:
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 293 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -619,12 +619,12 @@ tr378:
     }
 	goto st0;
 tr387:
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 298 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -636,12 +636,12 @@ tr387:
     }
 	goto st0;
 tr404:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -653,17 +653,17 @@ tr404:
     }
 	goto st0;
 tr426:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -675,17 +675,17 @@ tr426:
     }
 	goto st0;
 tr438:
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -697,7 +697,7 @@ tr438:
     }
 	goto st0;
 tr445:
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -709,12 +709,12 @@ tr445:
     }
 	goto st0;
 tr454:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -726,12 +726,12 @@ tr454:
     }
 	goto st0;
 tr467:
-#line 338 "src/vcf/vcf_v43.ragel"
+#line 336 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -743,12 +743,12 @@ tr467:
     }
 	goto st0;
 tr475:
-#line 343 "src/vcf/vcf_v43.ragel"
+#line 341 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -760,12 +760,12 @@ tr475:
     }
 	goto st0;
 tr492:
-#line 348 "src/vcf/vcf_v43.ragel"
+#line 346 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -777,7 +777,7 @@ tr492:
     }
 	goto st0;
 tr498:
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -789,12 +789,12 @@ tr498:
     }
 	goto st0;
 tr511:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -806,12 +806,12 @@ tr511:
     }
 	goto st0;
 tr517:
-#line 321 "src/vcf/vcf_v43.ragel"
+#line 319 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -823,12 +823,12 @@ tr517:
     }
 	goto st0;
 tr527:
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 314 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -840,12 +840,12 @@ tr527:
     }
 	goto st0;
 tr564:
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 309 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -857,7 +857,7 @@ tr564:
     }
 	goto st0;
 tr569:
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 352 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -869,12 +869,12 @@ tr569:
     }
 	goto st0;
 tr580:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 352 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -886,7 +886,7 @@ tr580:
     }
 	goto st0;
 tr620:
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 254 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -898,12 +898,12 @@ tr620:
     }
 	goto st0;
 tr629:
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 368 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 254 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -915,7 +915,7 @@ tr629:
     }
 	goto st0;
 tr650:
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 260 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -927,12 +927,12 @@ tr650:
     }
 	goto st0;
 tr661:
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 260 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -944,7 +944,7 @@ tr661:
     }
 	goto st0;
 tr699:
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 325 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -956,12 +956,12 @@ tr699:
     }
 	goto st0;
 tr711:
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 368 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 325 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -973,7 +973,7 @@ tr711:
     }
 	goto st0;
 tr734:
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -981,7 +981,7 @@ tr734:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -994,7 +994,7 @@ tr734:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -1009,7 +1009,7 @@ tr774:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -1017,7 +1017,7 @@ tr774:
     }
 	goto st0;
 tr789:
-#line 393 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
@@ -1029,7 +1029,7 @@ tr789:
     }
 	goto st0;
 tr792:
-#line 399 "src/vcf/vcf_v43.ragel"
+#line 397 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st799;}
@@ -1041,7 +1041,7 @@ tr792:
     }
 	goto st0;
 tr796:
-#line 405 "src/vcf/vcf_v43.ragel"
+#line 403 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st799;}
@@ -1053,7 +1053,7 @@ tr796:
     }
 	goto st0;
 tr801:
-#line 411 "src/vcf/vcf_v43.ragel"
+#line 409 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st799;}
@@ -1065,7 +1065,7 @@ tr801:
     }
 	goto st0;
 tr805:
-#line 417 "src/vcf/vcf_v43.ragel"
+#line 415 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st799;}
@@ -1077,7 +1077,7 @@ tr805:
     }
 	goto st0;
 tr814:
-#line 423 "src/vcf/vcf_v43.ragel"
+#line 421 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st799;}
@@ -1089,7 +1089,7 @@ tr814:
     }
 	goto st0;
 tr825:
-#line 429 "src/vcf/vcf_v43.ragel"
+#line 427 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st799;}
@@ -1101,12 +1101,12 @@ tr825:
     }
 	goto st0;
 tr833:
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1118,7 +1118,7 @@ tr833:
     }
 	goto st0;
 tr847:
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1130,7 +1130,7 @@ tr847:
     }
 	goto st0;
 tr851:
-#line 619 "src/vcf/vcf_v43.ragel"
+#line 617 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st799;}
@@ -1142,14 +1142,14 @@ tr851:
     }
 	goto st0;
 tr856:
-#line 632 "src/vcf/vcf_v43.ragel"
+#line 630 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 623 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1163,7 +1163,7 @@ tr856:
     }
 	goto st0;
 tr860:
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 623 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1184,12 +1184,12 @@ tr867:
     }
 	goto st0;
 tr879:
-#line 445 "src/vcf/vcf_v43.ragel"
+#line 443 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1201,7 +1201,7 @@ tr879:
     }
 	goto st0;
 tr881:
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 608 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1209,12 +1209,12 @@ tr881:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1226,7 +1226,7 @@ tr881:
     }
 	goto st0;
 tr883:
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 608 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1234,7 +1234,7 @@ tr883:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1246,7 +1246,7 @@ tr883:
     }
 	goto st0;
 tr891:
-#line 450 "src/vcf/vcf_v43.ragel"
+#line 448 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1254,7 +1254,7 @@ tr891:
                 "AA"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1266,7 +1266,7 @@ tr891:
     }
 	goto st0;
 tr894:
-#line 458 "src/vcf/vcf_v43.ragel"
+#line 456 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1274,7 +1274,7 @@ tr894:
                 "AC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1286,7 +1286,7 @@ tr894:
     }
 	goto st0;
 tr899:
-#line 466 "src/vcf/vcf_v43.ragel"
+#line 464 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1294,7 +1294,7 @@ tr899:
                 "AD"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1306,7 +1306,7 @@ tr899:
     }
 	goto st0;
 tr902:
-#line 474 "src/vcf/vcf_v43.ragel"
+#line 472 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1314,7 +1314,7 @@ tr902:
                 "ADF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1326,7 +1326,7 @@ tr902:
     }
 	goto st0;
 tr905:
-#line 482 "src/vcf/vcf_v43.ragel"
+#line 480 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1334,7 +1334,7 @@ tr905:
                 "ADR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1346,7 +1346,7 @@ tr905:
     }
 	goto st0;
 tr908:
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 488 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1354,7 +1354,7 @@ tr908:
                 "AF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1366,7 +1366,7 @@ tr908:
     }
 	goto st0;
 tr922:
-#line 498 "src/vcf/vcf_v43.ragel"
+#line 496 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1374,7 +1374,7 @@ tr922:
                 "AN"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1386,7 +1386,7 @@ tr922:
     }
 	goto st0;
 tr926:
-#line 506 "src/vcf/vcf_v43.ragel"
+#line 504 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1394,7 +1394,7 @@ tr926:
                 "BQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1406,7 +1406,7 @@ tr926:
     }
 	goto st0;
 tr944:
-#line 514 "src/vcf/vcf_v43.ragel"
+#line 512 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1414,7 +1414,7 @@ tr944:
                 "CIGAR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1426,7 +1426,7 @@ tr944:
     }
 	goto st0;
 tr949:
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 520 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1434,12 +1434,12 @@ tr949:
                 "DB"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1451,7 +1451,7 @@ tr949:
     }
 	goto st0;
 tr951:
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 520 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1459,7 +1459,7 @@ tr951:
                 "DB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1471,7 +1471,7 @@ tr951:
     }
 	goto st0;
 tr954:
-#line 530 "src/vcf/vcf_v43.ragel"
+#line 528 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1479,7 +1479,7 @@ tr954:
                 "DP"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1491,7 +1491,7 @@ tr954:
     }
 	goto st0;
 tr959:
-#line 538 "src/vcf/vcf_v43.ragel"
+#line 536 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1499,7 +1499,7 @@ tr959:
                 "END"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1511,7 +1511,7 @@ tr959:
     }
 	goto st0;
 tr963:
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 544 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1519,12 +1519,12 @@ tr963:
                 "H2"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1536,7 +1536,7 @@ tr963:
     }
 	goto st0;
 tr965:
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 544 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1544,7 +1544,7 @@ tr965:
                 "H2"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1556,7 +1556,7 @@ tr965:
     }
 	goto st0;
 tr967:
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 552 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1564,12 +1564,12 @@ tr967:
                 "H3"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1581,7 +1581,7 @@ tr967:
     }
 	goto st0;
 tr969:
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 552 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1589,7 +1589,7 @@ tr969:
                 "H3"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1601,7 +1601,7 @@ tr969:
     }
 	goto st0;
 tr975:
-#line 570 "src/vcf/vcf_v43.ragel"
+#line 568 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1609,7 +1609,7 @@ tr975:
                 "MQ0"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1621,7 +1621,7 @@ tr975:
     }
 	goto st0;
 tr977:
-#line 562 "src/vcf/vcf_v43.ragel"
+#line 560 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1629,7 +1629,7 @@ tr977:
                 "MQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1641,7 +1641,7 @@ tr977:
     }
 	goto st0;
 tr992:
-#line 578 "src/vcf/vcf_v43.ragel"
+#line 576 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1649,7 +1649,7 @@ tr992:
                 "NS"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1661,7 +1661,7 @@ tr992:
     }
 	goto st0;
 tr997:
-#line 586 "src/vcf/vcf_v43.ragel"
+#line 584 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1669,7 +1669,7 @@ tr997:
                 "SB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1681,7 +1681,7 @@ tr997:
     }
 	goto st0;
 tr1015:
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 592 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1689,12 +1689,12 @@ tr1015:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1706,7 +1706,7 @@ tr1015:
     }
 	goto st0;
 tr1017:
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 592 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1714,7 +1714,7 @@ tr1017:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1726,7 +1726,7 @@ tr1017:
     }
 	goto st0;
 tr1027:
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 600 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1734,12 +1734,12 @@ tr1027:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1751,7 +1751,7 @@ tr1027:
     }
 	goto st0;
 tr1029:
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 600 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1759,7 +1759,7 @@ tr1029:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -1778,13 +1778,13 @@ tr1078:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
         p--; {goto st799;}
     }
-#line 393 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
@@ -1999,7 +1999,7 @@ tr22:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           p--; {goto st798;}
         }
@@ -2134,7 +2134,7 @@ tr46:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -2154,7 +2154,7 @@ tr56:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -2186,7 +2186,7 @@ tr47:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -2206,7 +2206,7 @@ tr57:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -10587,7 +10587,7 @@ tr646:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -11826,7 +11826,7 @@ tr730:
 	{
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -12391,7 +12391,7 @@ tr1079:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -12433,7 +12433,7 @@ tr1080:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -12477,7 +12477,7 @@ tr1081:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -13162,12 +13162,10 @@ tr849:
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -13186,7 +13184,7 @@ st802:
 	if ( ++p == pe )
 		goto _test_eof802;
 case 802:
-#line 13190 "inc/vcf/validator_detail_v43.hpp"
+#line 13188 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1083;
 		case 13: goto tr1084;
@@ -13215,7 +13213,7 @@ tr1082:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -13224,7 +13222,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13228 "inc/vcf/validator_detail_v43.hpp"
+#line 13226 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr863;
 		case 59: goto tr863;
@@ -13265,7 +13263,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13269 "inc/vcf/validator_detail_v43.hpp"
+#line 13267 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr864;
 		case 59: goto tr864;
@@ -13294,7 +13292,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13298 "inc/vcf/validator_detail_v43.hpp"
+#line 13296 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr866;
 	goto tr789;
@@ -13321,12 +13319,10 @@ tr850:
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -13345,7 +13341,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13349 "inc/vcf/validator_detail_v43.hpp"
+#line 13345 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st802;
 	goto tr867;
@@ -13359,7 +13355,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13363 "inc/vcf/validator_detail_v43.hpp"
+#line 13359 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr861;
@@ -13386,7 +13382,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13390 "inc/vcf/validator_detail_v43.hpp"
+#line 13386 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13408,7 +13404,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13412 "inc/vcf/validator_detail_v43.hpp"
+#line 13408 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13445,7 +13441,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13449 "inc/vcf/validator_detail_v43.hpp"
+#line 13445 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr853;
 		case 10: goto tr849;
@@ -13483,7 +13479,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13487 "inc/vcf/validator_detail_v43.hpp"
+#line 13483 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13512,7 +13508,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13516 "inc/vcf/validator_detail_v43.hpp"
+#line 13512 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 49: goto tr836;
 		case 65: goto tr837;
@@ -13550,7 +13546,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13554 "inc/vcf/validator_detail_v43.hpp"
+#line 13550 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13580,7 +13576,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13584 "inc/vcf/validator_detail_v43.hpp"
+#line 13580 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13610,7 +13606,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 13614 "inc/vcf/validator_detail_v43.hpp"
+#line 13610 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13640,7 +13636,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 13644 "inc/vcf/validator_detail_v43.hpp"
+#line 13640 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13670,7 +13666,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 13674 "inc/vcf/validator_detail_v43.hpp"
+#line 13670 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr880;
@@ -13687,7 +13683,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 13691 "inc/vcf/validator_detail_v43.hpp"
+#line 13687 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13707,7 +13703,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 13711 "inc/vcf/validator_detail_v43.hpp"
+#line 13707 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13736,7 +13732,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 13740 "inc/vcf/validator_detail_v43.hpp"
+#line 13736 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr884;
 	goto tr883;
@@ -13750,7 +13746,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 13754 "inc/vcf/validator_detail_v43.hpp"
+#line 13750 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13772,7 +13768,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 13776 "inc/vcf/validator_detail_v43.hpp"
+#line 13772 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13806,7 +13802,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 13810 "inc/vcf/validator_detail_v43.hpp"
+#line 13806 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr890;
@@ -13831,7 +13827,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 13835 "inc/vcf/validator_detail_v43.hpp"
+#line 13831 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr892;
 	if ( (*p) < 45 ) {
@@ -13853,7 +13849,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 13857 "inc/vcf/validator_detail_v43.hpp"
+#line 13853 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13879,7 +13875,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 13883 "inc/vcf/validator_detail_v43.hpp"
+#line 13879 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr893;
@@ -13904,7 +13900,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 13908 "inc/vcf/validator_detail_v43.hpp"
+#line 13904 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr895;
 	goto tr894;
@@ -13918,7 +13914,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 13922 "inc/vcf/validator_detail_v43.hpp"
+#line 13918 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -13939,7 +13935,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 13943 "inc/vcf/validator_detail_v43.hpp"
+#line 13939 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr896;
@@ -13966,7 +13962,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 13970 "inc/vcf/validator_detail_v43.hpp"
+#line 13966 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr900;
 	goto tr899;
@@ -13980,7 +13976,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 13984 "inc/vcf/validator_detail_v43.hpp"
+#line 13980 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14001,7 +13997,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 14005 "inc/vcf/validator_detail_v43.hpp"
+#line 14001 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr901;
@@ -14026,7 +14022,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 14030 "inc/vcf/validator_detail_v43.hpp"
+#line 14026 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr903;
 	goto tr902;
@@ -14040,7 +14036,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 14044 "inc/vcf/validator_detail_v43.hpp"
+#line 14040 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14061,7 +14057,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 14065 "inc/vcf/validator_detail_v43.hpp"
+#line 14061 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr904;
@@ -14086,7 +14082,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 14090 "inc/vcf/validator_detail_v43.hpp"
+#line 14086 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr906;
 	goto tr905;
@@ -14100,7 +14096,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 14104 "inc/vcf/validator_detail_v43.hpp"
+#line 14100 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14121,7 +14117,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 14125 "inc/vcf/validator_detail_v43.hpp"
+#line 14121 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr907;
@@ -14146,7 +14142,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 14150 "inc/vcf/validator_detail_v43.hpp"
+#line 14146 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr909;
 		case 45: goto tr909;
@@ -14166,7 +14162,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 14170 "inc/vcf/validator_detail_v43.hpp"
+#line 14166 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr911;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14182,7 +14178,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14186 "inc/vcf/validator_detail_v43.hpp"
+#line 14182 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14206,7 +14202,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14210 "inc/vcf/validator_detail_v43.hpp"
+#line 14206 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr915;
 	goto tr908;
@@ -14220,7 +14216,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14224 "inc/vcf/validator_detail_v43.hpp"
+#line 14220 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14243,7 +14239,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14247 "inc/vcf/validator_detail_v43.hpp"
+#line 14243 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr916;
 		case 45: goto tr916;
@@ -14261,7 +14257,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 14265 "inc/vcf/validator_detail_v43.hpp"
+#line 14261 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr917;
 	goto tr908;
@@ -14275,7 +14271,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 14279 "inc/vcf/validator_detail_v43.hpp"
+#line 14275 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14296,7 +14292,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 14300 "inc/vcf/validator_detail_v43.hpp"
+#line 14296 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr918;
 	goto tr908;
@@ -14310,7 +14306,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 14314 "inc/vcf/validator_detail_v43.hpp"
+#line 14310 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr919;
 	goto tr908;
@@ -14324,7 +14320,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 14328 "inc/vcf/validator_detail_v43.hpp"
+#line 14324 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14343,7 +14339,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 14347 "inc/vcf/validator_detail_v43.hpp"
+#line 14343 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr920;
 	goto tr908;
@@ -14357,7 +14353,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 14361 "inc/vcf/validator_detail_v43.hpp"
+#line 14357 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr919;
 	goto tr908;
@@ -14371,7 +14367,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 14375 "inc/vcf/validator_detail_v43.hpp"
+#line 14371 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr921;
@@ -14396,7 +14392,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 14400 "inc/vcf/validator_detail_v43.hpp"
+#line 14396 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr923;
 	goto tr922;
@@ -14410,7 +14406,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 14414 "inc/vcf/validator_detail_v43.hpp"
+#line 14410 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14434,7 +14430,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 14438 "inc/vcf/validator_detail_v43.hpp"
+#line 14434 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14464,7 +14460,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 14468 "inc/vcf/validator_detail_v43.hpp"
+#line 14464 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr925;
@@ -14489,7 +14485,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 14493 "inc/vcf/validator_detail_v43.hpp"
+#line 14489 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr927;
 		case 45: goto tr927;
@@ -14509,7 +14505,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 14513 "inc/vcf/validator_detail_v43.hpp"
+#line 14509 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr929;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14525,7 +14521,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 14529 "inc/vcf/validator_detail_v43.hpp"
+#line 14525 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14548,7 +14544,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 14552 "inc/vcf/validator_detail_v43.hpp"
+#line 14548 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr926;
@@ -14562,7 +14558,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 14566 "inc/vcf/validator_detail_v43.hpp"
+#line 14562 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14584,7 +14580,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 14588 "inc/vcf/validator_detail_v43.hpp"
+#line 14584 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr934;
 		case 45: goto tr934;
@@ -14602,7 +14598,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 14606 "inc/vcf/validator_detail_v43.hpp"
+#line 14602 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr935;
 	goto tr926;
@@ -14616,7 +14612,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 14620 "inc/vcf/validator_detail_v43.hpp"
+#line 14616 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14636,7 +14632,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 14640 "inc/vcf/validator_detail_v43.hpp"
+#line 14636 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr936;
 	goto tr926;
@@ -14650,7 +14646,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 14654 "inc/vcf/validator_detail_v43.hpp"
+#line 14650 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr937;
 	goto tr926;
@@ -14664,7 +14660,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 14668 "inc/vcf/validator_detail_v43.hpp"
+#line 14664 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14682,7 +14678,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 14686 "inc/vcf/validator_detail_v43.hpp"
+#line 14682 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr938;
 	goto tr926;
@@ -14696,7 +14692,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 14700 "inc/vcf/validator_detail_v43.hpp"
+#line 14696 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr937;
 	goto tr926;
@@ -14714,7 +14710,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 14718 "inc/vcf/validator_detail_v43.hpp"
+#line 14714 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14744,7 +14740,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 14748 "inc/vcf/validator_detail_v43.hpp"
+#line 14744 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14774,7 +14770,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 14778 "inc/vcf/validator_detail_v43.hpp"
+#line 14774 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14804,7 +14800,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 14808 "inc/vcf/validator_detail_v43.hpp"
+#line 14804 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14834,7 +14830,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 14838 "inc/vcf/validator_detail_v43.hpp"
+#line 14834 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr943;
@@ -14859,7 +14855,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 14863 "inc/vcf/validator_detail_v43.hpp"
+#line 14859 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr945;
 	goto tr944;
@@ -14873,7 +14869,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 14877 "inc/vcf/validator_detail_v43.hpp"
+#line 14873 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 68: goto tr946;
 		case 80: goto tr946;
@@ -14899,7 +14895,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 14903 "inc/vcf/validator_detail_v43.hpp"
+#line 14899 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14923,7 +14919,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 14927 "inc/vcf/validator_detail_v43.hpp"
+#line 14923 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14954,7 +14950,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 14958 "inc/vcf/validator_detail_v43.hpp"
+#line 14954 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -14983,7 +14979,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 14987 "inc/vcf/validator_detail_v43.hpp"
+#line 14983 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr952;
 	goto tr951;
@@ -14997,7 +14993,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 15001 "inc/vcf/validator_detail_v43.hpp"
+#line 14997 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15015,7 +15011,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 15019 "inc/vcf/validator_detail_v43.hpp"
+#line 15015 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr953;
@@ -15040,7 +15036,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 15044 "inc/vcf/validator_detail_v43.hpp"
+#line 15040 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr955;
 	goto tr954;
@@ -15054,7 +15050,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 15058 "inc/vcf/validator_detail_v43.hpp"
+#line 15054 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15078,7 +15074,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 15082 "inc/vcf/validator_detail_v43.hpp"
+#line 15078 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15108,7 +15104,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 15112 "inc/vcf/validator_detail_v43.hpp"
+#line 15108 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15138,7 +15134,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 15142 "inc/vcf/validator_detail_v43.hpp"
+#line 15138 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr958;
@@ -15163,7 +15159,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 15167 "inc/vcf/validator_detail_v43.hpp"
+#line 15163 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr960;
 	goto tr959;
@@ -15177,7 +15173,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 15181 "inc/vcf/validator_detail_v43.hpp"
+#line 15177 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15201,7 +15197,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 15205 "inc/vcf/validator_detail_v43.hpp"
+#line 15201 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15232,7 +15228,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 15236 "inc/vcf/validator_detail_v43.hpp"
+#line 15232 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15261,7 +15257,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 15265 "inc/vcf/validator_detail_v43.hpp"
+#line 15261 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr966;
 	goto tr965;
@@ -15275,7 +15271,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 15279 "inc/vcf/validator_detail_v43.hpp"
+#line 15275 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15293,7 +15289,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 15297 "inc/vcf/validator_detail_v43.hpp"
+#line 15293 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15322,7 +15318,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 15326 "inc/vcf/validator_detail_v43.hpp"
+#line 15322 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr970;
 	goto tr969;
@@ -15336,7 +15332,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 15340 "inc/vcf/validator_detail_v43.hpp"
+#line 15336 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15358,7 +15354,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 15362 "inc/vcf/validator_detail_v43.hpp"
+#line 15358 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15388,7 +15384,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 15392 "inc/vcf/validator_detail_v43.hpp"
+#line 15388 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 48: goto tr972;
@@ -15414,7 +15410,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 15418 "inc/vcf/validator_detail_v43.hpp"
+#line 15414 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr974;
@@ -15439,7 +15435,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 15443 "inc/vcf/validator_detail_v43.hpp"
+#line 15439 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr976;
 	goto tr975;
@@ -15453,7 +15449,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 15457 "inc/vcf/validator_detail_v43.hpp"
+#line 15453 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15473,7 +15469,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 15477 "inc/vcf/validator_detail_v43.hpp"
+#line 15473 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr978;
 		case 45: goto tr978;
@@ -15493,7 +15489,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 15497 "inc/vcf/validator_detail_v43.hpp"
+#line 15493 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr980;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15509,7 +15505,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 15513 "inc/vcf/validator_detail_v43.hpp"
+#line 15509 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15532,7 +15528,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 15536 "inc/vcf/validator_detail_v43.hpp"
+#line 15532 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr984;
 	goto tr977;
@@ -15546,7 +15542,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 15550 "inc/vcf/validator_detail_v43.hpp"
+#line 15546 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15568,7 +15564,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 15572 "inc/vcf/validator_detail_v43.hpp"
+#line 15568 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr985;
 		case 45: goto tr985;
@@ -15586,7 +15582,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 15590 "inc/vcf/validator_detail_v43.hpp"
+#line 15586 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr986;
 	goto tr977;
@@ -15600,7 +15596,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 15604 "inc/vcf/validator_detail_v43.hpp"
+#line 15600 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15620,7 +15616,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 15624 "inc/vcf/validator_detail_v43.hpp"
+#line 15620 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr987;
 	goto tr977;
@@ -15634,7 +15630,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 15638 "inc/vcf/validator_detail_v43.hpp"
+#line 15634 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr988;
 	goto tr977;
@@ -15648,7 +15644,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 15652 "inc/vcf/validator_detail_v43.hpp"
+#line 15648 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15666,7 +15662,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 15670 "inc/vcf/validator_detail_v43.hpp"
+#line 15666 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr989;
 	goto tr977;
@@ -15680,7 +15676,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 15684 "inc/vcf/validator_detail_v43.hpp"
+#line 15680 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr988;
 	goto tr977;
@@ -15698,7 +15694,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 15702 "inc/vcf/validator_detail_v43.hpp"
+#line 15698 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15728,7 +15724,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 15732 "inc/vcf/validator_detail_v43.hpp"
+#line 15728 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr991;
@@ -15753,7 +15749,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 15757 "inc/vcf/validator_detail_v43.hpp"
+#line 15753 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr993;
 	goto tr992;
@@ -15767,7 +15763,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 15771 "inc/vcf/validator_detail_v43.hpp"
+#line 15767 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15791,7 +15787,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 15795 "inc/vcf/validator_detail_v43.hpp"
+#line 15791 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15822,7 +15818,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 15826 "inc/vcf/validator_detail_v43.hpp"
+#line 15822 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr872;
 		case 61: goto tr996;
@@ -15847,7 +15843,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 15851 "inc/vcf/validator_detail_v43.hpp"
+#line 15847 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr998;
 		case 45: goto tr998;
@@ -15867,7 +15863,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 15871 "inc/vcf/validator_detail_v43.hpp"
+#line 15867 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr1000;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15883,7 +15879,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 15887 "inc/vcf/validator_detail_v43.hpp"
+#line 15883 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15906,7 +15902,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 15910 "inc/vcf/validator_detail_v43.hpp"
+#line 15906 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1004;
 	goto tr997;
@@ -15920,7 +15916,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 15924 "inc/vcf/validator_detail_v43.hpp"
+#line 15920 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15942,7 +15938,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 15946 "inc/vcf/validator_detail_v43.hpp"
+#line 15942 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1005;
 		case 45: goto tr1005;
@@ -15960,7 +15956,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 15964 "inc/vcf/validator_detail_v43.hpp"
+#line 15960 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1006;
 	goto tr997;
@@ -15974,7 +15970,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 15978 "inc/vcf/validator_detail_v43.hpp"
+#line 15974 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -15994,7 +15990,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 15998 "inc/vcf/validator_detail_v43.hpp"
+#line 15994 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr1007;
 	goto tr997;
@@ -16008,7 +16004,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 16012 "inc/vcf/validator_detail_v43.hpp"
+#line 16008 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr1008;
 	goto tr997;
@@ -16022,7 +16018,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 16026 "inc/vcf/validator_detail_v43.hpp"
+#line 16022 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16040,7 +16036,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 16044 "inc/vcf/validator_detail_v43.hpp"
+#line 16040 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr1009;
 	goto tr997;
@@ -16054,7 +16050,7 @@ st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 16058 "inc/vcf/validator_detail_v43.hpp"
+#line 16054 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr1008;
 	goto tr997;
@@ -16068,7 +16064,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 16072 "inc/vcf/validator_detail_v43.hpp"
+#line 16068 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16098,7 +16094,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 16102 "inc/vcf/validator_detail_v43.hpp"
+#line 16098 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16128,7 +16124,7 @@ st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 16132 "inc/vcf/validator_detail_v43.hpp"
+#line 16128 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16158,7 +16154,7 @@ st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 16162 "inc/vcf/validator_detail_v43.hpp"
+#line 16158 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16188,7 +16184,7 @@ st734:
 	if ( ++p == pe )
 		goto _test_eof734;
 case 734:
-#line 16192 "inc/vcf/validator_detail_v43.hpp"
+#line 16188 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16218,7 +16214,7 @@ st735:
 	if ( ++p == pe )
 		goto _test_eof735;
 case 735:
-#line 16222 "inc/vcf/validator_detail_v43.hpp"
+#line 16218 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16247,7 +16243,7 @@ st736:
 	if ( ++p == pe )
 		goto _test_eof736;
 case 736:
-#line 16251 "inc/vcf/validator_detail_v43.hpp"
+#line 16247 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr1018;
 	goto tr1017;
@@ -16261,7 +16257,7 @@ st737:
 	if ( ++p == pe )
 		goto _test_eof737;
 case 737:
-#line 16265 "inc/vcf/validator_detail_v43.hpp"
+#line 16261 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16283,7 +16279,7 @@ st738:
 	if ( ++p == pe )
 		goto _test_eof738;
 case 738:
-#line 16287 "inc/vcf/validator_detail_v43.hpp"
+#line 16283 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16313,7 +16309,7 @@ st739:
 	if ( ++p == pe )
 		goto _test_eof739;
 case 739:
-#line 16317 "inc/vcf/validator_detail_v43.hpp"
+#line 16313 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16343,7 +16339,7 @@ st740:
 	if ( ++p == pe )
 		goto _test_eof740;
 case 740:
-#line 16347 "inc/vcf/validator_detail_v43.hpp"
+#line 16343 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16373,7 +16369,7 @@ st741:
 	if ( ++p == pe )
 		goto _test_eof741;
 case 741:
-#line 16377 "inc/vcf/validator_detail_v43.hpp"
+#line 16373 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16403,7 +16399,7 @@ st742:
 	if ( ++p == pe )
 		goto _test_eof742;
 case 742:
-#line 16407 "inc/vcf/validator_detail_v43.hpp"
+#line 16403 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16433,7 +16429,7 @@ st743:
 	if ( ++p == pe )
 		goto _test_eof743;
 case 743:
-#line 16437 "inc/vcf/validator_detail_v43.hpp"
+#line 16433 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16463,7 +16459,7 @@ st744:
 	if ( ++p == pe )
 		goto _test_eof744;
 case 744:
-#line 16467 "inc/vcf/validator_detail_v43.hpp"
+#line 16463 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16493,7 +16489,7 @@ st745:
 	if ( ++p == pe )
 		goto _test_eof745;
 case 745:
-#line 16497 "inc/vcf/validator_detail_v43.hpp"
+#line 16493 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16523,7 +16519,7 @@ st746:
 	if ( ++p == pe )
 		goto _test_eof746;
 case 746:
-#line 16527 "inc/vcf/validator_detail_v43.hpp"
+#line 16523 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16552,7 +16548,7 @@ st747:
 	if ( ++p == pe )
 		goto _test_eof747;
 case 747:
-#line 16556 "inc/vcf/validator_detail_v43.hpp"
+#line 16552 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr1030;
 	goto tr1029;
@@ -16566,7 +16562,7 @@ st748:
 	if ( ++p == pe )
 		goto _test_eof748;
 case 748:
-#line 16570 "inc/vcf/validator_detail_v43.hpp"
+#line 16566 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr848;
 		case 10: goto tr849;
@@ -16584,7 +16580,7 @@ st749:
 	if ( ++p == pe )
 		goto _test_eof749;
 case 749:
-#line 16588 "inc/vcf/validator_detail_v43.hpp"
+#line 16584 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr826;
 	if ( (*p) < 65 ) {
@@ -16622,7 +16618,7 @@ st750:
 	if ( ++p == pe )
 		goto _test_eof750;
 case 750:
-#line 16626 "inc/vcf/validator_detail_v43.hpp"
+#line 16622 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 58: goto st591;
@@ -16658,7 +16654,7 @@ st751:
 	if ( ++p == pe )
 		goto _test_eof751;
 case 751:
-#line 16662 "inc/vcf/validator_detail_v43.hpp"
+#line 16658 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1031;
 	goto tr814;
@@ -16672,7 +16668,7 @@ st752:
 	if ( ++p == pe )
 		goto _test_eof752;
 case 752:
-#line 16676 "inc/vcf/validator_detail_v43.hpp"
+#line 16672 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 69: goto tr824;
@@ -16691,7 +16687,7 @@ st753:
 	if ( ++p == pe )
 		goto _test_eof753;
 case 753:
-#line 16695 "inc/vcf/validator_detail_v43.hpp"
+#line 16691 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1032;
 		case 45: goto tr1032;
@@ -16709,7 +16705,7 @@ st754:
 	if ( ++p == pe )
 		goto _test_eof754;
 case 754:
-#line 16713 "inc/vcf/validator_detail_v43.hpp"
+#line 16709 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1033;
 	goto tr814;
@@ -16723,7 +16719,7 @@ st755:
 	if ( ++p == pe )
 		goto _test_eof755;
 case 755:
-#line 16727 "inc/vcf/validator_detail_v43.hpp"
+#line 16723 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16749,7 +16745,7 @@ st756:
 	if ( ++p == pe )
 		goto _test_eof756;
 case 756:
-#line 16753 "inc/vcf/validator_detail_v43.hpp"
+#line 16749 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr1034;
 	goto tr814;
@@ -16763,7 +16759,7 @@ st757:
 	if ( ++p == pe )
 		goto _test_eof757;
 case 757:
-#line 16767 "inc/vcf/validator_detail_v43.hpp"
+#line 16763 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr1035;
 	goto tr814;
@@ -16787,7 +16783,7 @@ st758:
 	if ( ++p == pe )
 		goto _test_eof758;
 case 758:
-#line 16791 "inc/vcf/validator_detail_v43.hpp"
+#line 16787 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	goto tr814;
@@ -16805,7 +16801,7 @@ st759:
 	if ( ++p == pe )
 		goto _test_eof759;
 case 759:
-#line 16809 "inc/vcf/validator_detail_v43.hpp"
+#line 16805 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr1036;
 	goto tr814;
@@ -16819,7 +16815,7 @@ st760:
 	if ( ++p == pe )
 		goto _test_eof760;
 case 760:
-#line 16823 "inc/vcf/validator_detail_v43.hpp"
+#line 16819 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr1035;
 	goto tr814;
@@ -16833,7 +16829,7 @@ st761:
 	if ( ++p == pe )
 		goto _test_eof761;
 case 761:
-#line 16837 "inc/vcf/validator_detail_v43.hpp"
+#line 16833 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr1037;
@@ -16872,7 +16868,7 @@ st762:
 	if ( ++p == pe )
 		goto _test_eof762;
 case 762:
-#line 16876 "inc/vcf/validator_detail_v43.hpp"
+#line 16872 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr1038;
 		case 67: goto tr1038;
@@ -16896,7 +16892,7 @@ st763:
 	if ( ++p == pe )
 		goto _test_eof763;
 case 763:
-#line 16900 "inc/vcf/validator_detail_v43.hpp"
+#line 16896 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -16932,7 +16928,7 @@ st764:
 	if ( ++p == pe )
 		goto _test_eof764;
 case 764:
-#line 16936 "inc/vcf/validator_detail_v43.hpp"
+#line 16932 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr1039;
 	if ( (*p) < 63 ) {
@@ -16972,7 +16968,7 @@ st765:
 	if ( ++p == pe )
 		goto _test_eof765;
 case 765:
-#line 16976 "inc/vcf/validator_detail_v43.hpp"
+#line 16972 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto tr1041;
 	if ( (*p) < 45 ) {
@@ -17004,7 +17000,7 @@ st766:
 	if ( ++p == pe )
 		goto _test_eof766;
 case 766:
-#line 17008 "inc/vcf/validator_detail_v43.hpp"
+#line 17004 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -17033,7 +17029,7 @@ st767:
 	if ( ++p == pe )
 		goto _test_eof767;
 case 767:
-#line 17037 "inc/vcf/validator_detail_v43.hpp"
+#line 17033 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1045;
 		case 59: goto tr1045;
@@ -17065,7 +17061,7 @@ st768:
 	if ( ++p == pe )
 		goto _test_eof768;
 case 768:
-#line 17069 "inc/vcf/validator_detail_v43.hpp"
+#line 17065 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1045;
 		case 58: goto tr1047;
@@ -17093,7 +17089,7 @@ st769:
 	if ( ++p == pe )
 		goto _test_eof769;
 case 769:
-#line 17097 "inc/vcf/validator_detail_v43.hpp"
+#line 17093 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1048;
 	goto tr805;
@@ -17107,7 +17103,7 @@ st770:
 	if ( ++p == pe )
 		goto _test_eof770;
 case 770:
-#line 17111 "inc/vcf/validator_detail_v43.hpp"
+#line 17107 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr1041;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17123,7 +17119,7 @@ st771:
 	if ( ++p == pe )
 		goto _test_eof771;
 case 771:
-#line 17127 "inc/vcf/validator_detail_v43.hpp"
+#line 17123 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1049;
 		case 59: goto tr1049;
@@ -17154,7 +17150,7 @@ st772:
 	if ( ++p == pe )
 		goto _test_eof772;
 case 772:
-#line 17158 "inc/vcf/validator_detail_v43.hpp"
+#line 17154 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1049;
 		case 59: goto tr1049;
@@ -17183,7 +17179,7 @@ st773:
 	if ( ++p == pe )
 		goto _test_eof773;
 case 773:
-#line 17187 "inc/vcf/validator_detail_v43.hpp"
+#line 17183 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1047;
 	goto tr805;
@@ -17197,7 +17193,7 @@ st774:
 	if ( ++p == pe )
 		goto _test_eof774;
 case 774:
-#line 17201 "inc/vcf/validator_detail_v43.hpp"
+#line 17197 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1051;
 		case 59: goto tr1051;
@@ -17229,7 +17225,7 @@ st775:
 	if ( ++p == pe )
 		goto _test_eof775;
 case 775:
-#line 17233 "inc/vcf/validator_detail_v43.hpp"
+#line 17229 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1051;
 		case 58: goto tr1053;
@@ -17257,7 +17253,7 @@ st776:
 	if ( ++p == pe )
 		goto _test_eof776;
 case 776:
-#line 17261 "inc/vcf/validator_detail_v43.hpp"
+#line 17257 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1054;
 	goto tr805;
@@ -17271,7 +17267,7 @@ st777:
 	if ( ++p == pe )
 		goto _test_eof777;
 case 777:
-#line 17275 "inc/vcf/validator_detail_v43.hpp"
+#line 17271 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr1041;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17287,7 +17283,7 @@ st778:
 	if ( ++p == pe )
 		goto _test_eof778;
 case 778:
-#line 17291 "inc/vcf/validator_detail_v43.hpp"
+#line 17287 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1055;
 		case 59: goto tr1055;
@@ -17318,7 +17314,7 @@ st779:
 	if ( ++p == pe )
 		goto _test_eof779;
 case 779:
-#line 17322 "inc/vcf/validator_detail_v43.hpp"
+#line 17318 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1055;
 		case 59: goto tr1055;
@@ -17347,7 +17343,7 @@ st780:
 	if ( ++p == pe )
 		goto _test_eof780;
 case 780:
-#line 17351 "inc/vcf/validator_detail_v43.hpp"
+#line 17347 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1053;
 	goto tr805;
@@ -17365,7 +17361,7 @@ st781:
 	if ( ++p == pe )
 		goto _test_eof781;
 case 781:
-#line 17369 "inc/vcf/validator_detail_v43.hpp"
+#line 17365 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1057;
 		case 59: goto tr1057;
@@ -17397,7 +17393,7 @@ st782:
 	if ( ++p == pe )
 		goto _test_eof782;
 case 782:
-#line 17401 "inc/vcf/validator_detail_v43.hpp"
+#line 17397 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1057;
 		case 58: goto tr1059;
@@ -17425,7 +17421,7 @@ st783:
 	if ( ++p == pe )
 		goto _test_eof783;
 case 783:
-#line 17429 "inc/vcf/validator_detail_v43.hpp"
+#line 17425 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1060;
 	goto tr805;
@@ -17439,7 +17435,7 @@ st784:
 	if ( ++p == pe )
 		goto _test_eof784;
 case 784:
-#line 17443 "inc/vcf/validator_detail_v43.hpp"
+#line 17439 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr1061;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17455,7 +17451,7 @@ st785:
 	if ( ++p == pe )
 		goto _test_eof785;
 case 785:
-#line 17459 "inc/vcf/validator_detail_v43.hpp"
+#line 17455 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1062;
 		case 59: goto tr1062;
@@ -17486,7 +17482,7 @@ st786:
 	if ( ++p == pe )
 		goto _test_eof786;
 case 786:
-#line 17490 "inc/vcf/validator_detail_v43.hpp"
+#line 17486 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1062;
 		case 59: goto tr1062;
@@ -17515,7 +17511,7 @@ st787:
 	if ( ++p == pe )
 		goto _test_eof787;
 case 787:
-#line 17519 "inc/vcf/validator_detail_v43.hpp"
+#line 17515 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1059;
 	goto tr805;
@@ -17533,7 +17529,7 @@ st788:
 	if ( ++p == pe )
 		goto _test_eof788;
 case 788:
-#line 17537 "inc/vcf/validator_detail_v43.hpp"
+#line 17533 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1064;
 		case 59: goto tr1064;
@@ -17565,7 +17561,7 @@ st789:
 	if ( ++p == pe )
 		goto _test_eof789;
 case 789:
-#line 17569 "inc/vcf/validator_detail_v43.hpp"
+#line 17565 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1064;
 		case 58: goto tr1066;
@@ -17593,7 +17589,7 @@ st790:
 	if ( ++p == pe )
 		goto _test_eof790;
 case 790:
-#line 17597 "inc/vcf/validator_detail_v43.hpp"
+#line 17593 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1067;
 	goto tr805;
@@ -17607,7 +17603,7 @@ st791:
 	if ( ++p == pe )
 		goto _test_eof791;
 case 791:
-#line 17611 "inc/vcf/validator_detail_v43.hpp"
+#line 17607 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr1061;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17623,7 +17619,7 @@ st792:
 	if ( ++p == pe )
 		goto _test_eof792;
 case 792:
-#line 17627 "inc/vcf/validator_detail_v43.hpp"
+#line 17623 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1068;
 		case 59: goto tr1068;
@@ -17654,7 +17650,7 @@ st793:
 	if ( ++p == pe )
 		goto _test_eof793;
 case 793:
-#line 17658 "inc/vcf/validator_detail_v43.hpp"
+#line 17654 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1068;
 		case 59: goto tr1068;
@@ -17683,7 +17679,7 @@ st794:
 	if ( ++p == pe )
 		goto _test_eof794;
 case 794:
-#line 17687 "inc/vcf/validator_detail_v43.hpp"
+#line 17683 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr1066;
 	goto tr805;
@@ -17701,7 +17697,7 @@ st795:
 	if ( ++p == pe )
 		goto _test_eof795;
 case 795:
-#line 17705 "inc/vcf/validator_detail_v43.hpp"
+#line 17701 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 65: goto tr1038;
@@ -17756,7 +17752,7 @@ st796:
 	if ( ++p == pe )
 		goto _test_eof796;
 case 796:
-#line 17760 "inc/vcf/validator_detail_v43.hpp"
+#line 17756 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st800;
 	goto tr774;
@@ -17765,7 +17761,7 @@ tr23:
 	{
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           p--; {goto st798;}
         }
@@ -17785,7 +17781,7 @@ st797:
 	if ( ++p == pe )
 		goto _test_eof797;
 case 797:
-#line 17789 "inc/vcf/validator_detail_v43.hpp"
+#line 17785 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -17805,7 +17801,7 @@ st798:
 	if ( ++p == pe )
 		goto _test_eof798;
 case 798:
-#line 17809 "inc/vcf/validator_detail_v43.hpp"
+#line 17805 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1073;
 		case 13: goto tr1074;
@@ -17822,14 +17818,14 @@ tr1073:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 907 "src/vcf/vcf_v43.ragel"
+#line 905 "src/vcf/vcf_v43.ragel"
 	{ {goto st28;} }
 	goto st803;
 st803:
 	if ( ++p == pe )
 		goto _test_eof803;
 case 803:
-#line 17833 "inc/vcf/validator_detail_v43.hpp"
+#line 17829 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 tr1077:
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -17847,7 +17843,7 @@ st799:
 	if ( ++p == pe )
 		goto _test_eof799;
 case 799:
-#line 17851 "inc/vcf/validator_detail_v43.hpp"
+#line 17847 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1076;
 		case 13: goto tr1077;
@@ -17864,14 +17860,14 @@ tr1076:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 908 "src/vcf/vcf_v43.ragel"
+#line 906 "src/vcf/vcf_v43.ragel"
 	{ {goto st802;} }
 	goto st804;
 st804:
 	if ( ++p == pe )
 		goto _test_eof804;
 case 804:
-#line 17875 "inc/vcf/validator_detail_v43.hpp"
+#line 17871 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -18761,7 +18757,7 @@ case 804:
 	{
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -18783,7 +18779,7 @@ case 804:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -18805,7 +18801,7 @@ case 804:
 	case 19: 
 	case 20: 
 	case 21: 
-#line 237 "src/vcf/vcf_v43.ragel"
+#line 235 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
             new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
@@ -18839,7 +18835,7 @@ case 804:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -18858,7 +18854,7 @@ case 804:
 	case 446: 
 	case 447: 
 	case 448: 
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 254 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -18898,7 +18894,7 @@ case 804:
 	case 496: 
 	case 497: 
 	case 498: 
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 260 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -18933,7 +18929,7 @@ case 804:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -18980,7 +18976,7 @@ case 804:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19026,7 +19022,7 @@ case 804:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19071,7 +19067,7 @@ case 804:
 	case 403: 
 	case 404: 
 	case 405: 
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19093,7 +19089,7 @@ case 804:
 	case 507: 
 	case 508: 
 	case 509: 
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 325 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -19136,7 +19132,7 @@ case 804:
 	case 348: 
 	case 349: 
 	case 351: 
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19176,7 +19172,7 @@ case 804:
 	case 438: 
 	case 439: 
 	case 440: 
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 352 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -19224,7 +19220,7 @@ case 804:
 	case 565: 
 	case 566: 
 	case 567: 
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -19232,7 +19228,7 @@ case 804:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -19245,7 +19241,7 @@ case 804:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -19256,7 +19252,7 @@ case 804:
 	case 599: 
 	case 600: 
 	case 601: 
-#line 393 "src/vcf/vcf_v43.ragel"
+#line 391 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st799;}
@@ -19269,7 +19265,7 @@ case 804:
 	break;
 	case 579: 
 	case 580: 
-#line 399 "src/vcf/vcf_v43.ragel"
+#line 397 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st799;}
@@ -19282,7 +19278,7 @@ case 804:
 	break;
 	case 581: 
 	case 582: 
-#line 405 "src/vcf/vcf_v43.ragel"
+#line 403 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st799;}
@@ -19295,7 +19291,7 @@ case 804:
 	break;
 	case 583: 
 	case 584: 
-#line 411 "src/vcf/vcf_v43.ragel"
+#line 409 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st799;}
@@ -19343,7 +19339,7 @@ case 804:
 	case 793: 
 	case 794: 
 	case 795: 
-#line 417 "src/vcf/vcf_v43.ragel"
+#line 415 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st799;}
@@ -19367,7 +19363,7 @@ case 804:
 	case 758: 
 	case 759: 
 	case 760: 
-#line 423 "src/vcf/vcf_v43.ragel"
+#line 421 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st799;}
@@ -19383,7 +19379,7 @@ case 804:
 	case 592: 
 	case 749: 
 	case 750: 
-#line 429 "src/vcf/vcf_v43.ragel"
+#line 427 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st799;}
@@ -19395,7 +19391,7 @@ case 804:
     }
 	break;
 	case 594: 
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -19408,7 +19404,7 @@ case 804:
 	break;
 	case 595: 
 	case 596: 
-#line 619 "src/vcf/vcf_v43.ragel"
+#line 617 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st799;}
@@ -19421,7 +19417,7 @@ case 804:
 	break;
 	case 598: 
 	case 603: 
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 623 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -19441,7 +19437,7 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -19449,7 +19445,7 @@ case 804:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -19462,7 +19458,7 @@ case 804:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -19472,13 +19468,13 @@ case 804:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 249 "src/vcf/vcf_v43.ragel"
+#line 247 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -19490,12 +19486,12 @@ case 804:
     }
 	break;
 	case 122: 
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19509,12 +19505,12 @@ case 804:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 279 "src/vcf/vcf_v43.ragel"
+#line 277 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19528,12 +19524,12 @@ case 804:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 295 "src/vcf/vcf_v43.ragel"
+#line 293 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19546,12 +19542,12 @@ case 804:
 	break;
 	case 199: 
 	case 200: 
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 298 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19564,12 +19560,12 @@ case 804:
 	break;
 	case 265: 
 	case 266: 
-#line 300 "src/vcf/vcf_v43.ragel"
+#line 298 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19583,12 +19579,12 @@ case 804:
 	case 406: 
 	case 407: 
 	case 408: 
-#line 311 "src/vcf/vcf_v43.ragel"
+#line 309 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19605,12 +19601,12 @@ case 804:
 	case 384: 
 	case 385: 
 	case 386: 
-#line 316 "src/vcf/vcf_v43.ragel"
+#line 314 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19632,12 +19628,12 @@ case 804:
 	case 395: 
 	case 396: 
 	case 397: 
-#line 321 "src/vcf/vcf_v43.ragel"
+#line 319 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19650,12 +19646,12 @@ case 804:
 	break;
 	case 324: 
 	case 325: 
-#line 338 "src/vcf/vcf_v43.ragel"
+#line 336 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19673,12 +19669,12 @@ case 804:
 	case 335: 
 	case 336: 
 	case 337: 
-#line 343 "src/vcf/vcf_v43.ragel"
+#line 341 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19691,12 +19687,12 @@ case 804:
 	break;
 	case 347: 
 	case 350: 
-#line 348 "src/vcf/vcf_v43.ragel"
+#line 346 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19710,12 +19706,12 @@ case 804:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -19728,12 +19724,12 @@ case 804:
 	break;
 	case 478: 
 	case 479: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 260 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
@@ -19750,12 +19746,12 @@ case 804:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -19772,12 +19768,12 @@ case 804:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19794,12 +19790,12 @@ case 804:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -19813,12 +19809,12 @@ case 804:
 	case 364: 
 	case 365: 
 	case 366: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
@@ -19832,12 +19828,12 @@ case 804:
 	case 314: 
 	case 315: 
 	case 316: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
@@ -19851,12 +19847,12 @@ case 804:
 	case 419: 
 	case 420: 
 	case 421: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 352 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
@@ -19881,12 +19877,12 @@ case 804:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -19911,12 +19907,12 @@ case 804:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -19941,12 +19937,12 @@ case 804:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -19971,12 +19967,12 @@ case 804:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -20006,12 +20002,12 @@ case 804:
 	case 465: 
 	case 466: 
 	case 467: 
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 368 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 254 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
@@ -20043,12 +20039,12 @@ case 804:
 	case 528: 
 	case 529: 
 	case 530: 
-#line 370 "src/vcf/vcf_v43.ragel"
+#line 368 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 325 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -20107,12 +20103,12 @@ case 804:
 	case 743: 
 	case 744: 
 	case 745: 
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20125,12 +20121,12 @@ case 804:
 	break;
 	case 613: 
 	case 614: 
-#line 445 "src/vcf/vcf_v43.ragel"
+#line 443 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20143,7 +20139,7 @@ case 804:
 	break;
 	case 620: 
 	case 621: 
-#line 450 "src/vcf/vcf_v43.ragel"
+#line 448 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20151,7 +20147,7 @@ case 804:
                 "AA"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20164,7 +20160,7 @@ case 804:
 	break;
 	case 623: 
 	case 624: 
-#line 458 "src/vcf/vcf_v43.ragel"
+#line 456 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20172,7 +20168,7 @@ case 804:
                 "AC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20185,7 +20181,7 @@ case 804:
 	break;
 	case 626: 
 	case 627: 
-#line 466 "src/vcf/vcf_v43.ragel"
+#line 464 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20193,7 +20189,7 @@ case 804:
                 "AD"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20206,7 +20202,7 @@ case 804:
 	break;
 	case 629: 
 	case 630: 
-#line 474 "src/vcf/vcf_v43.ragel"
+#line 472 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20214,7 +20210,7 @@ case 804:
                 "ADF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20227,7 +20223,7 @@ case 804:
 	break;
 	case 632: 
 	case 633: 
-#line 482 "src/vcf/vcf_v43.ragel"
+#line 480 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20235,7 +20231,7 @@ case 804:
                 "ADR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20259,7 +20255,7 @@ case 804:
 	case 645: 
 	case 646: 
 	case 647: 
-#line 490 "src/vcf/vcf_v43.ragel"
+#line 488 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20267,7 +20263,7 @@ case 804:
                 "AF"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20280,7 +20276,7 @@ case 804:
 	break;
 	case 649: 
 	case 650: 
-#line 498 "src/vcf/vcf_v43.ragel"
+#line 496 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20288,7 +20284,7 @@ case 804:
                 "AN"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20312,7 +20308,7 @@ case 804:
 	case 663: 
 	case 664: 
 	case 665: 
-#line 506 "src/vcf/vcf_v43.ragel"
+#line 504 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20320,7 +20316,7 @@ case 804:
                 "BQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20334,7 +20330,7 @@ case 804:
 	case 671: 
 	case 672: 
 	case 673: 
-#line 514 "src/vcf/vcf_v43.ragel"
+#line 512 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20342,7 +20338,7 @@ case 804:
                 "CIGAR"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20355,7 +20351,7 @@ case 804:
 	break;
 	case 676: 
 	case 677: 
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 520 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20363,7 +20359,7 @@ case 804:
                 "DB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20376,7 +20372,7 @@ case 804:
 	break;
 	case 679: 
 	case 680: 
-#line 530 "src/vcf/vcf_v43.ragel"
+#line 528 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20384,7 +20380,7 @@ case 804:
                 "DP"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20397,7 +20393,7 @@ case 804:
 	break;
 	case 684: 
 	case 685: 
-#line 538 "src/vcf/vcf_v43.ragel"
+#line 536 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20405,7 +20401,7 @@ case 804:
                 "END"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20418,7 +20414,7 @@ case 804:
 	break;
 	case 688: 
 	case 689: 
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 544 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20426,7 +20422,7 @@ case 804:
                 "H2"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20439,7 +20435,7 @@ case 804:
 	break;
 	case 691: 
 	case 692: 
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 552 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20447,7 +20443,7 @@ case 804:
                 "H3"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20471,7 +20467,7 @@ case 804:
 	case 708: 
 	case 709: 
 	case 710: 
-#line 562 "src/vcf/vcf_v43.ragel"
+#line 560 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20479,7 +20475,7 @@ case 804:
                 "MQ"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20492,7 +20488,7 @@ case 804:
 	break;
 	case 696: 
 	case 697: 
-#line 570 "src/vcf/vcf_v43.ragel"
+#line 568 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20500,7 +20496,7 @@ case 804:
                 "MQ0"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20513,7 +20509,7 @@ case 804:
 	break;
 	case 713: 
 	case 714: 
-#line 578 "src/vcf/vcf_v43.ragel"
+#line 576 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20521,7 +20517,7 @@ case 804:
                 "NS"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20545,7 +20541,7 @@ case 804:
 	case 727: 
 	case 728: 
 	case 729: 
-#line 586 "src/vcf/vcf_v43.ragel"
+#line 584 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20553,7 +20549,7 @@ case 804:
                 "SB"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20566,7 +20562,7 @@ case 804:
 	break;
 	case 736: 
 	case 737: 
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 592 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20574,7 +20570,7 @@ case 804:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20587,7 +20583,7 @@ case 804:
 	break;
 	case 747: 
 	case 748: 
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 600 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20595,7 +20591,7 @@ case 804:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20608,7 +20604,7 @@ case 804:
 	break;
 	case 616: 
 	case 617: 
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 608 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20616,7 +20612,7 @@ case 804:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20631,14 +20627,14 @@ case 804:
 	case 604: 
 	case 605: 
 	case 606: 
-#line 632 "src/vcf/vcf_v43.ragel"
+#line 630 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st799;}
     }
-#line 625 "src/vcf/vcf_v43.ragel"
+#line 623 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -20662,7 +20658,7 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st798;}
     }
-#line 376 "src/vcf/vcf_v43.ragel"
+#line 374 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -20670,7 +20666,7 @@ case 804:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -20683,7 +20679,7 @@ case 804:
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -20693,17 +20689,17 @@ case 804:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -20717,17 +20713,17 @@ case 804:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -20741,17 +20737,17 @@ case 804:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -20765,17 +20761,17 @@ case 804:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -20789,17 +20785,17 @@ case 804:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
@@ -20813,17 +20809,17 @@ case 804:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
@@ -20837,17 +20833,17 @@ case 804:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
@@ -20861,17 +20857,17 @@ case 804:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 365 "src/vcf/vcf_v43.ragel"
+#line 363 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st798;}
     }
-#line 360 "src/vcf/vcf_v43.ragel"
+#line 358 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
@@ -20883,7 +20879,7 @@ case 804:
     }
 	break;
 	case 675: 
-#line 522 "src/vcf/vcf_v43.ragel"
+#line 520 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20891,12 +20887,12 @@ case 804:
                 "DB"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20908,7 +20904,7 @@ case 804:
     }
 	break;
 	case 687: 
-#line 546 "src/vcf/vcf_v43.ragel"
+#line 544 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20916,12 +20912,12 @@ case 804:
                 "H2"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20933,7 +20929,7 @@ case 804:
     }
 	break;
 	case 690: 
-#line 554 "src/vcf/vcf_v43.ragel"
+#line 552 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20941,12 +20937,12 @@ case 804:
                 "H3"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20958,7 +20954,7 @@ case 804:
     }
 	break;
 	case 735: 
-#line 594 "src/vcf/vcf_v43.ragel"
+#line 592 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20966,12 +20962,12 @@ case 804:
                 "SOMATIC"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -20983,7 +20979,7 @@ case 804:
     }
 	break;
 	case 746: 
-#line 602 "src/vcf/vcf_v43.ragel"
+#line 600 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20991,12 +20987,12 @@ case 804:
                 "VALIDATED"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -21008,7 +21004,7 @@ case 804:
     }
 	break;
 	case 615: 
-#line 610 "src/vcf/vcf_v43.ragel"
+#line 608 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -21016,12 +21012,12 @@ case 804:
                 "1000G"});
         p--; {goto st799;}
     }
-#line 440 "src/vcf/vcf_v43.ragel"
+#line 438 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st799;}
     }
-#line 435 "src/vcf/vcf_v43.ragel"
+#line 433 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st799;}
@@ -21033,52 +21029,52 @@ case 804:
     }
 	break;
 	case 24: 
-#line 244 "src/vcf/vcf_v43.ragel"
+#line 242 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st798;}
     }
-#line 268 "src/vcf/vcf_v43.ragel"
+#line 266 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st798;}
     }
-#line 274 "src/vcf/vcf_v43.ragel"
+#line 272 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st798;}
     }
-#line 290 "src/vcf/vcf_v43.ragel"
+#line 288 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st798;}
     }
-#line 256 "src/vcf/vcf_v43.ragel"
+#line 254 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st798;}
     }
-#line 262 "src/vcf/vcf_v43.ragel"
+#line 260 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st798;}
     }
-#line 333 "src/vcf/vcf_v43.ragel"
+#line 331 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st798;}
     }
-#line 354 "src/vcf/vcf_v43.ragel"
+#line 352 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st798;}
     }
-#line 306 "src/vcf/vcf_v43.ragel"
+#line 304 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st798;}
     }
-#line 327 "src/vcf/vcf_v43.ragel"
+#line 325 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st798;}
@@ -21089,14 +21085,14 @@ case 804:
         p--; {goto st798;}
     }
 	break;
-#line 21093 "inc/vcf/validator_detail_v43.hpp"
+#line 21089 "inc/vcf/validator_detail_v43.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 937 "src/vcf/vcf_v43.ragel"
+#line 935 "src/vcf/vcf_v43.ragel"
 
     }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ namespace
             ("input,i", po::value<std::string>()->default_value("stdin"), "Path to the input VCF file, or stdin")
             ("level,l", po::value<std::string>()->default_value("warning"), "Validation level (error, warning, stop)")
             ("version,v", po::value<std::string>(), "VCF fileformat version to validate the file against (v4.1, v4.2, v4.3)")
-            ("report,r", po::value<std::string>()->default_value("stdout"), "Comma separated values for types of reports (database, stdout, complete)")
+            ("report,r", po::value<std::string>()->default_value("stdout"), "Comma separated values for types of reports (database, stdout)")
             ("outdir,o", po::value<std::string>()->default_value(""), "Directory for the output")
             ("ploidy,p", po::value<long>()->default_value(2), "Genome ploidy to expect through most or the whole VCF file (can be overwritten with --special-ploidy)")
             ("special-ploidy,s", po::value<std::string>(), "Ploidy expected in specific chromosomes/contigs, e.g Y=1,MyTriploidContig=3")
@@ -197,9 +197,7 @@ namespace
                 }
                 outputs.emplace_back(new ebi::vcf::OdbReportRW(db_filename));
             } else if (out == "stdout") {
-                outputs.emplace_back(new ebi::vcf::SummaryReportWriter());
-            } else if (out == "complete") {
-                outputs.emplace_back(new ebi::vcf::StdoutReportWriter());
+                outputs.emplace_back(new ebi::vcf::SummaryReportWriter(std::cout));
             } else {
                 throw std::invalid_argument{"Please use only valid report types"};
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ namespace
             ("input,i", po::value<std::string>()->default_value("stdin"), "Path to the input VCF file, or stdin")
             ("level,l", po::value<std::string>()->default_value("warning"), "Validation level (error, warning, stop)")
             ("version,v", po::value<std::string>(), "VCF fileformat version to validate the file against (v4.1, v4.2, v4.3)")
-            ("report,r", po::value<std::string>()->default_value("stdout"), "Comma separated values for types of reports (database, stdout, summary)")
+            ("report,r", po::value<std::string>()->default_value("stdout"), "Comma separated values for types of reports (database, stdout, complete)")
             ("outdir,o", po::value<std::string>()->default_value(""), "Directory for the output")
             ("ploidy,p", po::value<long>()->default_value(2), "Genome ploidy to expect through most or the whole VCF file (can be overwritten with --special-ploidy)")
             ("special-ploidy,s", po::value<std::string>(), "Ploidy expected in specific chromosomes/contigs, e.g Y=1,MyTriploidContig=3")
@@ -197,9 +197,9 @@ namespace
                 }
                 outputs.emplace_back(new ebi::vcf::OdbReportRW(db_filename));
             } else if (out == "stdout") {
-                outputs.emplace_back(new ebi::vcf::StdoutReportWriter());
-            } else if (out == "summary") {
                 outputs.emplace_back(new ebi::vcf::SummaryReportWriter());
+            } else if (out == "complete") {
+                outputs.emplace_back(new ebi::vcf::StdoutReportWriter());
             } else {
                 throw std::invalid_argument{"Please use only valid report types"};
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include "vcf/report_writer.hpp"
 #include "vcf/sqlite_report.hpp"
 #include "vcf/odb_report.hpp"
+#include "vcf/summary_report_writer.hpp"
 
 namespace
 {
@@ -46,7 +47,7 @@ namespace
             ("input,i", po::value<std::string>()->default_value("stdin"), "Path to the input VCF file, or stdin")
             ("level,l", po::value<std::string>()->default_value("warning"), "Validation level (error, warning, stop)")
             ("version,v", po::value<std::string>(), "VCF fileformat version to validate the file against (v4.1, v4.2, v4.3)")
-            ("report,r", po::value<std::string>()->default_value("stdout"), "Comma separated values for types of reports (database, stdout)")
+            ("report,r", po::value<std::string>()->default_value("stdout"), "Comma separated values for types of reports (database, stdout, summary)")
             ("outdir,o", po::value<std::string>()->default_value(""), "Directory for the output")
             ("ploidy,p", po::value<long>()->default_value(2), "Genome ploidy to expect through most or the whole VCF file (can be overwritten with --special-ploidy)")
             ("special-ploidy,s", po::value<std::string>(), "Ploidy expected in specific chromosomes/contigs, e.g Y=1,MyTriploidContig=3")
@@ -197,6 +198,8 @@ namespace
                 outputs.emplace_back(new ebi::vcf::OdbReportRW(db_filename));
             } else if (out == "stdout") {
                 outputs.emplace_back(new ebi::vcf::StdoutReportWriter());
+            } else if (out == "summary") {
+                outputs.emplace_back(new ebi::vcf::SummaryReportWriter());
             } else {
                 throw std::invalid_argument{"Please use only valid report types"};
             }

--- a/src/vcf/error-odb.cpp
+++ b/src/vcf/error-odb.cpp
@@ -3237,6 +3237,821 @@ namespace odb
     return st.execute ();
   }
 
+  // NoMetaDefinitionError
+  //
+
+  struct access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::extra_statement_cache_type
+  {
+    extra_statement_cache_type (
+      sqlite::connection&,
+      image_type&,
+      id_image_type&,
+      sqlite::binding&,
+      sqlite::binding&)
+    {
+    }
+  };
+
+  bool access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  grow (image_type& i,
+        bool* t,
+        std::size_t d)
+  {
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (t);
+
+    bool grew (false);
+
+    // Error base
+    //
+    if (--d != 0)
+    {
+      if (base_traits::grow (*i.base, t + 2UL))
+        i.base->version++;
+    }
+
+    // column
+    //
+    if (t[0UL])
+    {
+      i.column_value.capacity (i.column_size);
+      grew = true;
+    }
+
+    // field
+    //
+    if (t[1UL])
+    {
+      i.field_value.capacity (i.field_size);
+      grew = true;
+    }
+
+    return grew;
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  bind (sqlite::bind* b,
+        const sqlite::bind* id,
+        std::size_t id_size,
+        image_type& i,
+        sqlite::statement_kind sk)
+  {
+    ODB_POTENTIALLY_UNUSED (sk);
+
+    using namespace sqlite;
+
+    std::size_t n (0);
+
+    // id_
+    //
+    if (sk == statement_insert)
+    {
+      if (id != 0)
+        std::memcpy (&b[n], id, id_size * sizeof (id[0]));
+      n += id_size;
+    }
+
+    // column
+    //
+    b[n].type = sqlite::image_traits<
+      ::std::string,
+      sqlite::id_text>::bind_value;
+    b[n].buffer = i.column_value.data ();
+    b[n].size = &i.column_size;
+    b[n].capacity = i.column_value.capacity ();
+    b[n].is_null = &i.column_null;
+    n++;
+
+    // field
+    //
+    b[n].type = sqlite::image_traits<
+      ::std::string,
+      sqlite::id_text>::bind_value;
+    b[n].buffer = i.field_value.data ();
+    b[n].size = &i.field_size;
+    b[n].capacity = i.field_value.capacity ();
+    b[n].is_null = &i.field_null;
+    n++;
+
+    // id_
+    //
+    if (sk == statement_update)
+    {
+      if (id != 0)
+        std::memcpy (&b[n], id, id_size * sizeof (id[0]));
+      n += id_size;
+    }
+
+    // Error base
+    //
+    if (sk == statement_select)
+      base_traits::bind (b + n, *i.base, sk);
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  init (image_type& i,
+        const object_type& o,
+        sqlite::statement_kind sk)
+  {
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (o);
+    ODB_POTENTIALLY_UNUSED (sk);
+
+    using namespace sqlite;
+
+    bool grew (false);
+
+    // column
+    //
+    {
+      ::std::string const& v =
+        o.column;
+
+      bool is_null (false);
+      std::size_t cap (i.column_value.capacity ());
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_image (
+        i.column_value,
+        i.column_size,
+        is_null,
+        v);
+      i.column_null = is_null;
+      grew = grew || (cap != i.column_value.capacity ());
+    }
+
+    // field
+    //
+    {
+      ::std::string const& v =
+        o.field;
+
+      bool is_null (false);
+      std::size_t cap (i.field_value.capacity ());
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_image (
+        i.field_value,
+        i.field_size,
+        is_null,
+        v);
+      i.field_null = is_null;
+      grew = grew || (cap != i.field_value.capacity ());
+    }
+
+    return grew;
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  init (object_type& o,
+        const image_type& i,
+        database* db,
+        std::size_t d)
+  {
+    ODB_POTENTIALLY_UNUSED (o);
+    ODB_POTENTIALLY_UNUSED (i);
+    ODB_POTENTIALLY_UNUSED (db);
+
+    // Error base
+    //
+    if (--d != 0)
+      base_traits::init (o, *i.base, db);
+
+    // column
+    //
+    {
+      ::std::string& v =
+        o.column;
+
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_value (
+        v,
+        i.column_value,
+        i.column_size,
+        i.column_null);
+    }
+
+    // field
+    //
+    {
+      ::std::string& v =
+        o.field;
+
+      sqlite::value_traits<
+          ::std::string,
+          sqlite::id_text >::set_value (
+        v,
+        i.field_value,
+        i.field_size,
+        i.field_null);
+    }
+  }
+
+  const access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::info_type
+  access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::info (
+    typeid (::ebi::vcf::NoMetaDefinitionError),
+    &object_traits_impl< ::ebi::vcf::Error, id_sqlite >::info,
+    0,
+    "ebi::vcf::NoMetaDefinitionError",
+    &odb::create_impl< ::ebi::vcf::NoMetaDefinitionError >,
+    &odb::dispatch_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >,
+    &statements_type::delayed_loader);
+
+  static const access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::entry_type
+  polymorphic_entry_for_ebi_vcf_NoMetaDefinitionError;
+
+  const char access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::persist_statement[] =
+  "INSERT INTO \"NoMetaDefinitionError\" "
+  "(\"id\", "
+  "\"column\", "
+  "\"field\") "
+  "VALUES "
+  "(?, ?, ?)";
+
+  const char* const access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::find_statements[] =
+  {
+    "SELECT "
+    "\"NoMetaDefinitionError\".\"column\", "
+    "\"NoMetaDefinitionError\".\"field\", "
+    "\"Error\".\"line\", "
+    "\"Error\".\"message\", "
+    "\"Error\".\"severity\", "
+    "\"Error\".\"id\", "
+    "\"Error\".\"typeid\" "
+    "FROM \"NoMetaDefinitionError\" "
+    "LEFT JOIN \"Error\" ON \"Error\".\"id\"=\"NoMetaDefinitionError\".\"id\" "
+    "WHERE \"NoMetaDefinitionError\".\"id\"=?",
+
+    "SELECT "
+    "\"NoMetaDefinitionError\".\"column\", "
+    "\"NoMetaDefinitionError\".\"field\" "
+    "FROM \"NoMetaDefinitionError\" "
+    "WHERE \"NoMetaDefinitionError\".\"id\"=?"
+  };
+
+  const std::size_t access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::find_column_counts[] =
+  {
+    7UL,
+    2UL
+  };
+
+  const char access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::update_statement[] =
+  "UPDATE \"NoMetaDefinitionError\" "
+  "SET "
+  "\"column\"=?, "
+  "\"field\"=? "
+  "WHERE \"id\"=?";
+
+  const char access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::erase_statement[] =
+  "DELETE FROM \"NoMetaDefinitionError\" "
+  "WHERE \"id\"=?";
+
+  const char access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::query_statement[] =
+  "SELECT\n"
+  "\"NoMetaDefinitionError\".\"column\",\n"
+  "\"NoMetaDefinitionError\".\"field\",\n"
+  "\"Error\".\"line\",\n"
+  "\"Error\".\"message\",\n"
+  "\"Error\".\"severity\",\n"
+  "\"Error\".\"id\",\n"
+  "\"Error\".\"typeid\"\n"
+  "FROM \"NoMetaDefinitionError\"\n"
+  "LEFT JOIN \"Error\" ON \"Error\".\"id\"=\"NoMetaDefinitionError\".\"id\"";
+
+  const char access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::erase_query_statement[] =
+  "DELETE FROM \"NoMetaDefinitionError\"";
+
+  const char access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::table_name[] =
+  "\"NoMetaDefinitionError\"";
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  persist (database& db, object_type& obj, bool top, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    using namespace sqlite;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        pi.dispatch (info_type::call_persist, db, &obj, 0);
+        return;
+      }
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    if (top)
+      callback (db,
+                static_cast<const object_type&> (obj),
+                callback_event::pre_persist);
+
+    base_traits::persist (db, obj, false, false);
+
+    image_type& im (sts.image ());
+    binding& imb (sts.insert_image_binding ());
+    const binding& idb (sts.id_image_binding ());
+
+    if (init (im, obj, statement_insert))
+      im.version++;
+
+    if (idb.version != sts.insert_id_binding_version () ||
+        im.version != sts.insert_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, idb.bind, idb.count, im, statement_insert);
+      sts.insert_id_binding_version (idb.version);
+      sts.insert_image_version (im.version);
+      imb.version++;
+    }
+
+    insert_statement& st (sts.persist_statement ());
+    if (!st.execute ())
+      throw object_already_persistent ();
+
+    if (top)
+      callback (db,
+                static_cast<const object_type&> (obj),
+                callback_event::post_persist);
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  update (database& db, const object_type& obj, bool top, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    using namespace sqlite;
+    using sqlite::update_statement;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        pi.dispatch (info_type::call_update, db, &obj, 0);
+        return;
+      }
+    }
+
+    if (top)
+      callback (db, obj, callback_event::pre_update);
+
+    sqlite::transaction& tr (sqlite::transaction::current ());
+    sqlite::connection& conn (tr.connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    base_traits::update (db, obj, false, false);
+
+    image_type& im (sts.image ());
+    if (init (im, obj, statement_update))
+      im.version++;
+
+    const binding& idb (sts.id_image_binding ());
+    binding& imb (sts.update_image_binding ());
+    if (idb.version != sts.update_id_binding_version () ||
+        im.version != sts.update_image_version () ||
+        imb.version == 0)
+    {
+      bind (imb.bind, idb.bind, idb.count, im, statement_update);
+      sts.update_id_binding_version (idb.version);
+      sts.update_image_version (im.version);
+      imb.version++;
+    }
+
+    update_statement& st (sts.update_statement ());
+    if (st.execute () == 0)
+      throw object_not_persistent ();
+
+    if (top)
+    {
+      callback (db, obj, callback_event::post_update);
+      pointer_cache_traits::update (db, obj);
+    }
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  erase (database& db, const id_type& id, bool top, bool dyn)
+  {
+    using namespace sqlite;
+
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    if (dyn)
+    {
+      discriminator_type d;
+      root_traits::discriminator_ (sts.root_statements (), id, &d);
+
+      if (d != info.discriminator)
+      {
+        const info_type& pi (root_traits::map->find (d));
+
+        if (!pi.derived (info))
+          throw object_not_persistent ();
+
+        pi.dispatch (info_type::call_erase, db, 0, &id);
+        return;
+      }
+    }
+
+    if (top)
+    {
+      id_image_type& i (sts.id_image ());
+      init (i, id);
+
+      binding& idb (sts.id_image_binding ());
+      if (i.version != sts.id_image_version () || idb.version == 0)
+      {
+        bind (idb.bind, i);
+        sts.id_image_version (i.version);
+        idb.version++;
+      }
+    }
+
+    if (sts.erase_statement ().execute () != 1)
+      throw object_not_persistent ();
+
+    base_traits::erase (db, id, false, false);
+
+    if (top)
+      pointer_cache_traits::erase (db, id);
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  erase (database& db, const object_type& obj, bool top, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (db);
+    ODB_POTENTIALLY_UNUSED (top);
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        pi.dispatch (info_type::call_erase, db, &obj, 0);
+        return;
+      }
+    }
+
+    callback (db, obj, callback_event::pre_erase);
+    erase (db, id (obj), true, false);
+    callback (db, obj, callback_event::post_erase);
+  }
+
+  access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::pointer_type
+  access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  find (database& db, const id_type& id)
+  {
+    using namespace sqlite;
+
+    {
+      root_traits::pointer_type rp (pointer_cache_traits::find (db, id));
+
+      if (!root_traits::pointer_traits::null_ptr (rp))
+        return
+          root_traits::pointer_traits::dynamic_pointer_cast<object_type> (rp);
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+    root_statements_type& rsts (sts.root_statements ());
+
+    statements_type::auto_lock l (rsts);
+    root_traits::discriminator_type d;
+
+    if (l.locked ())
+    {
+      if (!find_ (sts, &id))
+        return pointer_type ();
+      d = root_traits::discriminator (rsts.image ());
+    }
+    else
+      root_traits::discriminator_ (rsts, id, &d);
+
+    const info_type& pi (
+      d == info.discriminator ? info : root_traits::map->find (d));
+
+    root_traits::pointer_type rp (pi.create ());
+    pointer_type p (
+      root_traits::pointer_traits::static_pointer_cast<object_type> (rp));
+    pointer_traits::guard pg (p);
+
+    pointer_cache_traits::insert_guard ig (
+      pointer_cache_traits::insert (db, id, rp));
+
+    object_type& obj (pointer_traits::get_ref (p));
+
+    if (l.locked ())
+    {
+      select_statement& st (sts.find_statement (depth));
+      ODB_POTENTIALLY_UNUSED (st);
+
+      callback_event ce (callback_event::pre_load);
+      pi.dispatch (info_type::call_callback, db, &obj, &ce);
+      init (obj, sts.image (), &db);
+      load_ (sts, obj, false);
+
+      if (&pi != &info)
+      {
+        std::size_t d (depth);
+        pi.dispatch (info_type::call_load, db, &obj, &d);
+      }
+
+      rsts.load_delayed (0);
+      l.unlock ();
+      ce = callback_event::post_load;
+      pi.dispatch (info_type::call_callback, db, &obj, &ce);
+      pointer_cache_traits::load (ig.position ());
+    }
+    else
+      rsts.delay_load (id, obj, ig.position (), pi.delayed_loader);
+
+    ig.release ();
+    pg.release ();
+    return p;
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  find (database& db, const id_type& id, object_type& obj, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (dyn);
+
+    using namespace sqlite;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        return pi.dispatch (info_type::call_find, db, &obj, &id);
+      }
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+    root_statements_type& rsts (sts.root_statements ());
+
+    statements_type::auto_lock l (rsts);
+
+    if (!find_ (sts, &id))
+      return false;
+
+    select_statement& st (sts.find_statement (depth));
+    ODB_POTENTIALLY_UNUSED (st);
+
+    reference_cache_traits::position_type pos (
+      reference_cache_traits::insert (db, id, obj));
+    reference_cache_traits::insert_guard ig (pos);
+
+    callback (db, obj, callback_event::pre_load);
+    init (obj, sts.image (), &db);
+    load_ (sts, obj, false);
+    rsts.load_delayed (0);
+    l.unlock ();
+    callback (db, obj, callback_event::post_load);
+    reference_cache_traits::load (pos);
+    ig.release ();
+    return true;
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  reload (database& db, object_type& obj, bool dyn)
+  {
+    ODB_POTENTIALLY_UNUSED (dyn);
+
+    using namespace sqlite;
+
+    if (dyn)
+    {
+      const std::type_info& t (typeid (obj));
+
+      if (t != info.type)
+      {
+        const info_type& pi (root_traits::map->find (t));
+        return pi.dispatch (info_type::call_reload, db, &obj, 0);
+      }
+    }
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+    root_statements_type& rsts (sts.root_statements ());
+
+    statements_type::auto_lock l (rsts);
+
+    const id_type& id  (
+      obj.id_);
+
+    if (!find_ (sts, &id))
+      return false;
+
+    select_statement& st (sts.find_statement (depth));
+    ODB_POTENTIALLY_UNUSED (st);
+
+    callback (db, obj, callback_event::pre_load);
+    init (obj, sts.image (), &db);
+    load_ (sts, obj, true);
+    rsts.load_delayed (0);
+    l.unlock ();
+    callback (db, obj, callback_event::post_load);
+    return true;
+  }
+
+  bool access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  find_ (statements_type& sts,
+         const id_type* id,
+         std::size_t d)
+  {
+    using namespace sqlite;
+
+    if (d == depth)
+    {
+      id_image_type& i (sts.id_image ());
+      init (i, *id);
+
+      binding& idb (sts.id_image_binding ());
+      if (i.version != sts.id_image_version () || idb.version == 0)
+      {
+        bind (idb.bind, i);
+        sts.id_image_version (i.version);
+        idb.version++;
+      }
+    }
+
+    image_type& im (sts.image ());
+    binding& imb (sts.select_image_binding (d));
+
+    if (imb.version == 0 ||
+        check_version (sts.select_image_versions (), im))
+    {
+      bind (imb.bind, 0, 0, im, statement_select);
+      update_version (sts.select_image_versions (),
+                      im,
+                      sts.select_image_bindings ());
+    }
+
+    select_statement& st (sts.find_statement (d));
+
+    st.execute ();
+    auto_result ar (st);
+    select_statement::result r (st.fetch ());
+
+    if (r == select_statement::truncated)
+    {
+      if (grow (im, sts.select_image_truncated (), d))
+        im.version++;
+
+      if (check_version (sts.select_image_versions (), im))
+      {
+        bind (imb.bind, 0, 0, im, statement_select);
+        update_version (sts.select_image_versions (),
+                        im,
+                        sts.select_image_bindings ());
+        st.refetch ();
+      }
+    }
+
+    return r != select_statement::no_data;
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  load_ (statements_type& sts,
+         object_type& obj,
+         bool reload,
+         std::size_t d)
+  {
+    ODB_POTENTIALLY_UNUSED (reload);
+
+    if (--d != 0)
+      base_traits::load_ (sts.base_statements (), obj, reload);
+  }
+
+  void access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  load_ (database& db, root_type& r, std::size_t d)
+  {
+    using namespace sqlite;
+
+    object_type& obj (static_cast<object_type&> (r));
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    d = depth - d;
+
+    if (!find_ (sts, 0, d))
+      throw object_not_persistent ();
+
+    select_statement& st (sts.find_statement (d));
+    ODB_POTENTIALLY_UNUSED (st);
+
+    init (obj, sts.image (), &db, d);
+    load_ (sts, obj, false, d);
+  }
+
+  result< access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::object_type >
+  access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  query (database&, const query_base_type& q)
+  {
+    using namespace sqlite;
+    using odb::details::shared;
+    using odb::details::shared_ptr;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+
+    statements_type& sts (
+      conn.statement_cache ().find_object<object_type> ());
+
+    image_type& im (sts.image ());
+    binding& imb (sts.select_image_binding (depth));
+
+    if (imb.version == 0 ||
+        check_version (sts.select_image_versions (), im))
+    {
+      bind (imb.bind, 0, 0, im, statement_select);
+      update_version (sts.select_image_versions (),
+                      im,
+                      sts.select_image_bindings ());
+    }
+
+    std::string text (query_statement);
+    if (!q.empty ())
+    {
+      text += "\n";
+      text += q.clause ();
+    }
+
+    q.init_parameters ();
+    shared_ptr<select_statement> st (
+      new (shared) select_statement (
+        conn,
+        text,
+        true,
+        true,
+        q.parameters_binding (),
+        imb));
+
+    st->execute ();
+
+    shared_ptr< odb::polymorphic_object_result_impl<object_type> > r (
+      new (shared) sqlite::polymorphic_object_result_impl<object_type> (
+        q, st, sts, 0));
+
+    return result<object_type> (r);
+  }
+
+  unsigned long long access::object_traits_impl< ::ebi::vcf::NoMetaDefinitionError, id_sqlite >::
+  erase_query (database&, const query_base_type& q)
+  {
+    using namespace sqlite;
+
+    sqlite::connection& conn (
+      sqlite::transaction::current ().connection ());
+
+    std::string text (erase_query_statement);
+    if (!q.empty ())
+    {
+      text += ' ';
+      text += q.clause ();
+    }
+
+    q.init_parameters ();
+    delete_statement st (
+      conn,
+      text,
+      q.parameters_binding ());
+
+    return st.execute ();
+  }
+
   // FileformatError
   //
 
@@ -12946,6 +13761,7 @@ namespace odb
           db.execute ("DROP TABLE IF EXISTS \"PositionBodyError\"");
           db.execute ("DROP TABLE IF EXISTS \"ChromosomeBodyError\"");
           db.execute ("DROP TABLE IF EXISTS \"FileformatError\"");
+          db.execute ("DROP TABLE IF EXISTS \"NoMetaDefinitionError\"");
           db.execute ("DROP TABLE IF EXISTS \"BodySectionError\"");
           db.execute ("DROP TABLE IF EXISTS \"HeaderSectionError\"");
           db.execute ("DROP TABLE IF EXISTS \"MetaSectionError\"");
@@ -12980,6 +13796,14 @@ namespace odb
                       "    ON DELETE CASCADE)");
           db.execute ("CREATE TABLE \"BodySectionError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
+                      "  CONSTRAINT \"id_fk\"\n"
+                      "    FOREIGN KEY (\"id\")\n"
+                      "    REFERENCES \"Error\" (\"id\")\n"
+                      "    ON DELETE CASCADE)");
+          db.execute ("CREATE TABLE \"NoMetaDefinitionError\" (\n"
+                      "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
+                      "  \"column\" TEXT NOT NULL,\n"
+                      "  \"field\" TEXT NOT NULL,\n"
                       "  CONSTRAINT \"id_fk\"\n"
                       "    FOREIGN KEY (\"id\")\n"
                       "    REFERENCES \"Error\" (\"id\")\n"

--- a/src/vcf/error.cpp
+++ b/src/vcf/error.cpp
@@ -33,6 +33,8 @@ namespace ebi
             return std::shared_ptr<Error>(new HeaderSectionError{line, message});
         case ErrorCode::body_section:
             return std::shared_ptr<Error>(new BodySectionError{line, message});
+        case ErrorCode::no_meta_definition:
+            return std::shared_ptr<Error>(new NoMetaDefinitionError{line, message, "", ""});
         case ErrorCode::fileformat:
             return std::shared_ptr<Error>(new FormatBodyError{line, message});
         case ErrorCode::chromosome_body:

--- a/src/vcf/parsing_state.cpp
+++ b/src/vcf/parsing_state.cpp
@@ -25,7 +25,7 @@ namespace ebi
     : n_lines{1}, n_columns{1}, n_batches{0}, cs{0}, m_is_valid{true}, 
       source{source}, record{},
       errors{}, warnings{},
-      undefined_metadata{}
+      defined_metadata{}
     {
     }
 
@@ -86,23 +86,6 @@ namespace ebi
     void ParsingState::add_well_defined_meta(std::string const & meta_type, std::string const & id)
     {
         defined_metadata.emplace(meta_type, id);
-    }
-    
-    bool ParsingState::is_bad_defined_meta(std::string const & meta_type, std::string const & id) const
-    {
-        typedef std::multimap<std::string,std::string>::const_iterator iter;
-        std::pair<iter, iter> range = undefined_metadata.equal_range(meta_type);
-        for (auto & current = range.first; current != range.second; ++current) {
-            if (current->second == id) {
-                return true;
-            }
-        }
-        return false;
-    }
-    
-    void ParsingState::add_bad_defined_meta(std::string const & meta_type, std::string const & id)
-    {
-        undefined_metadata.emplace(meta_type, id);
     }
   }
 }

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -148,8 +148,12 @@ namespace ebi
         if (is_record_subfield_in_header(current_chromosome, range.first, range.second)) {
             state.add_well_defined_meta("contig", current_chromosome);
         } else {
-            throw new ChromosomeBodyError{state.n_lines,
-                    "Chromosome/contig '" + current_chromosome + "' is not described in a 'contig' meta description"};
+            throw new NoMetaDefinitionError{
+                    state.n_lines,
+                    "Chromosome/contig '" + current_chromosome + "' is not described in a 'contig' meta description",
+                    "CHROM",
+                    current_chromosome
+            };
         }
     }
     
@@ -171,8 +175,12 @@ namespace ebi
                 if (is_record_subfield_in_header(alt_id, range.first, range.second)) {
                     state.add_well_defined_meta("ALT", alt_id);
                 } else {
-                    throw new AlternateAllelesBodyError{state.n_lines,
-                            "Alternate '<" + alt_id + ">' is not listed in a valid meta-data ALT entry"};
+                    throw new NoMetaDefinitionError{
+                            state.n_lines,
+                            "Alternate '<" + alt_id + ">' is not listed in a valid meta-data ALT entry",
+                            "ALT",
+                            alt_id
+                    };
                 }
             }
         }
@@ -192,8 +200,12 @@ namespace ebi
             if (is_record_subfield_in_header(filter, range.first, range.second)) {
                 state.add_well_defined_meta("FILTER", filter);
             } else {
-                throw new FilterBodyError{state.n_lines,
-                        "Filter '" + filter + "' is not listed in a valid meta-data FILTER entry"};
+                throw new NoMetaDefinitionError{
+                        state.n_lines,
+                        "Filter '" + filter + "' is not listed in a valid meta-data FILTER entry",
+                        "FILTER",
+                        filter
+                };
             }
         }
     }
@@ -213,9 +225,12 @@ namespace ebi
             if (is_record_subfield_in_header(id, range.first, range.second)) {
                 state.add_well_defined_meta("INFO", id);
             } else {
-                throw new InfoBodyError{state.n_lines,
-                                        "Info '" + id + "' is not listed in a valid meta-data INFO entry",
-                                        id};
+                throw new NoMetaDefinitionError{
+                        state.n_lines,
+                        "Info '" + id + "' is not listed in a valid meta-data INFO entry",
+                        "INFO",
+                        id
+                };
             }
         }
     }
@@ -232,8 +247,12 @@ namespace ebi
             if (is_record_subfield_in_header(fm, range.first, range.second)) {
                 state.add_well_defined_meta("FORMAT", fm);
             } else {
-                throw new FormatBodyError{state.n_lines,
-                        "Format '" + fm + "' is not listed in a valid meta-data FORMAT entry"};
+                throw new NoMetaDefinitionError{
+                        state.n_lines,
+                        "Format '" + fm + "' is not listed in a valid meta-data FORMAT entry",
+                        "FORMAT",
+                        fm
+                };
             }
         }
     }

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -139,9 +139,8 @@ namespace ebi
         // The associated 'contig' meta entry should exist (notify only once)
         std::string current_chromosome = record.chromosome;
 
-        if (state.is_bad_defined_meta("contig", current_chromosome) ||
-            state.is_well_defined_meta("contig", current_chromosome)) {
-            return; // Notify only once
+        if (state.is_well_defined_meta("contig", current_chromosome)) {
+            return; // Check only once
         }
         
         std::pair<meta_iterator, meta_iterator> range = state.source->meta_entries.equal_range("contig");
@@ -149,7 +148,6 @@ namespace ebi
         if (is_record_subfield_in_header(current_chromosome, range.first, range.second)) {
             state.add_well_defined_meta("contig", current_chromosome);
         } else {
-            state.add_bad_defined_meta("contig", current_chromosome);
             throw new ChromosomeBodyError{state.n_lines,
                     "Chromosome/contig '" + current_chromosome + "' is not described in a 'contig' meta description"};
         }
@@ -166,15 +164,13 @@ namespace ebi
             if (alternate[0] == '<' && boost::regex_match(alternate.c_str(), pieces_match, square_brackets_regex)) {
                 std::string alt_id = pieces_match[1];
                 
-                if (state.is_bad_defined_meta("ALT", alt_id) ||
-                    state.is_well_defined_meta("ALT", alt_id)) {
-                    continue; // Notify only once
+                if (state.is_well_defined_meta("ALT", alt_id)) {
+                    continue; // Check only once
                 }
                 
                 if (is_record_subfield_in_header(alt_id, range.first, range.second)) {
                     state.add_well_defined_meta("ALT", alt_id);
                 } else {
-                    state.add_bad_defined_meta("ALT", alt_id);
                     throw new AlternateAllelesBodyError{state.n_lines,
                             "Alternate '<" + alt_id + ">' is not listed in a valid meta-data ALT entry"};
                 }
@@ -189,15 +185,13 @@ namespace ebi
         for (auto & filter : record.filters) {
             if (filter == "PASS" || filter == ".") { continue; } // No need to check PASS or missing data
             
-            if (state.is_bad_defined_meta("FILTER", filter) ||
-                state.is_well_defined_meta("FILTER", filter)) {
-                continue; // Notify only once
+            if (state.is_well_defined_meta("FILTER", filter)) {
+                continue; // Check only once
             }
             
             if (is_record_subfield_in_header(filter, range.first, range.second)) {
                 state.add_well_defined_meta("FILTER", filter);
             } else {
-                state.add_bad_defined_meta("FILTER", filter);
                 throw new FilterBodyError{state.n_lines,
                         "Filter '" + filter + "' is not listed in a valid meta-data FILTER entry"};
             }
@@ -212,15 +206,13 @@ namespace ebi
             auto & id = field.first;
             if (field.first == ".") { continue; } // No need to check missing data
             
-            if (state.is_bad_defined_meta("INFO", id) ||
-                state.is_well_defined_meta("INFO", id)) {
-                continue; // Notify only once
+            if (state.is_well_defined_meta("INFO", id)) {
+                continue; // Check only once
             }
             
             if (is_record_subfield_in_header(id, range.first, range.second)) {
                 state.add_well_defined_meta("INFO", id);
             } else {
-                state.add_bad_defined_meta("INFO", id);
                 throw new InfoBodyError{state.n_lines,
                                         "Info '" + id + "' is not listed in a valid meta-data INFO entry",
                                         id};
@@ -233,15 +225,13 @@ namespace ebi
         std::pair<meta_iterator, meta_iterator> range = state.source->meta_entries.equal_range("FORMAT");
         
         for (auto & fm : record.format) {
-            if (state.is_bad_defined_meta("FORMAT", fm) ||
-                state.is_well_defined_meta("FORMAT", fm)) {
-                continue; // Notify only once
+            if (state.is_well_defined_meta("FORMAT", fm)) {
+                continue; // Check only once
             }
             
             if (is_record_subfield_in_header(fm, range.first, range.second)) {
                 state.add_well_defined_meta("FORMAT", fm);
             } else {
-                state.add_bad_defined_meta("FORMAT", fm);
                 throw new FormatBodyError{state.n_lines,
                         "Format '" + fm + "' is not listed in a valid meta-data FORMAT entry"};
             }

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -70,7 +70,7 @@
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -81,7 +81,7 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -99,7 +99,7 @@
     action fileformat_end {
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           fhold; fgoto meta_section_skip;
         }
@@ -176,7 +176,7 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -208,12 +208,10 @@
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -342,7 +340,7 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -70,7 +70,7 @@
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -81,7 +81,7 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -99,7 +99,7 @@
     action fileformat_end {
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           fhold; fgoto meta_section_skip;
         }
@@ -176,7 +176,7 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -208,12 +208,10 @@
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -342,7 +340,7 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -70,7 +70,7 @@
     action meta_section_end {
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
     }
@@ -81,7 +81,7 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         
@@ -99,7 +99,7 @@
     action fileformat_end {
         try {
           ParsePolicy::handle_fileformat(*this);
-        } catch (FileformatError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
           fhold; fgoto meta_section_skip;
         }
@@ -188,7 +188,7 @@
     action meta_entry_end {
         try {
           ParsePolicy::handle_meta_line(*this);
-        } catch (MetaSectionError *error) {
+        } catch (Error *error) {
           ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -220,12 +220,10 @@
             try {
                 // Check warnings (non-blocking errors but potential mistakes anyway, only makes sense if the last record parsed was correct)
                 OptionalPolicy::optional_check_body_entry(*this, *record);
-            } catch (MetaSectionError *warn) {
-                ErrorPolicy::handle_warning(*this, warn);
-            } catch (BodySectionError *warn) {
+            } catch (Error *warn) {
                 ErrorPolicy::handle_warning(*this, warn);
             }
-        } catch (BodySectionError *error) {
+        } catch (Error *error) {
             ErrorPolicy::handle_error(*this, error);
         }
     }
@@ -380,7 +378,7 @@
         // If an error occurs in the header, meta_section_end won't be triggered and the meta and header optional validations must be run here
         try {
           OptionalPolicy::optional_check_meta_section(*this);
-        } catch (MetaSectionError *warn) {
+        } catch (Error *warn) {
           ErrorPolicy::handle_warning(*this, warn);
         }
         


### PR DESCRIPTION
Allow filtering superfluous warnings when writing to standard output.

The checks are always done and always raised, but only reported in non-summary reports.
The previous behaviour was that if the error was already raised, it was not raised for any report type.