### PR TITLE
fix bug: string split on empty strings

### DIFF
--- a/inc/util/string_utils.hpp
+++ b/inc/util/string_utils.hpp
@@ -25,23 +25,33 @@ namespace ebi
 {
   namespace util
   {
+    /**
+     * Splits `s` using `delims` as separator and fills the container `ret` with the parts.
+     * An empty string results in an empty container `ret`.
+     * @param s input string to split
+     * @param delims any character here acts as a separator
+     * @param ret return by reference the container filled with the string split.
+     */
     template<typename C>
     void string_split(std::string const & s, char const * delims, C & ret)
     {
         C output;
-        char const* p = s.c_str();
-        char const* q = strpbrk(p+1, delims);
 
-        // Insert first to last-1 elements
-        for( ; q != NULL; q = strpbrk(p, delims) )
-        {
-            output.push_back(typename C::value_type(p, q));
-            p = q + 1;
-        }
+        if (s.size() > 0) {
+            char const* p = s.c_str();
+            char const* q = strpbrk(p+1, delims);
 
-        // Insert last element
-        if (p < &(s.back()) + 1) {
-            output.push_back(typename C::value_type(p));
+            // Insert first to last-1 elements
+            for( ; q != NULL; q = strpbrk(p, delims) )
+            {
+                output.push_back(typename C::value_type(p, q));
+                p = q + 1;
+            }
+
+            // Insert last element
+            if (p < &(s.back()) + 1) {
+                output.push_back(typename C::value_type(p));
+            }
         }
 
         output.swap(ret);


### PR DESCRIPTION
Symptom:
- different behaviour parsing info flags, depending on the version of the c++
standard library used.

Explanation of the effect chain:
- in 5.4 c++ library version (unlike in 4.8), the memory seems not to be
erased, on some string operations.
- using 5.4, sometimes in our program appear empty strings like "\0ns,type\0"
of length 0.
- the previous version of string_split (when the input string was empty) was
using past-the-end bytes.
- the split returned a vector of size 0 or 1 depending on the library version.
- the same vcf could be valid or invalid depending on the library version.