### PR TITLE
Added single-line duplicate values check for ID

### DIFF
--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -122,8 +122,8 @@ namespace ebi
         
         std::map<std::string, int> counter;
         for (auto & id : ids) {
-            counter[*id]++;
-            if (counter[*id] >= 2) {
+            counter[id]++;
+            if (counter[id] >= 2) {
                 throw new IdBodyError{line, "ID must not have duplicate values"};
             }
         }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -119,6 +119,14 @@ namespace ebi
                 throw new IdBodyError{line, "ID must not contain semicolons or whitespaces"};
             }
         }
+        
+        std::map<std::string, int> counter;
+        for (auto id = ids.begin(); id != ids.end(); ++id) {
+            counter[*id]++;
+            if (counter[*id] >= 2) {
+                throw new IdBodyError{line, "ID must not have duplicate values"};   
+            }
+        }
     }
 
     void Record::check_alternate_alleles() const

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -121,10 +121,10 @@ namespace ebi
         }
         
         std::map<std::string, int> counter;
-        for (auto id = ids.begin(); id != ids.end(); ++id) {
+        for (auto & id : ids) {
             counter[*id]++;
             if (counter[*id] >= 2) {
-                throw new IdBodyError{line, "ID must not have duplicate values"};   
+                throw new IdBodyError{line, "ID must not have duplicate values"};
             }
         }
     }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -119,12 +119,14 @@ namespace ebi
                 throw new IdBodyError{line, "ID must not contain semicolons or whitespaces"};
             }
         }
-        
-        std::map<std::string, int> counter;
-        for (auto & id : ids) {
-            counter[id]++;
-            if (counter[id] >= 2) {
-                throw new IdBodyError{line, "ID must not have duplicate values"};
+
+        if (ids.size() > 1) {
+            std::map<std::string, int> counter;
+            for (auto & id : ids) {
+                counter[id]++;
+                if (counter[id] >= 2) {
+                    throw new IdBodyError{line, "ID must not have duplicate values"};
+                }
             }
         }
     }

--- a/test/input_files/v4.1/failed/failed_body_id_003.vcf
+++ b/test/input_files/v4.1/failed/failed_body_id_003.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.1
+##CauseOfFailure=ID contains duplicate values in a single line
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00096	HG00097
+1	123	rs180734498;rs180734498	C	T	100	PASS	AN=2184;AC=249;AF=0.11	GT:DS:GL	0|0:0.050:-0.13,-0.58,-3.62	0|1:1.000:-2.45,-0.00,-5.00

--- a/test/input_files/v4.2/failed/failed_body_id_003.vcf
+++ b/test/input_files/v4.2/failed/failed_body_id_003.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.2
+##CauseOfFailure=ID contains duplicate values in a single line
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00096	HG00097
+1	123	rs180734498;rs180734498	C	T	100	PASS	AN=2184;AC=249;AF=0.11	GT:DS:GL	0|0:0.050:-0.13,-0.58,-3.62	0|1:1.000:-2.45,-0.00,-5.00

--- a/test/input_files/v4.3/failed/failed_body_id_003.vcf
+++ b/test/input_files/v4.3/failed/failed_body_id_003.vcf
@@ -1,0 +1,4 @@
+##fileformat=VCFv4.3
+##CauseOfFailure=ID contains duplicate values in a single line
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00096	HG00097
+1	123	rs180734498;rs180734498	C	T	100	PASS	AN=2184;AC=249;AF=0.11	GT:DS:GL	0|0:0.050:-0.13,-0.58,-3.62	0|1:1.000:-2.45,-0.00,-5.00

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -181,6 +181,24 @@ namespace ebi
                             vcf::IdBodyError*);
         }
 
+        SECTION("Duplicate IDs") 
+        {
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
+                                "chr1", 
+                                123456, 
+                                { "id123", "id123" }, 
+                                "A", 
+                                { "AC", "AT" }, 
+                                1.0, 
+                                { "PASS" }, 
+                                { {"AN", "12,7"}, {"AF", "0.5,0.3"} }, 
+                                { "GT", "DP" }, 
+                                { "0|1" },
+                                std::make_shared<vcf::Source>(source)}),
+                            vcf::IdBodyError*);
+        }
+
         SECTION("Different length alleles")
         {
             CHECK_NOTHROW( (vcf::Record{


### PR DESCRIPTION
This PR aims to partly fix the issue https://github.com/EBIvariation/vcf-validator/issues/35
According to VCF 4.3 specifications, ID cannot have duplicate values, so added a new check for duplicate values. If any duplicated IDs are found in a single line (semicolon separated list), then an error is thrown and file is declared as invalid. 
