### PR TITLE
EVA-720 Detect VCF version automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ We recommend using the [latest release](https://github.com/EBIvariation/vcf-vali
 
 vcf-validator only needs a non-compressed input VCF file to run, although pipes can be used for compressed files (see below). It accepts input in the following ways:
 
-* File path as argument: `vcf_validator -v v4.1 -i /path/to/file.vcf`
-* Standard input: `vcf_validator -v v4.1 < /path/to/file.vcf`
-* Standard input from pipe: `zcat /path/to/file.vcf.gz | vcf_validator -v v4.1`
-
-The VCF version must be always specified, using the `-v` / `--version`. 
+* File path as argument: `vcf_validator -i /path/to/file.vcf`
+* Standard input: `vcf_validator < /path/to/file.vcf`
+* Standard input from pipe: `zcat /path/to/file.vcf.gz | vcf_validator`
 
 The validation level can be configured using `-l` / `--level`. This parameter is optional and accepts 3 values:
 
@@ -49,12 +47,13 @@ The logs about what the debugulator is doing will be written into the error outp
 
 ### Examples
 
-Simple example: `vcf_validator -i /path/to/file.vcf -v v4.1`  
-Full example: `vcf_validator -i /path/to/file.vcf -v v4.1 -l stop -r database,stdout -o /path/to/output/folder/`
+Simple example: `vcf_validator -i /path/to/file.vcf`
+
+Full example: `vcf_validator -i /path/to/file.vcf -l stop -r database,stdout -o /path/to/output/folder/`
 
 Debugulator example:
 ```
-vcf_validator -i /path/to/file.vcf -v v4.1 -r database -o /path/to/write/report/
+vcf_validator -i /path/to/file.vcf -r database -o /path/to/write/report/
 vcf_debugulator -i /path/to/file.vcf -e /path/to/write/report/vcf.errors.timestamp.db -o /path/to/fixed.vcf 2>debugulator_log.txt
 ```
 

--- a/inc/util/string_utils.hpp
+++ b/inc/util/string_utils.hpp
@@ -71,6 +71,28 @@ namespace ebi
         }
         return std::make_pair(first1, first2);
     }
+
+    inline std::string remove_end_of_line(std::string &line)
+    {
+        bool has_r = false, has_n = false;
+        if (line.back() == '\n') {
+            has_n = true;
+            line.pop_back();
+        }
+        if (line.back() == '\r') {
+            has_r = true;
+            line.pop_back();
+        }
+
+        std::string eol;
+        if (has_r) {
+            eol.push_back('\r');
+        }
+        if (has_n) {
+            eol.push_back('\n');
+        }
+        return eol;
+    }
   }
 }
 

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -99,8 +99,6 @@ namespace ebi
      * - predeclare class before ErrorVisitor
      * - add a class at the end of this file
      * - change its name, its parent, its message and its error code
-     * - add a new error code to the enum above
-     * - add the new class in the get_error_instance function
      * - add a new method visit in ErrorVisitor
      */
     #pragma db object polymorphic

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -442,16 +442,9 @@ namespace ebi
 
             std::vector<std::string> columns;
             util::string_split(line, separator.c_str(), columns);
-            std::string eol;
-            if (columns.back().back() == '\n') {
-                //remove (and add it later) the newline so that the `fix_function` doesn't have to deal with it.
-                columns.back().pop_back();
-                if (columns.back().back() == '\r') {
-                    columns.back().pop_back();
-                    eol += "\r";
-                }
-                eol += "\n";
-            }
+
+            //remove (and add it later) the newline so that the `fix_function` doesn't have to deal with it.
+            std::string eol = util::remove_end_of_line(columns.back());
 
             // check ranges. don't allow an empty range, the fix_function should be called at least once
             size_t column_index_last_unsigned;

--- a/inc/vcf/ploidy.hpp
+++ b/inc/vcf/ploidy.hpp
@@ -43,7 +43,7 @@ namespace ebi
     class Ploidy
     {
       public:
-        Ploidy(size_t default_ploidy, const std::map<std::string, size_t> &contig_ploidies = {})
+        explicit Ploidy(size_t default_ploidy, const std::map<std::string, size_t> &contig_ploidies = {})
                 : default_ploidy(default_ploidy), contig_ploidies(contig_ploidies) {}
 
         size_t get_ploidy()

--- a/inc/vcf/validator.hpp
+++ b/inc/vcf/validator.hpp
@@ -178,25 +178,19 @@ namespace ebi
     using FullValidator_v43 = ParserImpl_v43<FullValidatorCfg>;
     using Reader_v43 = ParserImpl_v43<ReaderCfg>;
 
-    Version extract_version(std::vector<char> vector);
-
-    std::unique_ptr<Parser> build_parser(std::string const &path,
-                                         ValidationLevel level,
-                                         Version version,
-                                         Ploidy ploidy);
-
     bool is_valid_vcf_file(std::istream &input,
                            const std::string &sourceName,
                            ValidationLevel validationLevel,
                            Ploidy ploidy,
                            std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> &outputs);
 
-    bool is_valid_vcf_file(const std::vector<char> &firstLine,
-                           std::istream &input,
-                           ebi::vcf::Parser &validator,
-                           std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> &outputs);
+    Version detect_version(const std::vector<char> &line);
 
-    void write_errors(const Parser &validator, const std::vector<std::unique_ptr<ReportWriter>> &outputs);
+    std::unique_ptr<Parser> build_parser(std::string const &path,
+                                         ValidationLevel level,
+                                         Version version,
+                                         Ploidy ploidy);
+
   }
 }
 

--- a/inc/vcf/validator.hpp
+++ b/inc/vcf/validator.hpp
@@ -178,12 +178,21 @@ namespace ebi
     using FullValidator_v43 = ParserImpl_v43<FullValidatorCfg>;
     using Reader_v43 = ParserImpl_v43<ReaderCfg>;
 
+    Version extract_version(std::vector<char> vector);
+
     std::unique_ptr<Parser> build_parser(std::string const &path,
                                          ValidationLevel level,
                                          Version version,
                                          Ploidy ploidy);
 
     bool is_valid_vcf_file(std::istream &input,
+                           const std::string &sourceName,
+                           ValidationLevel validationLevel,
+                           Ploidy ploidy,
+                           std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> &outputs);
+
+    bool is_valid_vcf_file(const std::vector<char> &firstLine,
+                           std::istream &input,
                            ebi::vcf::Parser &validator,
                            std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> &outputs);
 

--- a/inc/vcf/validator.hpp
+++ b/inc/vcf/validator.hpp
@@ -183,14 +183,6 @@ namespace ebi
                            ValidationLevel validationLevel,
                            Ploidy ploidy,
                            std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> &outputs);
-
-    Version detect_version(const std::vector<char> &line);
-
-    std::unique_ptr<Parser> build_parser(std::string const &path,
-                                         ValidationLevel level,
-                                         Version version,
-                                         Ploidy ploidy);
-
   }
 }
 

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 823 "src/vcf/vcf_v41.ragel"
+#line 824 "src/vcf/vcf_v41.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v41_en_meta_section_skip = 579;
 static const int vcf_v41_en_body_section_skip = 580;
 
 
-#line 829 "src/vcf/vcf_v41.ragel"
+#line 830 "src/vcf/vcf_v41.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v41_start;
 	}
 
-#line 843 "src/vcf/vcf_v41.ragel"
+#line 844 "src/vcf/vcf_v41.ragel"
 
     }
 
@@ -87,7 +87,8 @@ tr14:
 #line 227 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         p--; {goto st579;}
     }
 #line 60 "src/vcf/vcf_v41.ragel"
@@ -107,7 +108,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 341 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -141,7 +142,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 341 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -170,47 +171,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 247 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 253 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 297 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 303 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -229,7 +230,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -241,13 +242,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 240 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st579;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -259,12 +260,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -276,12 +277,12 @@ tr152:
     }
 	goto st0;
 tr162:
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -293,7 +294,7 @@ tr162:
     }
 	goto st0;
 tr165:
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -305,12 +306,12 @@ tr165:
     }
 	goto st0;
 tr175:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -322,12 +323,12 @@ tr175:
     }
 	goto st0;
 tr194:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -339,7 +340,7 @@ tr194:
     }
 	goto st0;
 tr204:
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -351,12 +352,12 @@ tr204:
     }
 	goto st0;
 tr214:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -368,12 +369,12 @@ tr214:
     }
 	goto st0;
 tr227:
-#line 269 "src/vcf/vcf_v41.ragel"
+#line 270 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -385,12 +386,12 @@ tr227:
     }
 	goto st0;
 tr236:
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 291 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -402,12 +403,12 @@ tr236:
     }
 	goto st0;
 tr253:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -419,7 +420,7 @@ tr253:
     }
 	goto st0;
 tr264:
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -431,12 +432,12 @@ tr264:
     }
 	goto st0;
 tr273:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -448,12 +449,12 @@ tr273:
     }
 	goto st0;
 tr286:
-#line 285 "src/vcf/vcf_v41.ragel"
+#line 286 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -465,12 +466,12 @@ tr286:
     }
 	goto st0;
 tr295:
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 291 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -482,12 +483,12 @@ tr295:
     }
 	goto st0;
 tr312:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -499,7 +500,7 @@ tr312:
     }
 	goto st0;
 tr323:
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 297 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -511,12 +512,12 @@ tr323:
     }
 	goto st0;
 tr333:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 297 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -528,7 +529,7 @@ tr333:
     }
 	goto st0;
 tr345:
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -540,12 +541,12 @@ tr345:
     }
 	goto st0;
 tr356:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -557,17 +558,17 @@ tr356:
     }
 	goto st0;
 tr361:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -579,12 +580,12 @@ tr361:
     }
 	goto st0;
 tr363:
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -596,17 +597,17 @@ tr363:
     }
 	goto st0;
 tr373:
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 319 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -618,12 +619,12 @@ tr373:
     }
 	goto st0;
 tr376:
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 319 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -635,17 +636,17 @@ tr376:
     }
 	goto st0;
 tr386:
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 319 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -657,12 +658,12 @@ tr386:
     }
 	goto st0;
 tr389:
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -674,7 +675,7 @@ tr389:
     }
 	goto st0;
 tr412:
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 247 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -686,12 +687,12 @@ tr412:
     }
 	goto st0;
 tr421:
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 335 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 247 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -703,7 +704,7 @@ tr421:
     }
 	goto st0;
 tr442:
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 253 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -715,12 +716,12 @@ tr442:
     }
 	goto st0;
 tr453:
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 253 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -732,7 +733,7 @@ tr453:
     }
 	goto st0;
 tr491:
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 303 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -744,12 +745,12 @@ tr491:
     }
 	goto st0;
 tr503:
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 335 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 303 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -761,7 +762,7 @@ tr503:
     }
 	goto st0;
 tr526:
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 341 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -805,7 +806,7 @@ tr566:
     }
 	goto st0;
 tr581:
-#line 357 "src/vcf/vcf_v41.ragel"
+#line 358 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st580;}
@@ -817,7 +818,7 @@ tr581:
     }
 	goto st0;
 tr584:
-#line 363 "src/vcf/vcf_v41.ragel"
+#line 364 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st580;}
@@ -829,7 +830,7 @@ tr584:
     }
 	goto st0;
 tr588:
-#line 369 "src/vcf/vcf_v41.ragel"
+#line 370 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st580;}
@@ -841,7 +842,7 @@ tr588:
     }
 	goto st0;
 tr593:
-#line 375 "src/vcf/vcf_v41.ragel"
+#line 376 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st580;}
@@ -853,7 +854,7 @@ tr593:
     }
 	goto st0;
 tr597:
-#line 381 "src/vcf/vcf_v41.ragel"
+#line 382 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st580;}
@@ -865,7 +866,7 @@ tr597:
     }
 	goto st0;
 tr606:
-#line 387 "src/vcf/vcf_v41.ragel"
+#line 388 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st580;}
@@ -877,7 +878,7 @@ tr606:
     }
 	goto st0;
 tr617:
-#line 393 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st580;}
@@ -889,12 +890,12 @@ tr617:
     }
 	goto st0;
 tr625:
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -906,7 +907,7 @@ tr625:
     }
 	goto st0;
 tr642:
-#line 559 "src/vcf/vcf_v41.ragel"
+#line 560 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st580;}
@@ -918,14 +919,14 @@ tr642:
     }
 	goto st0;
 tr647:
-#line 572 "src/vcf/vcf_v41.ragel"
+#line 573 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st580;}
     }
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 566 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -946,7 +947,7 @@ tr655:
     }
 	goto st0;
 tr657:
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 566 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -960,12 +961,12 @@ tr657:
     }
 	goto st0;
 tr659:
-#line 409 "src/vcf/vcf_v41.ragel"
+#line 410 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -977,7 +978,7 @@ tr659:
     }
 	goto st0;
 tr661:
-#line 550 "src/vcf/vcf_v41.ragel"
+#line 551 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -985,7 +986,7 @@ tr661:
                 "1000G"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -997,7 +998,7 @@ tr661:
     }
 	goto st0;
 tr664:
-#line 414 "src/vcf/vcf_v41.ragel"
+#line 415 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1005,7 +1006,7 @@ tr664:
                 "AA"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1017,7 +1018,7 @@ tr664:
     }
 	goto st0;
 tr667:
-#line 422 "src/vcf/vcf_v41.ragel"
+#line 423 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1025,7 +1026,7 @@ tr667:
                 "AC"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1037,7 +1038,7 @@ tr667:
     }
 	goto st0;
 tr670:
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 431 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1045,7 +1046,7 @@ tr670:
                 "AF"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1057,7 +1058,7 @@ tr670:
     }
 	goto st0;
 tr682:
-#line 438 "src/vcf/vcf_v41.ragel"
+#line 439 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1065,7 +1066,7 @@ tr682:
                 "AN"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1077,7 +1078,7 @@ tr682:
     }
 	goto st0;
 tr685:
-#line 446 "src/vcf/vcf_v41.ragel"
+#line 447 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1085,7 +1086,7 @@ tr685:
                 "BQ"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1097,7 +1098,7 @@ tr685:
     }
 	goto st0;
 tr697:
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 455 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1105,7 +1106,7 @@ tr697:
                 "CIGAR"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1117,7 +1118,7 @@ tr697:
     }
 	goto st0;
 tr700:
-#line 462 "src/vcf/vcf_v41.ragel"
+#line 463 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1125,7 +1126,7 @@ tr700:
                 "DB"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1137,7 +1138,7 @@ tr700:
     }
 	goto st0;
 tr703:
-#line 470 "src/vcf/vcf_v41.ragel"
+#line 471 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1145,7 +1146,7 @@ tr703:
                 "DP"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1157,7 +1158,7 @@ tr703:
     }
 	goto st0;
 tr706:
-#line 478 "src/vcf/vcf_v41.ragel"
+#line 479 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1165,7 +1166,7 @@ tr706:
                 "END"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1177,7 +1178,7 @@ tr706:
     }
 	goto st0;
 tr708:
-#line 486 "src/vcf/vcf_v41.ragel"
+#line 487 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1185,7 +1186,7 @@ tr708:
                 "H2"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1197,7 +1198,7 @@ tr708:
     }
 	goto st0;
 tr710:
-#line 494 "src/vcf/vcf_v41.ragel"
+#line 495 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1205,7 +1206,7 @@ tr710:
                 "H3"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1217,7 +1218,7 @@ tr710:
     }
 	goto st0;
 tr715:
-#line 510 "src/vcf/vcf_v41.ragel"
+#line 511 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1225,7 +1226,7 @@ tr715:
                 "MQ0"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1237,7 +1238,7 @@ tr715:
     }
 	goto st0;
 tr717:
-#line 502 "src/vcf/vcf_v41.ragel"
+#line 503 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1245,7 +1246,7 @@ tr717:
                 "MQ"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1257,7 +1258,7 @@ tr717:
     }
 	goto st0;
 tr729:
-#line 518 "src/vcf/vcf_v41.ragel"
+#line 519 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1265,7 +1266,7 @@ tr729:
                 "NS"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1277,7 +1278,7 @@ tr729:
     }
 	goto st0;
 tr732:
-#line 526 "src/vcf/vcf_v41.ragel"
+#line 527 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1285,7 +1286,7 @@ tr732:
                 "SB"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1297,7 +1298,7 @@ tr732:
     }
 	goto st0;
 tr743:
-#line 534 "src/vcf/vcf_v41.ragel"
+#line 535 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1305,7 +1306,7 @@ tr743:
                 "SOMATIC"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1317,7 +1318,7 @@ tr743:
     }
 	goto st0;
 tr745:
-#line 542 "src/vcf/vcf_v41.ragel"
+#line 543 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1325,7 +1326,7 @@ tr745:
                 "VALIDATED"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1350,7 +1351,7 @@ tr794:
         
         p--; {goto st580;}
     }
-#line 357 "src/vcf/vcf_v41.ragel"
+#line 358 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st580;}
@@ -1362,7 +1363,7 @@ tr794:
     }
 	goto st0;
 tr816:
-#line 550 "src/vcf/vcf_v41.ragel"
+#line 551 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1370,12 +1371,12 @@ tr816:
                 "1000G"});
         p--; {goto st580;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1387,7 +1388,7 @@ tr816:
     }
 	goto st0;
 tr833:
-#line 462 "src/vcf/vcf_v41.ragel"
+#line 463 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1395,12 +1396,12 @@ tr833:
                 "DB"});
         p--; {goto st580;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1412,7 +1413,7 @@ tr833:
     }
 	goto st0;
 tr839:
-#line 486 "src/vcf/vcf_v41.ragel"
+#line 487 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1420,12 +1421,12 @@ tr839:
                 "H2"});
         p--; {goto st580;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1437,7 +1438,7 @@ tr839:
     }
 	goto st0;
 tr841:
-#line 494 "src/vcf/vcf_v41.ragel"
+#line 495 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1445,12 +1446,12 @@ tr841:
                 "H3"});
         p--; {goto st580;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1462,7 +1463,7 @@ tr841:
     }
 	goto st0;
 tr856:
-#line 534 "src/vcf/vcf_v41.ragel"
+#line 535 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1470,12 +1471,12 @@ tr856:
                 "SOMATIC"});
         p--; {goto st580;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1487,7 +1488,7 @@ tr856:
     }
 	goto st0;
 tr866:
-#line 542 "src/vcf/vcf_v41.ragel"
+#line 543 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1495,12 +1496,12 @@ tr866:
                 "VALIDATED"});
         p--; {goto st580;}
     }
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1511,7 +1512,7 @@ tr866:
         p--; {goto st580;}
     }
 	goto st0;
-#line 1515 "inc/vcf/validator_detail_v41.hpp"
+#line 1516 "inc/vcf/validator_detail_v41.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1620,7 +1621,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1624 "inc/vcf/validator_detail_v41.hpp"
+#line 1625 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1634,7 +1635,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1638 "inc/vcf/validator_detail_v41.hpp"
+#line 1639 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1648,7 +1649,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1652 "inc/vcf/validator_detail_v41.hpp"
+#line 1653 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1662,7 +1663,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1666 "inc/vcf/validator_detail_v41.hpp"
+#line 1667 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1676,7 +1677,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1680 "inc/vcf/validator_detail_v41.hpp"
+#line 1681 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1690,7 +1691,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1694 "inc/vcf/validator_detail_v41.hpp"
+#line 1695 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 49 )
 		goto tr21;
 	goto tr14;
@@ -1704,7 +1705,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1708 "inc/vcf/validator_detail_v41.hpp"
+#line 1709 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -1735,7 +1736,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1739 "inc/vcf/validator_detail_v41.hpp"
+#line 1740 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1788,7 +1789,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1792 "inc/vcf/validator_detail_v41.hpp"
+#line 1793 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1804,7 +1805,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1808 "inc/vcf/validator_detail_v41.hpp"
+#line 1809 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -1832,7 +1833,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 1836 "inc/vcf/validator_detail_v41.hpp"
+#line 1837 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -1888,7 +1889,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 1892 "inc/vcf/validator_detail_v41.hpp"
+#line 1893 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -1940,7 +1941,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 1944 "inc/vcf/validator_detail_v41.hpp"
+#line 1945 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -1975,7 +1976,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 1979 "inc/vcf/validator_detail_v41.hpp"
+#line 1980 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2003,7 +2004,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2007 "inc/vcf/validator_detail_v41.hpp"
+#line 2008 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2029,7 +2030,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2033 "inc/vcf/validator_detail_v41.hpp"
+#line 2034 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2051,7 +2052,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2055 "inc/vcf/validator_detail_v41.hpp"
+#line 2056 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2112,7 +2113,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2116 "inc/vcf/validator_detail_v41.hpp"
+#line 2117 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2140,7 +2141,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2144 "inc/vcf/validator_detail_v41.hpp"
+#line 2145 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
@@ -2164,7 +2165,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2168 "inc/vcf/validator_detail_v41.hpp"
+#line 2169 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2186,7 +2187,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2190 "inc/vcf/validator_detail_v41.hpp"
+#line 2191 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2205,7 +2206,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2209 "inc/vcf/validator_detail_v41.hpp"
+#line 2210 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2225,7 +2226,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2229 "inc/vcf/validator_detail_v41.hpp"
+#line 2230 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2260,7 +2261,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2264 "inc/vcf/validator_detail_v41.hpp"
+#line 2265 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2287,7 +2288,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2291 "inc/vcf/validator_detail_v41.hpp"
+#line 2292 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2319,7 +2320,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2323 "inc/vcf/validator_detail_v41.hpp"
+#line 2324 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2340,7 +2341,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2344 "inc/vcf/validator_detail_v41.hpp"
+#line 2345 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2365,7 +2366,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2369 "inc/vcf/validator_detail_v41.hpp"
+#line 2370 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2400,7 +2401,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2404 "inc/vcf/validator_detail_v41.hpp"
+#line 2405 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2427,7 +2428,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2431 "inc/vcf/validator_detail_v41.hpp"
+#line 2432 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2470,7 +2471,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2474 "inc/vcf/validator_detail_v41.hpp"
+#line 2475 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2498,7 +2499,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2502 "inc/vcf/validator_detail_v41.hpp"
+#line 2503 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2524,7 +2525,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2528 "inc/vcf/validator_detail_v41.hpp"
+#line 2529 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2546,7 +2547,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2550 "inc/vcf/validator_detail_v41.hpp"
+#line 2551 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2586,7 +2587,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2590 "inc/vcf/validator_detail_v41.hpp"
+#line 2591 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2637,7 +2638,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2641 "inc/vcf/validator_detail_v41.hpp"
+#line 2642 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2688,7 +2689,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2692 "inc/vcf/validator_detail_v41.hpp"
+#line 2693 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2731,7 +2732,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2735 "inc/vcf/validator_detail_v41.hpp"
+#line 2736 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2761,7 +2762,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2765 "inc/vcf/validator_detail_v41.hpp"
+#line 2766 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2801,7 +2802,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2805 "inc/vcf/validator_detail_v41.hpp"
+#line 2806 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2831,7 +2832,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 2835 "inc/vcf/validator_detail_v41.hpp"
+#line 2836 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -2851,7 +2852,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 2855 "inc/vcf/validator_detail_v41.hpp"
+#line 2856 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -2892,7 +2893,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 2896 "inc/vcf/validator_detail_v41.hpp"
+#line 2897 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -2920,7 +2921,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 2924 "inc/vcf/validator_detail_v41.hpp"
+#line 2925 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -2942,7 +2943,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 2946 "inc/vcf/validator_detail_v41.hpp"
+#line 2947 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -2972,7 +2973,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 2976 "inc/vcf/validator_detail_v41.hpp"
+#line 2977 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3023,7 +3024,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3027 "inc/vcf/validator_detail_v41.hpp"
+#line 3028 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3074,7 +3075,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3078 "inc/vcf/validator_detail_v41.hpp"
+#line 3079 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3117,7 +3118,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3121 "inc/vcf/validator_detail_v41.hpp"
+#line 3122 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3147,7 +3148,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3151 "inc/vcf/validator_detail_v41.hpp"
+#line 3152 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3177,7 +3178,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3181 "inc/vcf/validator_detail_v41.hpp"
+#line 3182 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3207,7 +3208,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3211 "inc/vcf/validator_detail_v41.hpp"
+#line 3212 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3231,7 +3232,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3235 "inc/vcf/validator_detail_v41.hpp"
+#line 3236 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3249,7 +3250,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3253 "inc/vcf/validator_detail_v41.hpp"
+#line 3254 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3276,7 +3277,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3280 "inc/vcf/validator_detail_v41.hpp"
+#line 3281 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3348,7 +3349,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3352 "inc/vcf/validator_detail_v41.hpp"
+#line 3353 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3402,7 +3403,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3406 "inc/vcf/validator_detail_v41.hpp"
+#line 3407 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3423,7 +3424,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3427 "inc/vcf/validator_detail_v41.hpp"
+#line 3428 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3521,7 +3522,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3525 "inc/vcf/validator_detail_v41.hpp"
+#line 3526 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3549,7 +3550,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3553 "inc/vcf/validator_detail_v41.hpp"
+#line 3554 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3577,7 +3578,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3581 "inc/vcf/validator_detail_v41.hpp"
+#line 3582 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st100;
 	goto tr152;
@@ -3610,7 +3611,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3614 "inc/vcf/validator_detail_v41.hpp"
+#line 3615 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr160;
 		case 92: goto tr158;
@@ -3632,7 +3633,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3636 "inc/vcf/validator_detail_v41.hpp"
+#line 3637 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 62: goto tr161;
@@ -3651,7 +3652,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3655 "inc/vcf/validator_detail_v41.hpp"
+#line 3656 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3675,7 +3676,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3679 "inc/vcf/validator_detail_v41.hpp"
+#line 3680 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr163;
@@ -3694,7 +3695,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3698 "inc/vcf/validator_detail_v41.hpp"
+#line 3699 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr166;
@@ -3712,7 +3713,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3716 "inc/vcf/validator_detail_v41.hpp"
+#line 3717 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr167;
@@ -3730,7 +3731,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3734 "inc/vcf/validator_detail_v41.hpp"
+#line 3735 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr168;
@@ -3748,7 +3749,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3752 "inc/vcf/validator_detail_v41.hpp"
+#line 3753 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st109;
@@ -3775,7 +3776,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 3779 "inc/vcf/validator_detail_v41.hpp"
+#line 3780 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st111;
 	goto tr165;
@@ -3832,7 +3833,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 3836 "inc/vcf/validator_detail_v41.hpp"
+#line 3837 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st115;
 	if ( (*p) < 48 ) {
@@ -3871,7 +3872,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 3875 "inc/vcf/validator_detail_v41.hpp"
+#line 3876 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr180;
 		case 95: goto tr179;
@@ -3898,7 +3899,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 3902 "inc/vcf/validator_detail_v41.hpp"
+#line 3903 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st118;
 	goto tr165;
@@ -3996,7 +3997,7 @@ st130:
 	if ( ++p == pe )
 		goto _test_eof130;
 case 130:
-#line 4000 "inc/vcf/validator_detail_v41.hpp"
+#line 4001 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr196;
 		case 92: goto tr197;
@@ -4024,7 +4025,7 @@ st131:
 	if ( ++p == pe )
 		goto _test_eof131;
 case 131:
-#line 4028 "inc/vcf/validator_detail_v41.hpp"
+#line 4029 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 92: goto tr200;
@@ -4052,7 +4053,7 @@ st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 4056 "inc/vcf/validator_detail_v41.hpp"
+#line 4057 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st133;
 	goto tr194;
@@ -4085,7 +4086,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4089 "inc/vcf/validator_detail_v41.hpp"
+#line 4090 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr202;
 		case 92: goto tr200;
@@ -4107,7 +4108,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4111 "inc/vcf/validator_detail_v41.hpp"
+#line 4112 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 62: goto tr203;
@@ -4126,7 +4127,7 @@ st136:
 	if ( ++p == pe )
 		goto _test_eof136;
 case 136:
-#line 4130 "inc/vcf/validator_detail_v41.hpp"
+#line 4131 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4146,7 +4147,7 @@ st137:
 	if ( ++p == pe )
 		goto _test_eof137;
 case 137:
-#line 4150 "inc/vcf/validator_detail_v41.hpp"
+#line 4151 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr205;
@@ -4164,7 +4165,7 @@ st138:
 	if ( ++p == pe )
 		goto _test_eof138;
 case 138:
-#line 4168 "inc/vcf/validator_detail_v41.hpp"
+#line 4169 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr206;
@@ -4182,7 +4183,7 @@ st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 4186 "inc/vcf/validator_detail_v41.hpp"
+#line 4187 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr207;
@@ -4200,7 +4201,7 @@ st140:
 	if ( ++p == pe )
 		goto _test_eof140;
 case 140:
-#line 4204 "inc/vcf/validator_detail_v41.hpp"
+#line 4205 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st141;
@@ -4227,7 +4228,7 @@ st142:
 	if ( ++p == pe )
 		goto _test_eof142;
 case 142:
-#line 4231 "inc/vcf/validator_detail_v41.hpp"
+#line 4232 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st143;
 	goto tr204;
@@ -4284,7 +4285,7 @@ st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 4288 "inc/vcf/validator_detail_v41.hpp"
+#line 4289 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st147;
 	if ( (*p) < 48 ) {
@@ -4323,7 +4324,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4327 "inc/vcf/validator_detail_v41.hpp"
+#line 4328 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr219;
 		case 95: goto tr218;
@@ -4350,7 +4351,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4354 "inc/vcf/validator_detail_v41.hpp"
+#line 4355 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st150;
 	goto tr204;
@@ -4426,7 +4427,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4430 "inc/vcf/validator_detail_v41.hpp"
+#line 4431 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	goto tr227;
@@ -4440,7 +4441,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 4444 "inc/vcf/validator_detail_v41.hpp"
+#line 4445 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st159;
 	goto tr204;
@@ -4506,7 +4507,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 4510 "inc/vcf/validator_detail_v41.hpp"
+#line 4511 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr238;
 	if ( (*p) > 90 ) {
@@ -4525,7 +4526,7 @@ st165:
 	if ( ++p == pe )
 		goto _test_eof165;
 case 165:
-#line 4529 "inc/vcf/validator_detail_v41.hpp"
+#line 4530 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st166;
 	goto tr204;
@@ -4623,7 +4624,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 4627 "inc/vcf/validator_detail_v41.hpp"
+#line 4628 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr255;
 		case 92: goto tr256;
@@ -4651,7 +4652,7 @@ st179:
 	if ( ++p == pe )
 		goto _test_eof179;
 case 179:
-#line 4655 "inc/vcf/validator_detail_v41.hpp"
+#line 4656 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 92: goto tr259;
@@ -4679,7 +4680,7 @@ st180:
 	if ( ++p == pe )
 		goto _test_eof180;
 case 180:
-#line 4683 "inc/vcf/validator_detail_v41.hpp"
+#line 4684 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st181;
 	goto tr253;
@@ -4712,7 +4713,7 @@ st182:
 	if ( ++p == pe )
 		goto _test_eof182;
 case 182:
-#line 4716 "inc/vcf/validator_detail_v41.hpp"
+#line 4717 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr261;
 		case 92: goto tr259;
@@ -4734,7 +4735,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 4738 "inc/vcf/validator_detail_v41.hpp"
+#line 4739 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 62: goto tr262;
@@ -4753,7 +4754,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 4757 "inc/vcf/validator_detail_v41.hpp"
+#line 4758 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4787,7 +4788,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 4791 "inc/vcf/validator_detail_v41.hpp"
+#line 4792 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -4807,7 +4808,7 @@ st186:
 	if ( ++p == pe )
 		goto _test_eof186;
 case 186:
-#line 4811 "inc/vcf/validator_detail_v41.hpp"
+#line 4812 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr265;
@@ -4825,7 +4826,7 @@ st187:
 	if ( ++p == pe )
 		goto _test_eof187;
 case 187:
-#line 4829 "inc/vcf/validator_detail_v41.hpp"
+#line 4830 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr266;
@@ -4843,7 +4844,7 @@ st188:
 	if ( ++p == pe )
 		goto _test_eof188;
 case 188:
-#line 4847 "inc/vcf/validator_detail_v41.hpp"
+#line 4848 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st189;
@@ -4870,7 +4871,7 @@ st190:
 	if ( ++p == pe )
 		goto _test_eof190;
 case 190:
-#line 4874 "inc/vcf/validator_detail_v41.hpp"
+#line 4875 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st191;
 	goto tr264;
@@ -4927,7 +4928,7 @@ st195:
 	if ( ++p == pe )
 		goto _test_eof195;
 case 195:
-#line 4931 "inc/vcf/validator_detail_v41.hpp"
+#line 4932 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st195;
 	if ( (*p) < 48 ) {
@@ -4966,7 +4967,7 @@ st196:
 	if ( ++p == pe )
 		goto _test_eof196;
 case 196:
-#line 4970 "inc/vcf/validator_detail_v41.hpp"
+#line 4971 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr278;
 		case 95: goto tr277;
@@ -4993,7 +4994,7 @@ st197:
 	if ( ++p == pe )
 		goto _test_eof197;
 case 197:
-#line 4997 "inc/vcf/validator_detail_v41.hpp"
+#line 4998 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st198;
 	goto tr264;
@@ -5069,7 +5070,7 @@ st205:
 	if ( ++p == pe )
 		goto _test_eof205;
 case 205:
-#line 5073 "inc/vcf/validator_detail_v41.hpp"
+#line 5074 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	goto tr286;
@@ -5083,7 +5084,7 @@ st206:
 	if ( ++p == pe )
 		goto _test_eof206;
 case 206:
-#line 5087 "inc/vcf/validator_detail_v41.hpp"
+#line 5088 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st207;
 	goto tr264;
@@ -5149,7 +5150,7 @@ st212:
 	if ( ++p == pe )
 		goto _test_eof212;
 case 212:
-#line 5153 "inc/vcf/validator_detail_v41.hpp"
+#line 5154 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr297;
 	if ( (*p) > 90 ) {
@@ -5168,7 +5169,7 @@ st213:
 	if ( ++p == pe )
 		goto _test_eof213;
 case 213:
-#line 5172 "inc/vcf/validator_detail_v41.hpp"
+#line 5173 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st214;
 	goto tr264;
@@ -5266,7 +5267,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 5270 "inc/vcf/validator_detail_v41.hpp"
+#line 5271 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr314;
 		case 92: goto tr315;
@@ -5294,7 +5295,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 5298 "inc/vcf/validator_detail_v41.hpp"
+#line 5299 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -5322,7 +5323,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 5326 "inc/vcf/validator_detail_v41.hpp"
+#line 5327 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st229;
 	goto tr312;
@@ -5355,7 +5356,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 5359 "inc/vcf/validator_detail_v41.hpp"
+#line 5360 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr318;
@@ -5377,7 +5378,7 @@ st231:
 	if ( ++p == pe )
 		goto _test_eof231;
 case 231:
-#line 5381 "inc/vcf/validator_detail_v41.hpp"
+#line 5382 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 62: goto tr321;
@@ -5396,7 +5397,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 5400 "inc/vcf/validator_detail_v41.hpp"
+#line 5401 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5430,7 +5431,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 5434 "inc/vcf/validator_detail_v41.hpp"
+#line 5435 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -5450,7 +5451,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 5454 "inc/vcf/validator_detail_v41.hpp"
+#line 5455 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr324;
@@ -5468,7 +5469,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 5472 "inc/vcf/validator_detail_v41.hpp"
+#line 5473 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr325;
@@ -5486,7 +5487,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 5490 "inc/vcf/validator_detail_v41.hpp"
+#line 5491 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr326;
@@ -5504,7 +5505,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 5508 "inc/vcf/validator_detail_v41.hpp"
+#line 5509 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr327;
@@ -5522,7 +5523,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 5526 "inc/vcf/validator_detail_v41.hpp"
+#line 5527 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr328;
@@ -5540,7 +5541,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 5544 "inc/vcf/validator_detail_v41.hpp"
+#line 5545 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr329;
@@ -5558,7 +5559,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 5562 "inc/vcf/validator_detail_v41.hpp"
+#line 5563 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st241;
@@ -5585,7 +5586,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 5589 "inc/vcf/validator_detail_v41.hpp"
+#line 5590 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st243;
 	goto tr323;
@@ -5599,7 +5600,7 @@ st243:
 	if ( ++p == pe )
 		goto _test_eof243;
 case 243:
-#line 5603 "inc/vcf/validator_detail_v41.hpp"
+#line 5604 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr334;
 	if ( (*p) < 48 ) {
@@ -5624,7 +5625,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 5628 "inc/vcf/validator_detail_v41.hpp"
+#line 5629 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st244;
 	if ( (*p) < 48 ) {
@@ -5659,7 +5660,7 @@ st245:
 	if ( ++p == pe )
 		goto _test_eof245;
 case 245:
-#line 5663 "inc/vcf/validator_detail_v41.hpp"
+#line 5664 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr338;
 		case 95: goto tr337;
@@ -5686,7 +5687,7 @@ st246:
 	if ( ++p == pe )
 		goto _test_eof246;
 case 246:
-#line 5690 "inc/vcf/validator_detail_v41.hpp"
+#line 5691 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr339;
 	if ( (*p) < 48 ) {
@@ -5711,7 +5712,7 @@ st247:
 	if ( ++p == pe )
 		goto _test_eof247;
 case 247:
-#line 5715 "inc/vcf/validator_detail_v41.hpp"
+#line 5716 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st247;
 	if ( (*p) < 48 ) {
@@ -5746,7 +5747,7 @@ st248:
 	if ( ++p == pe )
 		goto _test_eof248;
 case 248:
-#line 5750 "inc/vcf/validator_detail_v41.hpp"
+#line 5751 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr343;
 		case 62: goto tr344;
@@ -5774,7 +5775,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 5778 "inc/vcf/validator_detail_v41.hpp"
+#line 5779 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5794,7 +5795,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 5798 "inc/vcf/validator_detail_v41.hpp"
+#line 5799 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr346;
@@ -5812,7 +5813,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 5816 "inc/vcf/validator_detail_v41.hpp"
+#line 5817 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr347;
@@ -5830,7 +5831,7 @@ st252:
 	if ( ++p == pe )
 		goto _test_eof252;
 case 252:
-#line 5834 "inc/vcf/validator_detail_v41.hpp"
+#line 5835 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr348;
@@ -5848,7 +5849,7 @@ st253:
 	if ( ++p == pe )
 		goto _test_eof253;
 case 253:
-#line 5852 "inc/vcf/validator_detail_v41.hpp"
+#line 5853 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr349;
@@ -5866,7 +5867,7 @@ st254:
 	if ( ++p == pe )
 		goto _test_eof254;
 case 254:
-#line 5870 "inc/vcf/validator_detail_v41.hpp"
+#line 5871 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st255;
@@ -5893,7 +5894,7 @@ st256:
 	if ( ++p == pe )
 		goto _test_eof256;
 case 256:
-#line 5897 "inc/vcf/validator_detail_v41.hpp"
+#line 5898 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st257;
 	goto tr345;
@@ -5950,7 +5951,7 @@ st261:
 	if ( ++p == pe )
 		goto _test_eof261;
 case 261:
-#line 5954 "inc/vcf/validator_detail_v41.hpp"
+#line 5955 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st261;
 	if ( (*p) < 48 ) {
@@ -5989,7 +5990,7 @@ st262:
 	if ( ++p == pe )
 		goto _test_eof262;
 case 262:
-#line 5993 "inc/vcf/validator_detail_v41.hpp"
+#line 5994 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr362;
 		case 95: goto tr360;
@@ -6016,7 +6017,7 @@ st263:
 	if ( ++p == pe )
 		goto _test_eof263;
 case 263:
-#line 6020 "inc/vcf/validator_detail_v41.hpp"
+#line 6021 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 71 )
 		goto st264;
 	goto tr363;
@@ -6109,7 +6110,7 @@ st272:
 	if ( ++p == pe )
 		goto _test_eof272;
 case 272:
-#line 6113 "inc/vcf/validator_detail_v41.hpp"
+#line 6114 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr375;
 	if ( (*p) < 35 ) {
@@ -6131,7 +6132,7 @@ st273:
 	if ( ++p == pe )
 		goto _test_eof273;
 case 273:
-#line 6135 "inc/vcf/validator_detail_v41.hpp"
+#line 6136 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 77 )
 		goto st274;
 	goto tr376;
@@ -6224,7 +6225,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 6228 "inc/vcf/validator_detail_v41.hpp"
+#line 6229 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) < 35 ) {
@@ -6246,7 +6247,7 @@ st283:
 	if ( ++p == pe )
 		goto _test_eof283;
 case 283:
-#line 6250 "inc/vcf/validator_detail_v41.hpp"
+#line 6251 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st284;
 	goto tr389;
@@ -6344,7 +6345,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 6348 "inc/vcf/validator_detail_v41.hpp"
+#line 6349 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 92: goto tr405;
@@ -6372,7 +6373,7 @@ st297:
 	if ( ++p == pe )
 		goto _test_eof297;
 case 297:
-#line 6376 "inc/vcf/validator_detail_v41.hpp"
+#line 6377 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 92: goto tr408;
@@ -6400,7 +6401,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 6404 "inc/vcf/validator_detail_v41.hpp"
+#line 6405 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st299;
 	goto tr389;
@@ -6433,7 +6434,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 6437 "inc/vcf/validator_detail_v41.hpp"
+#line 6438 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr410;
 		case 92: goto tr408;
@@ -6455,7 +6456,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 6459 "inc/vcf/validator_detail_v41.hpp"
+#line 6460 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 62: goto tr411;
@@ -6474,7 +6475,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 6478 "inc/vcf/validator_detail_v41.hpp"
+#line 6479 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6498,7 +6499,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 6502 "inc/vcf/validator_detail_v41.hpp"
+#line 6503 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr413;
@@ -6516,7 +6517,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 6520 "inc/vcf/validator_detail_v41.hpp"
+#line 6521 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr414;
@@ -6534,7 +6535,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 6538 "inc/vcf/validator_detail_v41.hpp"
+#line 6539 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr415;
@@ -6552,7 +6553,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 6556 "inc/vcf/validator_detail_v41.hpp"
+#line 6557 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr416;
@@ -6570,7 +6571,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 6574 "inc/vcf/validator_detail_v41.hpp"
+#line 6575 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr417;
@@ -6588,7 +6589,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 6592 "inc/vcf/validator_detail_v41.hpp"
+#line 6593 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr418;
@@ -6606,7 +6607,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 6610 "inc/vcf/validator_detail_v41.hpp"
+#line 6611 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st310;
@@ -6633,7 +6634,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 6637 "inc/vcf/validator_detail_v41.hpp"
+#line 6638 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr422;
@@ -6650,7 +6651,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 6654 "inc/vcf/validator_detail_v41.hpp"
+#line 6655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6676,7 +6677,7 @@ st313:
 	if ( ++p == pe )
 		goto _test_eof313;
 case 313:
-#line 6680 "inc/vcf/validator_detail_v41.hpp"
+#line 6681 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6799,7 +6800,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 6803 "inc/vcf/validator_detail_v41.hpp"
+#line 6804 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr438;
@@ -6867,7 +6868,7 @@ st330:
 	if ( ++p == pe )
 		goto _test_eof330;
 case 330:
-#line 6871 "inc/vcf/validator_detail_v41.hpp"
+#line 6872 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr443;
@@ -6885,7 +6886,7 @@ st331:
 	if ( ++p == pe )
 		goto _test_eof331;
 case 331:
-#line 6889 "inc/vcf/validator_detail_v41.hpp"
+#line 6890 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr444;
@@ -6903,7 +6904,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 6907 "inc/vcf/validator_detail_v41.hpp"
+#line 6908 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr445;
@@ -6921,7 +6922,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 6925 "inc/vcf/validator_detail_v41.hpp"
+#line 6926 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr446;
@@ -6939,7 +6940,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 6943 "inc/vcf/validator_detail_v41.hpp"
+#line 6944 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st335;
@@ -6966,7 +6967,7 @@ st336:
 	if ( ++p == pe )
 		goto _test_eof336;
 case 336:
-#line 6970 "inc/vcf/validator_detail_v41.hpp"
+#line 6971 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st337;
 	goto tr442;
@@ -7028,7 +7029,7 @@ st341:
 	if ( ++p == pe )
 		goto _test_eof341;
 case 341:
-#line 7032 "inc/vcf/validator_detail_v41.hpp"
+#line 7033 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 59: goto tr455;
@@ -7050,7 +7051,7 @@ st342:
 	if ( ++p == pe )
 		goto _test_eof342;
 case 342:
-#line 7054 "inc/vcf/validator_detail_v41.hpp"
+#line 7055 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr458;
 	if ( (*p) < 48 ) {
@@ -7075,7 +7076,7 @@ st343:
 	if ( ++p == pe )
 		goto _test_eof343;
 case 343:
-#line 7079 "inc/vcf/validator_detail_v41.hpp"
+#line 7080 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st343;
 	if ( (*p) < 48 ) {
@@ -7110,7 +7111,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 7114 "inc/vcf/validator_detail_v41.hpp"
+#line 7115 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr462;
 		case 95: goto tr461;
@@ -7137,7 +7138,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 7141 "inc/vcf/validator_detail_v41.hpp"
+#line 7142 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st348;
 	if ( (*p) < 45 ) {
@@ -7169,7 +7170,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 7173 "inc/vcf/validator_detail_v41.hpp"
+#line 7174 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 62: goto tr457;
@@ -7190,7 +7191,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 7194 "inc/vcf/validator_detail_v41.hpp"
+#line 7195 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7227,7 +7228,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 7231 "inc/vcf/validator_detail_v41.hpp"
+#line 7232 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 92: goto tr471;
@@ -7255,7 +7256,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 7259 "inc/vcf/validator_detail_v41.hpp"
+#line 7260 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st342;
 		case 62: goto st347;
@@ -7281,7 +7282,7 @@ st351:
 	if ( ++p == pe )
 		goto _test_eof351;
 case 351:
-#line 7285 "inc/vcf/validator_detail_v41.hpp"
+#line 7286 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 92: goto tr471;
@@ -7303,7 +7304,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 7307 "inc/vcf/validator_detail_v41.hpp"
+#line 7308 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr475;
@@ -7343,7 +7344,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 7347 "inc/vcf/validator_detail_v41.hpp"
+#line 7348 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7394,7 +7395,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 7398 "inc/vcf/validator_detail_v41.hpp"
+#line 7399 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7445,7 +7446,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 7449 "inc/vcf/validator_detail_v41.hpp"
+#line 7450 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7488,7 +7489,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 7492 "inc/vcf/validator_detail_v41.hpp"
+#line 7493 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr483;
 		case 44: goto tr469;
@@ -7518,7 +7519,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 7522 "inc/vcf/validator_detail_v41.hpp"
+#line 7523 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr486;
@@ -7558,7 +7559,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 7562 "inc/vcf/validator_detail_v41.hpp"
+#line 7563 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7588,7 +7589,7 @@ st359:
 	if ( ++p == pe )
 		goto _test_eof359;
 case 359:
-#line 7592 "inc/vcf/validator_detail_v41.hpp"
+#line 7593 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 44: goto tr486;
@@ -7608,7 +7609,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 7612 "inc/vcf/validator_detail_v41.hpp"
+#line 7613 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr467;
 		case 44: goto tr489;
@@ -7632,7 +7633,7 @@ st361:
 	if ( ++p == pe )
 		goto _test_eof361;
 case 361:
-#line 7636 "inc/vcf/validator_detail_v41.hpp"
+#line 7637 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr492;
@@ -7650,7 +7651,7 @@ st362:
 	if ( ++p == pe )
 		goto _test_eof362;
 case 362:
-#line 7654 "inc/vcf/validator_detail_v41.hpp"
+#line 7655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr493;
@@ -7668,7 +7669,7 @@ st363:
 	if ( ++p == pe )
 		goto _test_eof363;
 case 363:
-#line 7672 "inc/vcf/validator_detail_v41.hpp"
+#line 7673 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr494;
@@ -7686,7 +7687,7 @@ st364:
 	if ( ++p == pe )
 		goto _test_eof364;
 case 364:
-#line 7690 "inc/vcf/validator_detail_v41.hpp"
+#line 7691 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr495;
@@ -7704,7 +7705,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 7708 "inc/vcf/validator_detail_v41.hpp"
+#line 7709 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr496;
@@ -7722,7 +7723,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 7726 "inc/vcf/validator_detail_v41.hpp"
+#line 7727 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr497;
@@ -7740,7 +7741,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 7744 "inc/vcf/validator_detail_v41.hpp"
+#line 7745 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr498;
@@ -7758,7 +7759,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 7762 "inc/vcf/validator_detail_v41.hpp"
+#line 7763 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr499;
@@ -7776,7 +7777,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 7780 "inc/vcf/validator_detail_v41.hpp"
+#line 7781 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st370;
@@ -7803,7 +7804,7 @@ st371:
 	if ( ++p == pe )
 		goto _test_eof371;
 case 371:
-#line 7807 "inc/vcf/validator_detail_v41.hpp"
+#line 7808 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st372;
 	goto tr491;
@@ -7827,7 +7828,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 7831 "inc/vcf/validator_detail_v41.hpp"
+#line 7832 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7853,7 +7854,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 7857 "inc/vcf/validator_detail_v41.hpp"
+#line 7858 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7964,7 +7965,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 7968 "inc/vcf/validator_detail_v41.hpp"
+#line 7969 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr520;
@@ -7985,7 +7986,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 7989 "inc/vcf/validator_detail_v41.hpp"
+#line 7990 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr522;
@@ -8020,7 +8021,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 8024 "inc/vcf/validator_detail_v41.hpp"
+#line 8025 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr520;
@@ -8120,7 +8121,7 @@ st398:
 	if ( ++p == pe )
 		goto _test_eof398;
 case 398:
-#line 8124 "inc/vcf/validator_detail_v41.hpp"
+#line 8125 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 80 )
 		goto st399;
 	goto tr526;
@@ -8155,7 +8156,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 8159 "inc/vcf/validator_detail_v41.hpp"
+#line 8160 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st403;
 	goto tr526;
@@ -8183,7 +8184,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 8187 "inc/vcf/validator_detail_v41.hpp"
+#line 8188 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 82 )
 		goto st406;
 	goto tr526;
@@ -8218,7 +8219,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 8222 "inc/vcf/validator_detail_v41.hpp"
+#line 8223 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 65 )
 		goto st410;
 	goto tr526;
@@ -8253,7 +8254,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 8257 "inc/vcf/validator_detail_v41.hpp"
+#line 8258 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 81 )
 		goto st414;
 	goto tr526;
@@ -8295,7 +8296,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 8299 "inc/vcf/validator_detail_v41.hpp"
+#line 8300 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st419;
 	goto tr526;
@@ -8351,7 +8352,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 8355 "inc/vcf/validator_detail_v41.hpp"
+#line 8356 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st426;
 	goto tr526;
@@ -8396,7 +8397,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 8400 "inc/vcf/validator_detail_v41.hpp"
+#line 8401 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st431;
 	goto tr566;
@@ -8462,7 +8463,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 8466 "inc/vcf/validator_detail_v41.hpp"
+#line 8467 "inc/vcf/validator_detail_v41.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr574;
 	goto tr566;
@@ -8486,7 +8487,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 8490 "inc/vcf/validator_detail_v41.hpp"
+#line 8491 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr575;
 		case 10: goto tr576;
@@ -8535,7 +8536,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 8539 "inc/vcf/validator_detail_v41.hpp"
+#line 8540 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr795;
 		case 13: goto tr796;
@@ -8586,7 +8587,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 8590 "inc/vcf/validator_detail_v41.hpp"
+#line 8591 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr799;
 		case 13: goto tr800;
@@ -8628,7 +8629,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 8632 "inc/vcf/validator_detail_v41.hpp"
+#line 8633 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st582;
 	goto st0;
@@ -8670,7 +8671,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 8674 "inc/vcf/validator_detail_v41.hpp"
+#line 8675 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr582;
 		case 59: goto tr583;
@@ -8713,7 +8714,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 8717 "inc/vcf/validator_detail_v41.hpp"
+#line 8718 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr585;
 	goto tr584;
@@ -8737,7 +8738,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 8741 "inc/vcf/validator_detail_v41.hpp"
+#line 8742 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr586;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8767,7 +8768,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 8771 "inc/vcf/validator_detail_v41.hpp"
+#line 8772 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr589;
@@ -8794,7 +8795,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 8798 "inc/vcf/validator_detail_v41.hpp"
+#line 8799 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr590;
 		case 59: goto tr592;
@@ -8820,7 +8821,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 8824 "inc/vcf/validator_detail_v41.hpp"
+#line 8825 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr594;
 		case 67: goto tr594;
@@ -8854,7 +8855,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 8858 "inc/vcf/validator_detail_v41.hpp"
+#line 8859 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr595;
 		case 65: goto tr596;
@@ -8887,7 +8888,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 8891 "inc/vcf/validator_detail_v41.hpp"
+#line 8892 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr599;
@@ -8926,7 +8927,7 @@ st448:
 	if ( ++p == pe )
 		goto _test_eof448;
 case 448:
-#line 8930 "inc/vcf/validator_detail_v41.hpp"
+#line 8931 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -8950,7 +8951,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 8954 "inc/vcf/validator_detail_v41.hpp"
+#line 8955 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr607;
 		case 45: goto tr607;
@@ -8975,7 +8976,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 8979 "inc/vcf/validator_detail_v41.hpp"
+#line 8980 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr613;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9001,7 +9002,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 9005 "inc/vcf/validator_detail_v41.hpp"
+#line 9006 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 46: goto tr615;
@@ -9029,7 +9030,7 @@ st452:
 	if ( ++p == pe )
 		goto _test_eof452;
 case 452:
-#line 9033 "inc/vcf/validator_detail_v41.hpp"
+#line 9034 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr619;
 		case 58: goto tr618;
@@ -9065,7 +9066,7 @@ st453:
 	if ( ++p == pe )
 		goto _test_eof453;
 case 453:
-#line 9069 "inc/vcf/validator_detail_v41.hpp"
+#line 9070 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto st453;
 	if ( (*p) < 65 ) {
@@ -9109,7 +9110,7 @@ st454:
 	if ( ++p == pe )
 		goto _test_eof454;
 case 454:
-#line 9113 "inc/vcf/validator_detail_v41.hpp"
+#line 9114 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 59: goto tr624;
@@ -9135,7 +9136,7 @@ st455:
 	if ( ++p == pe )
 		goto _test_eof455;
 case 455:
-#line 9139 "inc/vcf/validator_detail_v41.hpp"
+#line 9140 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr627;
 		case 49: goto tr629;
@@ -9193,7 +9194,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 9197 "inc/vcf/validator_detail_v41.hpp"
+#line 9198 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr640;
 		case 60: goto tr640;
@@ -9239,7 +9240,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 9243 "inc/vcf/validator_detail_v41.hpp"
+#line 9244 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9274,7 +9275,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 9278 "inc/vcf/validator_detail_v41.hpp"
+#line 9279 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr643;
@@ -9304,7 +9305,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 9308 "inc/vcf/validator_detail_v41.hpp"
+#line 9309 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 58: goto tr646;
@@ -9336,7 +9337,7 @@ st459:
 	if ( ++p == pe )
 		goto _test_eof459;
 case 459:
-#line 9340 "inc/vcf/validator_detail_v41.hpp"
+#line 9341 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr649;
 	if ( (*p) < 48 ) {
@@ -9368,7 +9369,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 9372 "inc/vcf/validator_detail_v41.hpp"
+#line 9373 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9427,7 +9428,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 9431 "inc/vcf/validator_detail_v41.hpp"
+#line 9432 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr799;
 		case 13: goto tr800;
@@ -9456,7 +9457,7 @@ st460:
 	if ( ++p == pe )
 		goto _test_eof460;
 case 460:
-#line 9460 "inc/vcf/validator_detail_v41.hpp"
+#line 9461 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr651;
@@ -9486,7 +9487,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 9490 "inc/vcf/validator_detail_v41.hpp"
+#line 9491 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr652;
 		case 62: goto tr653;
@@ -9510,7 +9511,7 @@ st462:
 	if ( ++p == pe )
 		goto _test_eof462;
 case 462:
-#line 9514 "inc/vcf/validator_detail_v41.hpp"
+#line 9515 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr654;
 	goto tr581;
@@ -9563,7 +9564,7 @@ st463:
 	if ( ++p == pe )
 		goto _test_eof463;
 case 463:
-#line 9567 "inc/vcf/validator_detail_v41.hpp"
+#line 9568 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st585;
 	goto tr655;
@@ -9577,7 +9578,7 @@ st464:
 	if ( ++p == pe )
 		goto _test_eof464;
 case 464:
-#line 9581 "inc/vcf/validator_detail_v41.hpp"
+#line 9582 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr658;
@@ -9604,7 +9605,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 9608 "inc/vcf/validator_detail_v41.hpp"
+#line 9609 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9626,7 +9627,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 9630 "inc/vcf/validator_detail_v41.hpp"
+#line 9631 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9663,7 +9664,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 9667 "inc/vcf/validator_detail_v41.hpp"
+#line 9668 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9691,7 +9692,7 @@ st465:
 	if ( ++p == pe )
 		goto _test_eof465;
 case 465:
-#line 9695 "inc/vcf/validator_detail_v41.hpp"
+#line 9696 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 49: goto tr629;
 		case 58: goto tr626;
@@ -9742,7 +9743,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 9746 "inc/vcf/validator_detail_v41.hpp"
+#line 9747 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9764,7 +9765,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 9768 "inc/vcf/validator_detail_v41.hpp"
+#line 9769 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9786,7 +9787,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 9790 "inc/vcf/validator_detail_v41.hpp"
+#line 9791 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9808,7 +9809,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 9812 "inc/vcf/validator_detail_v41.hpp"
+#line 9813 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9830,7 +9831,7 @@ st466:
 	if ( ++p == pe )
 		goto _test_eof466;
 case 466:
-#line 9834 "inc/vcf/validator_detail_v41.hpp"
+#line 9835 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr660;
@@ -9847,7 +9848,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 9851 "inc/vcf/validator_detail_v41.hpp"
+#line 9852 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9867,7 +9868,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 9871 "inc/vcf/validator_detail_v41.hpp"
+#line 9872 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9888,7 +9889,7 @@ st467:
 	if ( ++p == pe )
 		goto _test_eof467;
 case 467:
-#line 9892 "inc/vcf/validator_detail_v41.hpp"
+#line 9893 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr662;
 	goto tr661;
@@ -9902,7 +9903,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 9906 "inc/vcf/validator_detail_v41.hpp"
+#line 9907 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9924,7 +9925,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 9928 "inc/vcf/validator_detail_v41.hpp"
+#line 9929 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9949,7 +9950,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 9953 "inc/vcf/validator_detail_v41.hpp"
+#line 9954 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr663;
 	if ( (*p) > 58 ) {
@@ -9968,7 +9969,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 9972 "inc/vcf/validator_detail_v41.hpp"
+#line 9973 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr665;
 	if ( (*p) < 45 ) {
@@ -9990,7 +9991,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 9994 "inc/vcf/validator_detail_v41.hpp"
+#line 9995 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10016,7 +10017,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10020 "inc/vcf/validator_detail_v41.hpp"
+#line 10021 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr666;
 	if ( (*p) > 58 ) {
@@ -10035,7 +10036,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 10039 "inc/vcf/validator_detail_v41.hpp"
+#line 10040 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr668;
 	goto tr667;
@@ -10049,7 +10050,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 10053 "inc/vcf/validator_detail_v41.hpp"
+#line 10054 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10070,7 +10071,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 10074 "inc/vcf/validator_detail_v41.hpp"
+#line 10075 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr669;
 	if ( (*p) > 58 ) {
@@ -10089,7 +10090,7 @@ st473:
 	if ( ++p == pe )
 		goto _test_eof473;
 case 473:
-#line 10093 "inc/vcf/validator_detail_v41.hpp"
+#line 10094 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr671;
 		case 45: goto tr671;
@@ -10109,7 +10110,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10113 "inc/vcf/validator_detail_v41.hpp"
+#line 10114 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr673;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10125,7 +10126,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 10129 "inc/vcf/validator_detail_v41.hpp"
+#line 10130 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10149,7 +10150,7 @@ st475:
 	if ( ++p == pe )
 		goto _test_eof475;
 case 475:
-#line 10153 "inc/vcf/validator_detail_v41.hpp"
+#line 10154 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr675;
 	goto tr670;
@@ -10163,7 +10164,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 10167 "inc/vcf/validator_detail_v41.hpp"
+#line 10168 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10186,7 +10187,7 @@ st476:
 	if ( ++p == pe )
 		goto _test_eof476;
 case 476:
-#line 10190 "inc/vcf/validator_detail_v41.hpp"
+#line 10191 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr676;
 		case 45: goto tr676;
@@ -10204,7 +10205,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 10208 "inc/vcf/validator_detail_v41.hpp"
+#line 10209 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr677;
 	goto tr670;
@@ -10218,7 +10219,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 10222 "inc/vcf/validator_detail_v41.hpp"
+#line 10223 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10239,7 +10240,7 @@ st478:
 	if ( ++p == pe )
 		goto _test_eof478;
 case 478:
-#line 10243 "inc/vcf/validator_detail_v41.hpp"
+#line 10244 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr678;
 	goto tr670;
@@ -10253,7 +10254,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 10257 "inc/vcf/validator_detail_v41.hpp"
+#line 10258 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr679;
 	goto tr670;
@@ -10267,7 +10268,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 10271 "inc/vcf/validator_detail_v41.hpp"
+#line 10272 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10286,7 +10287,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 10290 "inc/vcf/validator_detail_v41.hpp"
+#line 10291 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr680;
 	goto tr670;
@@ -10300,7 +10301,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10304 "inc/vcf/validator_detail_v41.hpp"
+#line 10305 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr679;
 	goto tr670;
@@ -10314,7 +10315,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 10318 "inc/vcf/validator_detail_v41.hpp"
+#line 10319 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr681;
 	if ( (*p) > 58 ) {
@@ -10333,7 +10334,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 10337 "inc/vcf/validator_detail_v41.hpp"
+#line 10338 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr683;
 	goto tr682;
@@ -10347,7 +10348,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 10351 "inc/vcf/validator_detail_v41.hpp"
+#line 10352 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10371,7 +10372,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 10375 "inc/vcf/validator_detail_v41.hpp"
+#line 10376 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10393,7 +10394,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10397 "inc/vcf/validator_detail_v41.hpp"
+#line 10398 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr684;
 	if ( (*p) > 58 ) {
@@ -10412,7 +10413,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10416 "inc/vcf/validator_detail_v41.hpp"
+#line 10417 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr686;
 		case 45: goto tr686;
@@ -10432,7 +10433,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 10436 "inc/vcf/validator_detail_v41.hpp"
+#line 10437 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr688;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10448,7 +10449,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 10452 "inc/vcf/validator_detail_v41.hpp"
+#line 10453 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10471,7 +10472,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 10475 "inc/vcf/validator_detail_v41.hpp"
+#line 10476 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr690;
 	goto tr685;
@@ -10485,7 +10486,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 10489 "inc/vcf/validator_detail_v41.hpp"
+#line 10490 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10507,7 +10508,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 10511 "inc/vcf/validator_detail_v41.hpp"
+#line 10512 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr691;
 		case 45: goto tr691;
@@ -10525,7 +10526,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 10529 "inc/vcf/validator_detail_v41.hpp"
+#line 10530 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr692;
 	goto tr685;
@@ -10539,7 +10540,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 10543 "inc/vcf/validator_detail_v41.hpp"
+#line 10544 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10559,7 +10560,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10563 "inc/vcf/validator_detail_v41.hpp"
+#line 10564 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr693;
 	goto tr685;
@@ -10573,7 +10574,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 10577 "inc/vcf/validator_detail_v41.hpp"
+#line 10578 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr694;
 	goto tr685;
@@ -10587,7 +10588,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 10591 "inc/vcf/validator_detail_v41.hpp"
+#line 10592 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10605,7 +10606,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 10609 "inc/vcf/validator_detail_v41.hpp"
+#line 10610 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr695;
 	goto tr685;
@@ -10619,7 +10620,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 10623 "inc/vcf/validator_detail_v41.hpp"
+#line 10624 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr694;
 	goto tr685;
@@ -10637,7 +10638,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 10641 "inc/vcf/validator_detail_v41.hpp"
+#line 10642 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10659,7 +10660,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 10663 "inc/vcf/validator_detail_v41.hpp"
+#line 10664 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10681,7 +10682,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 10685 "inc/vcf/validator_detail_v41.hpp"
+#line 10686 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10703,7 +10704,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 10707 "inc/vcf/validator_detail_v41.hpp"
+#line 10708 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10725,7 +10726,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 10729 "inc/vcf/validator_detail_v41.hpp"
+#line 10730 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr696;
 	if ( (*p) > 58 ) {
@@ -10744,7 +10745,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10748 "inc/vcf/validator_detail_v41.hpp"
+#line 10749 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr698;
 	goto tr697;
@@ -10758,7 +10759,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10762 "inc/vcf/validator_detail_v41.hpp"
+#line 10763 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 68: goto tr699;
 		case 80: goto tr699;
@@ -10784,7 +10785,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 10788 "inc/vcf/validator_detail_v41.hpp"
+#line 10789 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10809,7 +10810,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 10813 "inc/vcf/validator_detail_v41.hpp"
+#line 10814 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10832,7 +10833,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 10836 "inc/vcf/validator_detail_v41.hpp"
+#line 10837 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10853,7 +10854,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10857 "inc/vcf/validator_detail_v41.hpp"
+#line 10858 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr701;
 	goto tr700;
@@ -10867,7 +10868,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 10871 "inc/vcf/validator_detail_v41.hpp"
+#line 10872 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10885,7 +10886,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10889 "inc/vcf/validator_detail_v41.hpp"
+#line 10890 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr702;
 	if ( (*p) > 58 ) {
@@ -10904,7 +10905,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10908 "inc/vcf/validator_detail_v41.hpp"
+#line 10909 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr704;
 	goto tr703;
@@ -10918,7 +10919,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 10922 "inc/vcf/validator_detail_v41.hpp"
+#line 10923 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10942,7 +10943,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 10946 "inc/vcf/validator_detail_v41.hpp"
+#line 10947 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10964,7 +10965,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 10968 "inc/vcf/validator_detail_v41.hpp"
+#line 10969 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10986,7 +10987,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10990 "inc/vcf/validator_detail_v41.hpp"
+#line 10991 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr705;
 	if ( (*p) > 58 ) {
@@ -11005,7 +11006,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 11009 "inc/vcf/validator_detail_v41.hpp"
+#line 11010 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr707;
 	goto tr706;
@@ -11019,7 +11020,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 11023 "inc/vcf/validator_detail_v41.hpp"
+#line 11024 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11043,7 +11044,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 11047 "inc/vcf/validator_detail_v41.hpp"
+#line 11048 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11066,7 +11067,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 11070 "inc/vcf/validator_detail_v41.hpp"
+#line 11071 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11087,7 +11088,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 11091 "inc/vcf/validator_detail_v41.hpp"
+#line 11092 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr709;
 	goto tr708;
@@ -11101,7 +11102,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 11105 "inc/vcf/validator_detail_v41.hpp"
+#line 11106 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11119,7 +11120,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 11123 "inc/vcf/validator_detail_v41.hpp"
+#line 11124 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11140,7 +11141,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11144 "inc/vcf/validator_detail_v41.hpp"
+#line 11145 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr711;
 	goto tr710;
@@ -11154,7 +11155,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 11158 "inc/vcf/validator_detail_v41.hpp"
+#line 11159 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11176,7 +11177,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 11180 "inc/vcf/validator_detail_v41.hpp"
+#line 11181 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11198,7 +11199,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11202 "inc/vcf/validator_detail_v41.hpp"
+#line 11203 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 48: goto tr712;
 		case 61: goto tr713;
@@ -11219,7 +11220,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11223 "inc/vcf/validator_detail_v41.hpp"
+#line 11224 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr714;
 	if ( (*p) > 58 ) {
@@ -11238,7 +11239,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11242 "inc/vcf/validator_detail_v41.hpp"
+#line 11243 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr716;
 	goto tr715;
@@ -11252,7 +11253,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 11256 "inc/vcf/validator_detail_v41.hpp"
+#line 11257 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11272,7 +11273,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11276 "inc/vcf/validator_detail_v41.hpp"
+#line 11277 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr718;
 		case 45: goto tr718;
@@ -11292,7 +11293,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 11296 "inc/vcf/validator_detail_v41.hpp"
+#line 11297 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr720;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11308,7 +11309,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 11312 "inc/vcf/validator_detail_v41.hpp"
+#line 11313 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11331,7 +11332,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11335 "inc/vcf/validator_detail_v41.hpp"
+#line 11336 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr722;
 	goto tr717;
@@ -11345,7 +11346,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 11349 "inc/vcf/validator_detail_v41.hpp"
+#line 11350 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11367,7 +11368,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 11371 "inc/vcf/validator_detail_v41.hpp"
+#line 11372 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr723;
 		case 45: goto tr723;
@@ -11385,7 +11386,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11389 "inc/vcf/validator_detail_v41.hpp"
+#line 11390 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr724;
 	goto tr717;
@@ -11399,7 +11400,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 11403 "inc/vcf/validator_detail_v41.hpp"
+#line 11404 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11419,7 +11420,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11423 "inc/vcf/validator_detail_v41.hpp"
+#line 11424 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr725;
 	goto tr717;
@@ -11433,7 +11434,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11437 "inc/vcf/validator_detail_v41.hpp"
+#line 11438 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr726;
 	goto tr717;
@@ -11447,7 +11448,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 11451 "inc/vcf/validator_detail_v41.hpp"
+#line 11452 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11465,7 +11466,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11469 "inc/vcf/validator_detail_v41.hpp"
+#line 11470 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr727;
 	goto tr717;
@@ -11479,7 +11480,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11483 "inc/vcf/validator_detail_v41.hpp"
+#line 11484 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr726;
 	goto tr717;
@@ -11497,7 +11498,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 11501 "inc/vcf/validator_detail_v41.hpp"
+#line 11502 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11519,7 +11520,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11523 "inc/vcf/validator_detail_v41.hpp"
+#line 11524 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr728;
 	if ( (*p) > 58 ) {
@@ -11538,7 +11539,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11542 "inc/vcf/validator_detail_v41.hpp"
+#line 11543 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr730;
 	goto tr729;
@@ -11552,7 +11553,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 11556 "inc/vcf/validator_detail_v41.hpp"
+#line 11557 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11576,7 +11577,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 11580 "inc/vcf/validator_detail_v41.hpp"
+#line 11581 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11599,7 +11600,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11603 "inc/vcf/validator_detail_v41.hpp"
+#line 11604 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr731;
 	if ( (*p) > 58 ) {
@@ -11618,7 +11619,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11622 "inc/vcf/validator_detail_v41.hpp"
+#line 11623 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr733;
 		case 45: goto tr733;
@@ -11638,7 +11639,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11642 "inc/vcf/validator_detail_v41.hpp"
+#line 11643 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr735;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11654,7 +11655,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 11658 "inc/vcf/validator_detail_v41.hpp"
+#line 11659 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11677,7 +11678,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11681 "inc/vcf/validator_detail_v41.hpp"
+#line 11682 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr737;
 	goto tr732;
@@ -11691,7 +11692,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 11695 "inc/vcf/validator_detail_v41.hpp"
+#line 11696 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11713,7 +11714,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11717 "inc/vcf/validator_detail_v41.hpp"
+#line 11718 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr738;
 		case 45: goto tr738;
@@ -11731,7 +11732,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11735 "inc/vcf/validator_detail_v41.hpp"
+#line 11736 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr739;
 	goto tr732;
@@ -11745,7 +11746,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 11749 "inc/vcf/validator_detail_v41.hpp"
+#line 11750 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11765,7 +11766,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11769 "inc/vcf/validator_detail_v41.hpp"
+#line 11770 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr740;
 	goto tr732;
@@ -11779,7 +11780,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11783 "inc/vcf/validator_detail_v41.hpp"
+#line 11784 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr741;
 	goto tr732;
@@ -11793,7 +11794,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 11797 "inc/vcf/validator_detail_v41.hpp"
+#line 11798 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11811,7 +11812,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11815 "inc/vcf/validator_detail_v41.hpp"
+#line 11816 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr742;
 	goto tr732;
@@ -11825,7 +11826,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11829 "inc/vcf/validator_detail_v41.hpp"
+#line 11830 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr741;
 	goto tr732;
@@ -11839,7 +11840,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 11843 "inc/vcf/validator_detail_v41.hpp"
+#line 11844 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11861,7 +11862,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 11865 "inc/vcf/validator_detail_v41.hpp"
+#line 11866 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11883,7 +11884,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 11887 "inc/vcf/validator_detail_v41.hpp"
+#line 11888 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11905,7 +11906,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 11909 "inc/vcf/validator_detail_v41.hpp"
+#line 11910 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11927,7 +11928,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 11931 "inc/vcf/validator_detail_v41.hpp"
+#line 11932 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11949,7 +11950,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 11953 "inc/vcf/validator_detail_v41.hpp"
+#line 11954 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11970,7 +11971,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11974 "inc/vcf/validator_detail_v41.hpp"
+#line 11975 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr744;
 	goto tr743;
@@ -11984,7 +11985,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 11988 "inc/vcf/validator_detail_v41.hpp"
+#line 11989 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12006,7 +12007,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 12010 "inc/vcf/validator_detail_v41.hpp"
+#line 12011 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12028,7 +12029,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 12032 "inc/vcf/validator_detail_v41.hpp"
+#line 12033 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12050,7 +12051,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 12054 "inc/vcf/validator_detail_v41.hpp"
+#line 12055 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12072,7 +12073,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 12076 "inc/vcf/validator_detail_v41.hpp"
+#line 12077 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12094,7 +12095,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 12098 "inc/vcf/validator_detail_v41.hpp"
+#line 12099 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12116,7 +12117,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 12120 "inc/vcf/validator_detail_v41.hpp"
+#line 12121 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12138,7 +12139,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 12142 "inc/vcf/validator_detail_v41.hpp"
+#line 12143 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12160,7 +12161,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 12164 "inc/vcf/validator_detail_v41.hpp"
+#line 12165 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12182,7 +12183,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 12186 "inc/vcf/validator_detail_v41.hpp"
+#line 12187 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12203,7 +12204,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 12207 "inc/vcf/validator_detail_v41.hpp"
+#line 12208 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr746;
 	goto tr745;
@@ -12217,7 +12218,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 12221 "inc/vcf/validator_detail_v41.hpp"
+#line 12222 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12239,7 +12240,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 12243 "inc/vcf/validator_detail_v41.hpp"
+#line 12244 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12278,7 +12279,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 12282 "inc/vcf/validator_detail_v41.hpp"
+#line 12283 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr618;
 	if ( (*p) < 65 ) {
@@ -12316,7 +12317,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 12320 "inc/vcf/validator_detail_v41.hpp"
+#line 12321 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 58: goto st453;
@@ -12352,7 +12353,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 12356 "inc/vcf/validator_detail_v41.hpp"
+#line 12357 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr747;
 	goto tr606;
@@ -12366,7 +12367,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 12370 "inc/vcf/validator_detail_v41.hpp"
+#line 12371 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 69: goto tr616;
@@ -12385,7 +12386,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 12389 "inc/vcf/validator_detail_v41.hpp"
+#line 12390 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr748;
 		case 45: goto tr748;
@@ -12403,7 +12404,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 12407 "inc/vcf/validator_detail_v41.hpp"
+#line 12408 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr749;
 	goto tr606;
@@ -12417,7 +12418,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12421 "inc/vcf/validator_detail_v41.hpp"
+#line 12422 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12443,7 +12444,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12447 "inc/vcf/validator_detail_v41.hpp"
+#line 12448 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr750;
 	goto tr606;
@@ -12457,7 +12458,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12461 "inc/vcf/validator_detail_v41.hpp"
+#line 12462 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr751;
 	goto tr606;
@@ -12481,7 +12482,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12485 "inc/vcf/validator_detail_v41.hpp"
+#line 12486 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	goto tr606;
@@ -12499,7 +12500,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12503 "inc/vcf/validator_detail_v41.hpp"
+#line 12504 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr752;
 	goto tr606;
@@ -12513,7 +12514,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12517 "inc/vcf/validator_detail_v41.hpp"
+#line 12518 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr751;
 	goto tr606;
@@ -12527,7 +12528,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12531 "inc/vcf/validator_detail_v41.hpp"
+#line 12532 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr753;
@@ -12566,7 +12567,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12570 "inc/vcf/validator_detail_v41.hpp"
+#line 12571 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr754;
 		case 67: goto tr754;
@@ -12590,7 +12591,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12594 "inc/vcf/validator_detail_v41.hpp"
+#line 12595 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12626,7 +12627,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12630 "inc/vcf/validator_detail_v41.hpp"
+#line 12631 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr755;
 	if ( (*p) < 63 ) {
@@ -12666,7 +12667,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12670 "inc/vcf/validator_detail_v41.hpp"
+#line 12671 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto tr757;
 	if ( (*p) < 45 ) {
@@ -12698,7 +12699,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12702 "inc/vcf/validator_detail_v41.hpp"
+#line 12703 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12727,7 +12728,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12731 "inc/vcf/validator_detail_v41.hpp"
+#line 12732 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr762;
 	if ( (*p) < 65 ) {
@@ -12749,7 +12750,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12753 "inc/vcf/validator_detail_v41.hpp"
+#line 12754 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr763;
 		case 61: goto tr761;
@@ -12773,7 +12774,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12777 "inc/vcf/validator_detail_v41.hpp"
+#line 12778 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr764;
 	goto tr597;
@@ -12787,7 +12788,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12791 "inc/vcf/validator_detail_v41.hpp"
+#line 12792 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr757;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12803,7 +12804,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12807 "inc/vcf/validator_detail_v41.hpp"
+#line 12808 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr765;
@@ -12823,7 +12824,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12827 "inc/vcf/validator_detail_v41.hpp"
+#line 12828 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr765;
 		case 62: goto tr766;
@@ -12847,7 +12848,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12851 "inc/vcf/validator_detail_v41.hpp"
+#line 12852 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr763;
 	goto tr597;
@@ -12861,7 +12862,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12865 "inc/vcf/validator_detail_v41.hpp"
+#line 12866 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr768;
 	if ( (*p) < 65 ) {
@@ -12883,7 +12884,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12887 "inc/vcf/validator_detail_v41.hpp"
+#line 12888 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr769;
 		case 61: goto tr767;
@@ -12907,7 +12908,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12911 "inc/vcf/validator_detail_v41.hpp"
+#line 12912 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr770;
 	goto tr597;
@@ -12921,7 +12922,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12925 "inc/vcf/validator_detail_v41.hpp"
+#line 12926 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr757;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12937,7 +12938,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12941 "inc/vcf/validator_detail_v41.hpp"
+#line 12942 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr771;
@@ -12957,7 +12958,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12961 "inc/vcf/validator_detail_v41.hpp"
+#line 12962 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr771;
 		case 62: goto tr772;
@@ -12981,7 +12982,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 12985 "inc/vcf/validator_detail_v41.hpp"
+#line 12986 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr769;
 	goto tr597;
@@ -12999,7 +13000,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 13003 "inc/vcf/validator_detail_v41.hpp"
+#line 13004 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr774;
 	if ( (*p) < 65 ) {
@@ -13021,7 +13022,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 13025 "inc/vcf/validator_detail_v41.hpp"
+#line 13026 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr775;
 		case 61: goto tr773;
@@ -13045,7 +13046,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 13049 "inc/vcf/validator_detail_v41.hpp"
+#line 13050 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr776;
 	goto tr597;
@@ -13059,7 +13060,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 13063 "inc/vcf/validator_detail_v41.hpp"
+#line 13064 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr777;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13075,7 +13076,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 13079 "inc/vcf/validator_detail_v41.hpp"
+#line 13080 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr778;
@@ -13095,7 +13096,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 13099 "inc/vcf/validator_detail_v41.hpp"
+#line 13100 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr778;
 		case 62: goto tr779;
@@ -13119,7 +13120,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 13123 "inc/vcf/validator_detail_v41.hpp"
+#line 13124 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr775;
 	goto tr597;
@@ -13137,7 +13138,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 13141 "inc/vcf/validator_detail_v41.hpp"
+#line 13142 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr781;
 	if ( (*p) < 65 ) {
@@ -13159,7 +13160,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 13163 "inc/vcf/validator_detail_v41.hpp"
+#line 13164 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr782;
 		case 61: goto tr780;
@@ -13183,7 +13184,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 13187 "inc/vcf/validator_detail_v41.hpp"
+#line 13188 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr783;
 	goto tr597;
@@ -13197,7 +13198,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 13201 "inc/vcf/validator_detail_v41.hpp"
+#line 13202 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr777;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13213,7 +13214,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 13217 "inc/vcf/validator_detail_v41.hpp"
+#line 13218 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr784;
@@ -13233,7 +13234,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 13237 "inc/vcf/validator_detail_v41.hpp"
+#line 13238 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr784;
 		case 62: goto tr785;
@@ -13257,7 +13258,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 13261 "inc/vcf/validator_detail_v41.hpp"
+#line 13262 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr782;
 	goto tr597;
@@ -13275,7 +13276,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 13279 "inc/vcf/validator_detail_v41.hpp"
+#line 13280 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 65: goto tr754;
@@ -13330,7 +13331,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 13334 "inc/vcf/validator_detail_v41.hpp"
+#line 13335 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st581;
 	goto tr566;
@@ -13359,7 +13360,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 13363 "inc/vcf/validator_detail_v41.hpp"
+#line 13364 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -13379,7 +13380,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 13383 "inc/vcf/validator_detail_v41.hpp"
+#line 13384 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr789;
 		case 13: goto tr790;
@@ -13396,14 +13397,14 @@ tr789:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 821 "src/vcf/vcf_v41.ragel"
+#line 822 "src/vcf/vcf_v41.ragel"
 	{ {goto st28;} }
 	goto st657;
 st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 13407 "inc/vcf/validator_detail_v41.hpp"
+#line 13408 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 tr793:
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -13421,7 +13422,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 13425 "inc/vcf/validator_detail_v41.hpp"
+#line 13426 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr792;
 		case 13: goto tr793;
@@ -13438,14 +13439,14 @@ tr792:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 822 "src/vcf/vcf_v41.ragel"
+#line 823 "src/vcf/vcf_v41.ragel"
 	{ {goto st585;} }
 	goto st658;
 st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 13449 "inc/vcf/validator_detail_v41.hpp"
+#line 13450 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -14236,7 +14237,8 @@ case 658:
 #line 227 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         p--; {goto st579;}
     }
 #line 60 "src/vcf/vcf_v41.ragel"
@@ -14266,7 +14268,7 @@ case 658:
 	case 95: 
 	case 96: 
 	case 100: 
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -14285,7 +14287,7 @@ case 658:
 	case 308: 
 	case 309: 
 	case 310: 
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 247 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -14325,7 +14327,7 @@ case 658:
 	case 358: 
 	case 359: 
 	case 360: 
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 253 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -14359,7 +14361,7 @@ case 658:
 	case 128: 
 	case 129: 
 	case 133: 
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -14405,7 +14407,7 @@ case 658:
 	case 176: 
 	case 177: 
 	case 181: 
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14450,7 +14452,7 @@ case 658:
 	case 224: 
 	case 225: 
 	case 229: 
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -14471,7 +14473,7 @@ case 658:
 	case 241: 
 	case 242: 
 	case 249: 
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 297 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -14493,7 +14495,7 @@ case 658:
 	case 369: 
 	case 370: 
 	case 371: 
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 303 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -14515,7 +14517,7 @@ case 658:
 	case 258: 
 	case 259: 
 	case 299: 
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -14563,7 +14565,7 @@ case 658:
 	case 427: 
 	case 428: 
 	case 429: 
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 341 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14595,7 +14597,7 @@ case 658:
 	case 460: 
 	case 461: 
 	case 462: 
-#line 357 "src/vcf/vcf_v41.ragel"
+#line 358 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st580;}
@@ -14608,7 +14610,7 @@ case 658:
 	break;
 	case 441: 
 	case 442: 
-#line 363 "src/vcf/vcf_v41.ragel"
+#line 364 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st580;}
@@ -14621,7 +14623,7 @@ case 658:
 	break;
 	case 443: 
 	case 444: 
-#line 369 "src/vcf/vcf_v41.ragel"
+#line 370 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st580;}
@@ -14634,7 +14636,7 @@ case 658:
 	break;
 	case 445: 
 	case 446: 
-#line 375 "src/vcf/vcf_v41.ragel"
+#line 376 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st580;}
@@ -14682,7 +14684,7 @@ case 658:
 	case 574: 
 	case 575: 
 	case 576: 
-#line 381 "src/vcf/vcf_v41.ragel"
+#line 382 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st580;}
@@ -14706,7 +14708,7 @@ case 658:
 	case 539: 
 	case 540: 
 	case 541: 
-#line 387 "src/vcf/vcf_v41.ragel"
+#line 388 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st580;}
@@ -14722,7 +14724,7 @@ case 658:
 	case 454: 
 	case 530: 
 	case 531: 
-#line 393 "src/vcf/vcf_v41.ragel"
+#line 394 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st580;}
@@ -14735,7 +14737,7 @@ case 658:
 	break;
 	case 457: 
 	case 458: 
-#line 559 "src/vcf/vcf_v41.ragel"
+#line 560 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st580;}
@@ -14747,7 +14749,7 @@ case 658:
     }
 	break;
 	case 464: 
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 566 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -14874,7 +14876,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 341 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14905,13 +14907,13 @@ case 658:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 239 "src/vcf/vcf_v41.ragel"
+#line 240 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st579;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -14923,12 +14925,12 @@ case 658:
     }
 	break;
 	case 104: 
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14942,12 +14944,12 @@ case 658:
 	case 156: 
 	case 157: 
 	case 185: 
-#line 269 "src/vcf/vcf_v41.ragel"
+#line 270 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14961,12 +14963,12 @@ case 658:
 	case 204: 
 	case 205: 
 	case 233: 
-#line 285 "src/vcf/vcf_v41.ragel"
+#line 286 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -14979,12 +14981,12 @@ case 658:
 	break;
 	case 163: 
 	case 164: 
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 291 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14997,12 +14999,12 @@ case 658:
 	break;
 	case 211: 
 	case 212: 
-#line 290 "src/vcf/vcf_v41.ragel"
+#line 291 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -15022,12 +15024,12 @@ case 658:
 	case 269: 
 	case 270: 
 	case 271: 
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15047,12 +15049,12 @@ case 658:
 	case 279: 
 	case 280: 
 	case 281: 
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 319 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15065,12 +15067,12 @@ case 658:
 	break;
 	case 340: 
 	case 341: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 253 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -15084,12 +15086,12 @@ case 658:
 	case 114: 
 	case 115: 
 	case 116: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -15103,12 +15105,12 @@ case 658:
 	case 146: 
 	case 147: 
 	case 148: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -15122,12 +15124,12 @@ case 658:
 	case 194: 
 	case 195: 
 	case 196: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -15144,12 +15146,12 @@ case 658:
 	case 246: 
 	case 247: 
 	case 248: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 297 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -15162,12 +15164,12 @@ case 658:
 	break;
 	case 260: 
 	case 261: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15184,12 +15186,12 @@ case 658:
 	case 101: 
 	case 102: 
 	case 103: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -15206,12 +15208,12 @@ case 658:
 	case 134: 
 	case 135: 
 	case 136: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -15228,12 +15230,12 @@ case 658:
 	case 182: 
 	case 183: 
 	case 184: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -15250,12 +15252,12 @@ case 658:
 	case 230: 
 	case 231: 
 	case 232: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -15285,12 +15287,12 @@ case 658:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15320,12 +15322,12 @@ case 658:
 	case 327: 
 	case 328: 
 	case 329: 
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 335 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 247 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -15357,12 +15359,12 @@ case 658:
 	case 390: 
 	case 391: 
 	case 392: 
-#line 334 "src/vcf/vcf_v41.ragel"
+#line 335 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 303 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -15388,12 +15390,12 @@ case 658:
 	case 505: 
 	case 516: 
 	case 518: 
-#line 404 "src/vcf/vcf_v41.ragel"
+#line 405 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15405,12 +15407,12 @@ case 658:
     }
 	break;
 	case 466: 
-#line 409 "src/vcf/vcf_v41.ragel"
+#line 410 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15422,7 +15424,7 @@ case 658:
     }
 	break;
 	case 469: 
-#line 414 "src/vcf/vcf_v41.ragel"
+#line 415 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15430,7 +15432,7 @@ case 658:
                 "AA"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15442,7 +15444,7 @@ case 658:
     }
 	break;
 	case 471: 
-#line 422 "src/vcf/vcf_v41.ragel"
+#line 423 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15450,7 +15452,7 @@ case 658:
                 "AC"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15470,7 +15472,7 @@ case 658:
 	case 479: 
 	case 480: 
 	case 481: 
-#line 430 "src/vcf/vcf_v41.ragel"
+#line 431 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15478,7 +15480,7 @@ case 658:
                 "AF"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15490,7 +15492,7 @@ case 658:
     }
 	break;
 	case 483: 
-#line 438 "src/vcf/vcf_v41.ragel"
+#line 439 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15498,7 +15500,7 @@ case 658:
                 "AN"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15518,7 +15520,7 @@ case 658:
 	case 491: 
 	case 492: 
 	case 493: 
-#line 446 "src/vcf/vcf_v41.ragel"
+#line 447 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15526,7 +15528,7 @@ case 658:
                 "BQ"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15539,7 +15541,7 @@ case 658:
 	break;
 	case 495: 
 	case 496: 
-#line 454 "src/vcf/vcf_v41.ragel"
+#line 455 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15547,7 +15549,7 @@ case 658:
                 "CIGAR"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15559,7 +15561,7 @@ case 658:
     }
 	break;
 	case 497: 
-#line 462 "src/vcf/vcf_v41.ragel"
+#line 463 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15567,7 +15569,7 @@ case 658:
                 "DB"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15579,7 +15581,7 @@ case 658:
     }
 	break;
 	case 499: 
-#line 470 "src/vcf/vcf_v41.ragel"
+#line 471 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15587,7 +15589,7 @@ case 658:
                 "DP"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15599,7 +15601,7 @@ case 658:
     }
 	break;
 	case 501: 
-#line 478 "src/vcf/vcf_v41.ragel"
+#line 479 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15607,7 +15609,7 @@ case 658:
                 "END"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15619,7 +15621,7 @@ case 658:
     }
 	break;
 	case 502: 
-#line 486 "src/vcf/vcf_v41.ragel"
+#line 487 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15627,7 +15629,7 @@ case 658:
                 "H2"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15639,7 +15641,7 @@ case 658:
     }
 	break;
 	case 503: 
-#line 494 "src/vcf/vcf_v41.ragel"
+#line 495 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15647,7 +15649,7 @@ case 658:
                 "H3"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15667,7 +15669,7 @@ case 658:
 	case 513: 
 	case 514: 
 	case 515: 
-#line 502 "src/vcf/vcf_v41.ragel"
+#line 503 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15675,7 +15677,7 @@ case 658:
                 "MQ"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15687,7 +15689,7 @@ case 658:
     }
 	break;
 	case 506: 
-#line 510 "src/vcf/vcf_v41.ragel"
+#line 511 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15695,7 +15697,7 @@ case 658:
                 "MQ0"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15707,7 +15709,7 @@ case 658:
     }
 	break;
 	case 517: 
-#line 518 "src/vcf/vcf_v41.ragel"
+#line 519 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15715,7 +15717,7 @@ case 658:
                 "NS"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15735,7 +15737,7 @@ case 658:
 	case 525: 
 	case 526: 
 	case 527: 
-#line 526 "src/vcf/vcf_v41.ragel"
+#line 527 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15743,7 +15745,7 @@ case 658:
                 "SB"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15755,7 +15757,7 @@ case 658:
     }
 	break;
 	case 528: 
-#line 534 "src/vcf/vcf_v41.ragel"
+#line 535 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15763,7 +15765,7 @@ case 658:
                 "SOMATIC"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15775,7 +15777,7 @@ case 658:
     }
 	break;
 	case 529: 
-#line 542 "src/vcf/vcf_v41.ragel"
+#line 543 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15783,7 +15785,7 @@ case 658:
                 "VALIDATED"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15795,7 +15797,7 @@ case 658:
     }
 	break;
 	case 467: 
-#line 550 "src/vcf/vcf_v41.ragel"
+#line 551 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15803,7 +15805,7 @@ case 658:
                 "1000G"});
         p--; {goto st580;}
     }
-#line 399 "src/vcf/vcf_v41.ragel"
+#line 400 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15815,14 +15817,14 @@ case 658:
     }
 	break;
 	case 459: 
-#line 572 "src/vcf/vcf_v41.ragel"
+#line 573 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st580;}
     }
-#line 565 "src/vcf/vcf_v41.ragel"
+#line 566 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -15846,7 +15848,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 340 "src/vcf/vcf_v41.ragel"
+#line 341 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -15875,17 +15877,17 @@ case 658:
     }
 	break;
 	case 272: 
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 319 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15897,17 +15899,17 @@ case 658:
     }
 	break;
 	case 282: 
-#line 318 "src/vcf/vcf_v41.ragel"
+#line 319 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 329 "src/vcf/vcf_v41.ragel"
+#line 330 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15919,17 +15921,17 @@ case 658:
     }
 	break;
 	case 262: 
-#line 324 "src/vcf/vcf_v41.ragel"
+#line 325 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 313 "src/vcf/vcf_v41.ragel"
+#line 314 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15941,47 +15943,47 @@ case 658:
     }
 	break;
 	case 24: 
-#line 234 "src/vcf/vcf_v41.ragel"
+#line 235 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
     }
-#line 258 "src/vcf/vcf_v41.ragel"
+#line 259 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 264 "src/vcf/vcf_v41.ragel"
+#line 265 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
     }
-#line 280 "src/vcf/vcf_v41.ragel"
+#line 281 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
     }
-#line 246 "src/vcf/vcf_v41.ragel"
+#line 247 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
     }
-#line 252 "src/vcf/vcf_v41.ragel"
+#line 253 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
     }
-#line 308 "src/vcf/vcf_v41.ragel"
+#line 309 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
     }
-#line 296 "src/vcf/vcf_v41.ragel"
+#line 297 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
     }
-#line 302 "src/vcf/vcf_v41.ragel"
+#line 303 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -15992,14 +15994,14 @@ case 658:
         p--; {goto st579;}
     }
 	break;
-#line 15996 "inc/vcf/validator_detail_v41.hpp"
+#line 15998 "inc/vcf/validator_detail_v41.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 851 "src/vcf/vcf_v41.ragel"
+#line 852 "src/vcf/vcf_v41.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v41.hpp
+++ b/inc/vcf/validator_detail_v41.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 824 "src/vcf/vcf_v41.ragel"
+#line 823 "src/vcf/vcf_v41.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v41_en_meta_section_skip = 579;
 static const int vcf_v41_en_body_section_skip = 580;
 
 
-#line 830 "src/vcf/vcf_v41.ragel"
+#line 829 "src/vcf/vcf_v41.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v41_start;
 	}
 
-#line 844 "src/vcf/vcf_v41.ragel"
+#line 843 "src/vcf/vcf_v41.ragel"
 
     }
 
@@ -87,8 +87,7 @@ tr14:
 #line 227 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         p--; {goto st579;}
     }
 #line 60 "src/vcf/vcf_v41.ragel"
@@ -108,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 341 "src/vcf/vcf_v41.ragel"
+#line 340 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -142,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 341 "src/vcf/vcf_v41.ragel"
+#line 340 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -171,47 +170,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
     }
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
     }
-#line 247 "src/vcf/vcf_v41.ragel"
+#line 246 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
     }
-#line 253 "src/vcf/vcf_v41.ragel"
+#line 252 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
     }
-#line 297 "src/vcf/vcf_v41.ragel"
+#line 296 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
     }
-#line 303 "src/vcf/vcf_v41.ragel"
+#line 302 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -230,7 +229,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -242,13 +241,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 240 "src/vcf/vcf_v41.ragel"
+#line 239 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st579;}
     }
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -260,12 +259,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -277,12 +276,12 @@ tr152:
     }
 	goto st0;
 tr162:
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -294,7 +293,7 @@ tr162:
     }
 	goto st0;
 tr165:
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -306,12 +305,12 @@ tr165:
     }
 	goto st0;
 tr175:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -323,12 +322,12 @@ tr175:
     }
 	goto st0;
 tr194:
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -340,7 +339,7 @@ tr194:
     }
 	goto st0;
 tr204:
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -352,12 +351,12 @@ tr204:
     }
 	goto st0;
 tr214:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -369,12 +368,12 @@ tr214:
     }
 	goto st0;
 tr227:
-#line 270 "src/vcf/vcf_v41.ragel"
+#line 269 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -386,12 +385,12 @@ tr227:
     }
 	goto st0;
 tr236:
-#line 291 "src/vcf/vcf_v41.ragel"
+#line 290 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -403,12 +402,12 @@ tr236:
     }
 	goto st0;
 tr253:
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -420,7 +419,7 @@ tr253:
     }
 	goto st0;
 tr264:
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -432,12 +431,12 @@ tr264:
     }
 	goto st0;
 tr273:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -449,12 +448,12 @@ tr273:
     }
 	goto st0;
 tr286:
-#line 286 "src/vcf/vcf_v41.ragel"
+#line 285 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -466,12 +465,12 @@ tr286:
     }
 	goto st0;
 tr295:
-#line 291 "src/vcf/vcf_v41.ragel"
+#line 290 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -483,12 +482,12 @@ tr295:
     }
 	goto st0;
 tr312:
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -500,7 +499,7 @@ tr312:
     }
 	goto st0;
 tr323:
-#line 297 "src/vcf/vcf_v41.ragel"
+#line 296 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -512,12 +511,12 @@ tr323:
     }
 	goto st0;
 tr333:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 297 "src/vcf/vcf_v41.ragel"
+#line 296 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -529,7 +528,7 @@ tr333:
     }
 	goto st0;
 tr345:
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -541,12 +540,12 @@ tr345:
     }
 	goto st0;
 tr356:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -558,17 +557,17 @@ tr356:
     }
 	goto st0;
 tr361:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 314 "src/vcf/vcf_v41.ragel"
+#line 313 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -580,12 +579,12 @@ tr361:
     }
 	goto st0;
 tr363:
-#line 314 "src/vcf/vcf_v41.ragel"
+#line 313 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -597,17 +596,17 @@ tr363:
     }
 	goto st0;
 tr373:
-#line 314 "src/vcf/vcf_v41.ragel"
+#line 313 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 319 "src/vcf/vcf_v41.ragel"
+#line 318 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -619,12 +618,12 @@ tr373:
     }
 	goto st0;
 tr376:
-#line 319 "src/vcf/vcf_v41.ragel"
+#line 318 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -636,17 +635,17 @@ tr376:
     }
 	goto st0;
 tr386:
-#line 319 "src/vcf/vcf_v41.ragel"
+#line 318 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -658,12 +657,12 @@ tr386:
     }
 	goto st0;
 tr389:
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -675,7 +674,7 @@ tr389:
     }
 	goto st0;
 tr412:
-#line 247 "src/vcf/vcf_v41.ragel"
+#line 246 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -687,12 +686,12 @@ tr412:
     }
 	goto st0;
 tr421:
-#line 335 "src/vcf/vcf_v41.ragel"
+#line 334 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 247 "src/vcf/vcf_v41.ragel"
+#line 246 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -704,7 +703,7 @@ tr421:
     }
 	goto st0;
 tr442:
-#line 253 "src/vcf/vcf_v41.ragel"
+#line 252 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -716,12 +715,12 @@ tr442:
     }
 	goto st0;
 tr453:
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 253 "src/vcf/vcf_v41.ragel"
+#line 252 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -733,7 +732,7 @@ tr453:
     }
 	goto st0;
 tr491:
-#line 303 "src/vcf/vcf_v41.ragel"
+#line 302 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -745,12 +744,12 @@ tr491:
     }
 	goto st0;
 tr503:
-#line 335 "src/vcf/vcf_v41.ragel"
+#line 334 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 303 "src/vcf/vcf_v41.ragel"
+#line 302 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -762,7 +761,7 @@ tr503:
     }
 	goto st0;
 tr526:
-#line 341 "src/vcf/vcf_v41.ragel"
+#line 340 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -806,7 +805,7 @@ tr566:
     }
 	goto st0;
 tr581:
-#line 358 "src/vcf/vcf_v41.ragel"
+#line 357 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st580;}
@@ -818,7 +817,7 @@ tr581:
     }
 	goto st0;
 tr584:
-#line 364 "src/vcf/vcf_v41.ragel"
+#line 363 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st580;}
@@ -830,7 +829,7 @@ tr584:
     }
 	goto st0;
 tr588:
-#line 370 "src/vcf/vcf_v41.ragel"
+#line 369 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st580;}
@@ -842,7 +841,7 @@ tr588:
     }
 	goto st0;
 tr593:
-#line 376 "src/vcf/vcf_v41.ragel"
+#line 375 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st580;}
@@ -854,7 +853,7 @@ tr593:
     }
 	goto st0;
 tr597:
-#line 382 "src/vcf/vcf_v41.ragel"
+#line 381 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st580;}
@@ -866,7 +865,7 @@ tr597:
     }
 	goto st0;
 tr606:
-#line 388 "src/vcf/vcf_v41.ragel"
+#line 387 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st580;}
@@ -878,7 +877,7 @@ tr606:
     }
 	goto st0;
 tr617:
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 393 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st580;}
@@ -890,12 +889,12 @@ tr617:
     }
 	goto st0;
 tr625:
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -907,7 +906,7 @@ tr625:
     }
 	goto st0;
 tr642:
-#line 560 "src/vcf/vcf_v41.ragel"
+#line 559 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st580;}
@@ -919,14 +918,14 @@ tr642:
     }
 	goto st0;
 tr647:
-#line 573 "src/vcf/vcf_v41.ragel"
+#line 572 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st580;}
     }
-#line 566 "src/vcf/vcf_v41.ragel"
+#line 565 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -947,7 +946,7 @@ tr655:
     }
 	goto st0;
 tr657:
-#line 566 "src/vcf/vcf_v41.ragel"
+#line 565 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -961,12 +960,12 @@ tr657:
     }
 	goto st0;
 tr659:
-#line 410 "src/vcf/vcf_v41.ragel"
+#line 409 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -978,7 +977,7 @@ tr659:
     }
 	goto st0;
 tr661:
-#line 551 "src/vcf/vcf_v41.ragel"
+#line 550 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -986,7 +985,7 @@ tr661:
                 "1000G"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -998,7 +997,7 @@ tr661:
     }
 	goto st0;
 tr664:
-#line 415 "src/vcf/vcf_v41.ragel"
+#line 414 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1006,7 +1005,7 @@ tr664:
                 "AA"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1018,7 +1017,7 @@ tr664:
     }
 	goto st0;
 tr667:
-#line 423 "src/vcf/vcf_v41.ragel"
+#line 422 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1026,7 +1025,7 @@ tr667:
                 "AC"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1038,7 +1037,7 @@ tr667:
     }
 	goto st0;
 tr670:
-#line 431 "src/vcf/vcf_v41.ragel"
+#line 430 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1046,7 +1045,7 @@ tr670:
                 "AF"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1058,7 +1057,7 @@ tr670:
     }
 	goto st0;
 tr682:
-#line 439 "src/vcf/vcf_v41.ragel"
+#line 438 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1066,7 +1065,7 @@ tr682:
                 "AN"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1078,7 +1077,7 @@ tr682:
     }
 	goto st0;
 tr685:
-#line 447 "src/vcf/vcf_v41.ragel"
+#line 446 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1086,7 +1085,7 @@ tr685:
                 "BQ"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1098,7 +1097,7 @@ tr685:
     }
 	goto st0;
 tr697:
-#line 455 "src/vcf/vcf_v41.ragel"
+#line 454 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1106,7 +1105,7 @@ tr697:
                 "CIGAR"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1118,7 +1117,7 @@ tr697:
     }
 	goto st0;
 tr700:
-#line 463 "src/vcf/vcf_v41.ragel"
+#line 462 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1126,7 +1125,7 @@ tr700:
                 "DB"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1138,7 +1137,7 @@ tr700:
     }
 	goto st0;
 tr703:
-#line 471 "src/vcf/vcf_v41.ragel"
+#line 470 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1146,7 +1145,7 @@ tr703:
                 "DP"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1158,7 +1157,7 @@ tr703:
     }
 	goto st0;
 tr706:
-#line 479 "src/vcf/vcf_v41.ragel"
+#line 478 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1166,7 +1165,7 @@ tr706:
                 "END"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1178,7 +1177,7 @@ tr706:
     }
 	goto st0;
 tr708:
-#line 487 "src/vcf/vcf_v41.ragel"
+#line 486 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1186,7 +1185,7 @@ tr708:
                 "H2"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1198,7 +1197,7 @@ tr708:
     }
 	goto st0;
 tr710:
-#line 495 "src/vcf/vcf_v41.ragel"
+#line 494 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1206,7 +1205,7 @@ tr710:
                 "H3"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1218,7 +1217,7 @@ tr710:
     }
 	goto st0;
 tr715:
-#line 511 "src/vcf/vcf_v41.ragel"
+#line 510 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1226,7 +1225,7 @@ tr715:
                 "MQ0"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1238,7 +1237,7 @@ tr715:
     }
 	goto st0;
 tr717:
-#line 503 "src/vcf/vcf_v41.ragel"
+#line 502 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1246,7 +1245,7 @@ tr717:
                 "MQ"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1258,7 +1257,7 @@ tr717:
     }
 	goto st0;
 tr729:
-#line 519 "src/vcf/vcf_v41.ragel"
+#line 518 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1266,7 +1265,7 @@ tr729:
                 "NS"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1278,7 +1277,7 @@ tr729:
     }
 	goto st0;
 tr732:
-#line 527 "src/vcf/vcf_v41.ragel"
+#line 526 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1286,7 +1285,7 @@ tr732:
                 "SB"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1298,7 +1297,7 @@ tr732:
     }
 	goto st0;
 tr743:
-#line 535 "src/vcf/vcf_v41.ragel"
+#line 534 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1306,7 +1305,7 @@ tr743:
                 "SOMATIC"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1318,7 +1317,7 @@ tr743:
     }
 	goto st0;
 tr745:
-#line 543 "src/vcf/vcf_v41.ragel"
+#line 542 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1326,7 +1325,7 @@ tr745:
                 "VALIDATED"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1351,7 +1350,7 @@ tr794:
         
         p--; {goto st580;}
     }
-#line 358 "src/vcf/vcf_v41.ragel"
+#line 357 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st580;}
@@ -1363,7 +1362,7 @@ tr794:
     }
 	goto st0;
 tr816:
-#line 551 "src/vcf/vcf_v41.ragel"
+#line 550 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1371,12 +1370,12 @@ tr816:
                 "1000G"});
         p--; {goto st580;}
     }
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1388,7 +1387,7 @@ tr816:
     }
 	goto st0;
 tr833:
-#line 463 "src/vcf/vcf_v41.ragel"
+#line 462 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1396,12 +1395,12 @@ tr833:
                 "DB"});
         p--; {goto st580;}
     }
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1413,7 +1412,7 @@ tr833:
     }
 	goto st0;
 tr839:
-#line 487 "src/vcf/vcf_v41.ragel"
+#line 486 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1421,12 +1420,12 @@ tr839:
                 "H2"});
         p--; {goto st580;}
     }
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1438,7 +1437,7 @@ tr839:
     }
 	goto st0;
 tr841:
-#line 495 "src/vcf/vcf_v41.ragel"
+#line 494 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1446,12 +1445,12 @@ tr841:
                 "H3"});
         p--; {goto st580;}
     }
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1463,7 +1462,7 @@ tr841:
     }
 	goto st0;
 tr856:
-#line 535 "src/vcf/vcf_v41.ragel"
+#line 534 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1471,12 +1470,12 @@ tr856:
                 "SOMATIC"});
         p--; {goto st580;}
     }
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1488,7 +1487,7 @@ tr856:
     }
 	goto st0;
 tr866:
-#line 543 "src/vcf/vcf_v41.ragel"
+#line 542 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1496,12 +1495,12 @@ tr866:
                 "VALIDATED"});
         p--; {goto st580;}
     }
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -1512,7 +1511,7 @@ tr866:
         p--; {goto st580;}
     }
 	goto st0;
-#line 1516 "inc/vcf/validator_detail_v41.hpp"
+#line 1515 "inc/vcf/validator_detail_v41.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1621,7 +1620,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1625 "inc/vcf/validator_detail_v41.hpp"
+#line 1624 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1635,7 +1634,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1639 "inc/vcf/validator_detail_v41.hpp"
+#line 1638 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1649,7 +1648,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1653 "inc/vcf/validator_detail_v41.hpp"
+#line 1652 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1663,7 +1662,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1667 "inc/vcf/validator_detail_v41.hpp"
+#line 1666 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1677,7 +1676,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1681 "inc/vcf/validator_detail_v41.hpp"
+#line 1680 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1691,7 +1690,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1695 "inc/vcf/validator_detail_v41.hpp"
+#line 1694 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 49 )
 		goto tr21;
 	goto tr14;
@@ -1705,7 +1704,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1709 "inc/vcf/validator_detail_v41.hpp"
+#line 1708 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -1736,7 +1735,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1740 "inc/vcf/validator_detail_v41.hpp"
+#line 1739 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1789,7 +1788,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1793 "inc/vcf/validator_detail_v41.hpp"
+#line 1792 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1805,7 +1804,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 1809 "inc/vcf/validator_detail_v41.hpp"
+#line 1808 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -1833,7 +1832,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 1837 "inc/vcf/validator_detail_v41.hpp"
+#line 1836 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -1889,7 +1888,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 1893 "inc/vcf/validator_detail_v41.hpp"
+#line 1892 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -1941,7 +1940,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 1945 "inc/vcf/validator_detail_v41.hpp"
+#line 1944 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -1976,7 +1975,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 1980 "inc/vcf/validator_detail_v41.hpp"
+#line 1979 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2004,7 +2003,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2008 "inc/vcf/validator_detail_v41.hpp"
+#line 2007 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2030,7 +2029,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2034 "inc/vcf/validator_detail_v41.hpp"
+#line 2033 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2052,7 +2051,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2056 "inc/vcf/validator_detail_v41.hpp"
+#line 2055 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2113,7 +2112,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2117 "inc/vcf/validator_detail_v41.hpp"
+#line 2116 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2141,7 +2140,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2145 "inc/vcf/validator_detail_v41.hpp"
+#line 2144 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
@@ -2165,7 +2164,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2169 "inc/vcf/validator_detail_v41.hpp"
+#line 2168 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2187,7 +2186,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2191 "inc/vcf/validator_detail_v41.hpp"
+#line 2190 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2206,7 +2205,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2210 "inc/vcf/validator_detail_v41.hpp"
+#line 2209 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2226,7 +2225,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2230 "inc/vcf/validator_detail_v41.hpp"
+#line 2229 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2261,7 +2260,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2265 "inc/vcf/validator_detail_v41.hpp"
+#line 2264 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2288,7 +2287,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2292 "inc/vcf/validator_detail_v41.hpp"
+#line 2291 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2320,7 +2319,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2324 "inc/vcf/validator_detail_v41.hpp"
+#line 2323 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2341,7 +2340,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2345 "inc/vcf/validator_detail_v41.hpp"
+#line 2344 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2366,7 +2365,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2370 "inc/vcf/validator_detail_v41.hpp"
+#line 2369 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2401,7 +2400,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2405 "inc/vcf/validator_detail_v41.hpp"
+#line 2404 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2428,7 +2427,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2432 "inc/vcf/validator_detail_v41.hpp"
+#line 2431 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2471,7 +2470,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2475 "inc/vcf/validator_detail_v41.hpp"
+#line 2474 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2499,7 +2498,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2503 "inc/vcf/validator_detail_v41.hpp"
+#line 2502 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2525,7 +2524,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2529 "inc/vcf/validator_detail_v41.hpp"
+#line 2528 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2547,7 +2546,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2551 "inc/vcf/validator_detail_v41.hpp"
+#line 2550 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2587,7 +2586,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2591 "inc/vcf/validator_detail_v41.hpp"
+#line 2590 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2638,7 +2637,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2642 "inc/vcf/validator_detail_v41.hpp"
+#line 2641 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2689,7 +2688,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2693 "inc/vcf/validator_detail_v41.hpp"
+#line 2692 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2732,7 +2731,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2736 "inc/vcf/validator_detail_v41.hpp"
+#line 2735 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2762,7 +2761,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2766 "inc/vcf/validator_detail_v41.hpp"
+#line 2765 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2802,7 +2801,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2806 "inc/vcf/validator_detail_v41.hpp"
+#line 2805 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2832,7 +2831,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 2836 "inc/vcf/validator_detail_v41.hpp"
+#line 2835 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -2852,7 +2851,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 2856 "inc/vcf/validator_detail_v41.hpp"
+#line 2855 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -2893,7 +2892,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 2897 "inc/vcf/validator_detail_v41.hpp"
+#line 2896 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -2921,7 +2920,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 2925 "inc/vcf/validator_detail_v41.hpp"
+#line 2924 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -2943,7 +2942,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 2947 "inc/vcf/validator_detail_v41.hpp"
+#line 2946 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -2973,7 +2972,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 2977 "inc/vcf/validator_detail_v41.hpp"
+#line 2976 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3024,7 +3023,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3028 "inc/vcf/validator_detail_v41.hpp"
+#line 3027 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3075,7 +3074,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3079 "inc/vcf/validator_detail_v41.hpp"
+#line 3078 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3118,7 +3117,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3122 "inc/vcf/validator_detail_v41.hpp"
+#line 3121 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3148,7 +3147,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3152 "inc/vcf/validator_detail_v41.hpp"
+#line 3151 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3178,7 +3177,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3182 "inc/vcf/validator_detail_v41.hpp"
+#line 3181 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3208,7 +3207,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3212 "inc/vcf/validator_detail_v41.hpp"
+#line 3211 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3232,7 +3231,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3236 "inc/vcf/validator_detail_v41.hpp"
+#line 3235 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3250,7 +3249,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3254 "inc/vcf/validator_detail_v41.hpp"
+#line 3253 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3277,7 +3276,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3281 "inc/vcf/validator_detail_v41.hpp"
+#line 3280 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3349,7 +3348,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3353 "inc/vcf/validator_detail_v41.hpp"
+#line 3352 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3403,7 +3402,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3407 "inc/vcf/validator_detail_v41.hpp"
+#line 3406 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3424,7 +3423,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3428 "inc/vcf/validator_detail_v41.hpp"
+#line 3427 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3522,7 +3521,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3526 "inc/vcf/validator_detail_v41.hpp"
+#line 3525 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3550,7 +3549,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3554 "inc/vcf/validator_detail_v41.hpp"
+#line 3553 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3578,7 +3577,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3582 "inc/vcf/validator_detail_v41.hpp"
+#line 3581 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st100;
 	goto tr152;
@@ -3611,7 +3610,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3615 "inc/vcf/validator_detail_v41.hpp"
+#line 3614 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr160;
 		case 92: goto tr158;
@@ -3633,7 +3632,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3637 "inc/vcf/validator_detail_v41.hpp"
+#line 3636 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 62: goto tr161;
@@ -3652,7 +3651,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3656 "inc/vcf/validator_detail_v41.hpp"
+#line 3655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3676,7 +3675,7 @@ st104:
 	if ( ++p == pe )
 		goto _test_eof104;
 case 104:
-#line 3680 "inc/vcf/validator_detail_v41.hpp"
+#line 3679 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr163;
@@ -3695,7 +3694,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3699 "inc/vcf/validator_detail_v41.hpp"
+#line 3698 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr166;
@@ -3713,7 +3712,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3717 "inc/vcf/validator_detail_v41.hpp"
+#line 3716 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr167;
@@ -3731,7 +3730,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3735 "inc/vcf/validator_detail_v41.hpp"
+#line 3734 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr168;
@@ -3749,7 +3748,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3753 "inc/vcf/validator_detail_v41.hpp"
+#line 3752 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st109;
@@ -3776,7 +3775,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 3780 "inc/vcf/validator_detail_v41.hpp"
+#line 3779 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st111;
 	goto tr165;
@@ -3833,7 +3832,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 3837 "inc/vcf/validator_detail_v41.hpp"
+#line 3836 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st115;
 	if ( (*p) < 48 ) {
@@ -3872,7 +3871,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 3876 "inc/vcf/validator_detail_v41.hpp"
+#line 3875 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr180;
 		case 95: goto tr179;
@@ -3899,7 +3898,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 3903 "inc/vcf/validator_detail_v41.hpp"
+#line 3902 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st118;
 	goto tr165;
@@ -3997,7 +3996,7 @@ st130:
 	if ( ++p == pe )
 		goto _test_eof130;
 case 130:
-#line 4001 "inc/vcf/validator_detail_v41.hpp"
+#line 4000 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr196;
 		case 92: goto tr197;
@@ -4025,7 +4024,7 @@ st131:
 	if ( ++p == pe )
 		goto _test_eof131;
 case 131:
-#line 4029 "inc/vcf/validator_detail_v41.hpp"
+#line 4028 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 92: goto tr200;
@@ -4053,7 +4052,7 @@ st132:
 	if ( ++p == pe )
 		goto _test_eof132;
 case 132:
-#line 4057 "inc/vcf/validator_detail_v41.hpp"
+#line 4056 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st133;
 	goto tr194;
@@ -4086,7 +4085,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4090 "inc/vcf/validator_detail_v41.hpp"
+#line 4089 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr202;
 		case 92: goto tr200;
@@ -4108,7 +4107,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4112 "inc/vcf/validator_detail_v41.hpp"
+#line 4111 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr199;
 		case 62: goto tr203;
@@ -4127,7 +4126,7 @@ st136:
 	if ( ++p == pe )
 		goto _test_eof136;
 case 136:
-#line 4131 "inc/vcf/validator_detail_v41.hpp"
+#line 4130 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4147,7 +4146,7 @@ st137:
 	if ( ++p == pe )
 		goto _test_eof137;
 case 137:
-#line 4151 "inc/vcf/validator_detail_v41.hpp"
+#line 4150 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr205;
@@ -4165,7 +4164,7 @@ st138:
 	if ( ++p == pe )
 		goto _test_eof138;
 case 138:
-#line 4169 "inc/vcf/validator_detail_v41.hpp"
+#line 4168 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr206;
@@ -4183,7 +4182,7 @@ st139:
 	if ( ++p == pe )
 		goto _test_eof139;
 case 139:
-#line 4187 "inc/vcf/validator_detail_v41.hpp"
+#line 4186 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr207;
@@ -4201,7 +4200,7 @@ st140:
 	if ( ++p == pe )
 		goto _test_eof140;
 case 140:
-#line 4205 "inc/vcf/validator_detail_v41.hpp"
+#line 4204 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st141;
@@ -4228,7 +4227,7 @@ st142:
 	if ( ++p == pe )
 		goto _test_eof142;
 case 142:
-#line 4232 "inc/vcf/validator_detail_v41.hpp"
+#line 4231 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st143;
 	goto tr204;
@@ -4285,7 +4284,7 @@ st147:
 	if ( ++p == pe )
 		goto _test_eof147;
 case 147:
-#line 4289 "inc/vcf/validator_detail_v41.hpp"
+#line 4288 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st147;
 	if ( (*p) < 48 ) {
@@ -4324,7 +4323,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4328 "inc/vcf/validator_detail_v41.hpp"
+#line 4327 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr219;
 		case 95: goto tr218;
@@ -4351,7 +4350,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4355 "inc/vcf/validator_detail_v41.hpp"
+#line 4354 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st150;
 	goto tr204;
@@ -4427,7 +4426,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4431 "inc/vcf/validator_detail_v41.hpp"
+#line 4430 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	goto tr227;
@@ -4441,7 +4440,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 4445 "inc/vcf/validator_detail_v41.hpp"
+#line 4444 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st159;
 	goto tr204;
@@ -4507,7 +4506,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 4511 "inc/vcf/validator_detail_v41.hpp"
+#line 4510 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr238;
 	if ( (*p) > 90 ) {
@@ -4526,7 +4525,7 @@ st165:
 	if ( ++p == pe )
 		goto _test_eof165;
 case 165:
-#line 4530 "inc/vcf/validator_detail_v41.hpp"
+#line 4529 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st166;
 	goto tr204;
@@ -4624,7 +4623,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 4628 "inc/vcf/validator_detail_v41.hpp"
+#line 4627 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr255;
 		case 92: goto tr256;
@@ -4652,7 +4651,7 @@ st179:
 	if ( ++p == pe )
 		goto _test_eof179;
 case 179:
-#line 4656 "inc/vcf/validator_detail_v41.hpp"
+#line 4655 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 92: goto tr259;
@@ -4680,7 +4679,7 @@ st180:
 	if ( ++p == pe )
 		goto _test_eof180;
 case 180:
-#line 4684 "inc/vcf/validator_detail_v41.hpp"
+#line 4683 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st181;
 	goto tr253;
@@ -4713,7 +4712,7 @@ st182:
 	if ( ++p == pe )
 		goto _test_eof182;
 case 182:
-#line 4717 "inc/vcf/validator_detail_v41.hpp"
+#line 4716 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr261;
 		case 92: goto tr259;
@@ -4735,7 +4734,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 4739 "inc/vcf/validator_detail_v41.hpp"
+#line 4738 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr258;
 		case 62: goto tr262;
@@ -4754,7 +4753,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 4758 "inc/vcf/validator_detail_v41.hpp"
+#line 4757 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4788,7 +4787,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 4792 "inc/vcf/validator_detail_v41.hpp"
+#line 4791 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr230;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -4808,7 +4807,7 @@ st186:
 	if ( ++p == pe )
 		goto _test_eof186;
 case 186:
-#line 4812 "inc/vcf/validator_detail_v41.hpp"
+#line 4811 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr265;
@@ -4826,7 +4825,7 @@ st187:
 	if ( ++p == pe )
 		goto _test_eof187;
 case 187:
-#line 4830 "inc/vcf/validator_detail_v41.hpp"
+#line 4829 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr266;
@@ -4844,7 +4843,7 @@ st188:
 	if ( ++p == pe )
 		goto _test_eof188;
 case 188:
-#line 4848 "inc/vcf/validator_detail_v41.hpp"
+#line 4847 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st189;
@@ -4871,7 +4870,7 @@ st190:
 	if ( ++p == pe )
 		goto _test_eof190;
 case 190:
-#line 4875 "inc/vcf/validator_detail_v41.hpp"
+#line 4874 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st191;
 	goto tr264;
@@ -4928,7 +4927,7 @@ st195:
 	if ( ++p == pe )
 		goto _test_eof195;
 case 195:
-#line 4932 "inc/vcf/validator_detail_v41.hpp"
+#line 4931 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st195;
 	if ( (*p) < 48 ) {
@@ -4967,7 +4966,7 @@ st196:
 	if ( ++p == pe )
 		goto _test_eof196;
 case 196:
-#line 4971 "inc/vcf/validator_detail_v41.hpp"
+#line 4970 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr278;
 		case 95: goto tr277;
@@ -4994,7 +4993,7 @@ st197:
 	if ( ++p == pe )
 		goto _test_eof197;
 case 197:
-#line 4998 "inc/vcf/validator_detail_v41.hpp"
+#line 4997 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto st198;
 	goto tr264;
@@ -5070,7 +5069,7 @@ st205:
 	if ( ++p == pe )
 		goto _test_eof205;
 case 205:
-#line 5074 "inc/vcf/validator_detail_v41.hpp"
+#line 5073 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	goto tr286;
@@ -5084,7 +5083,7 @@ st206:
 	if ( ++p == pe )
 		goto _test_eof206;
 case 206:
-#line 5088 "inc/vcf/validator_detail_v41.hpp"
+#line 5087 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 84 )
 		goto st207;
 	goto tr264;
@@ -5150,7 +5149,7 @@ st212:
 	if ( ++p == pe )
 		goto _test_eof212;
 case 212:
-#line 5154 "inc/vcf/validator_detail_v41.hpp"
+#line 5153 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr297;
 	if ( (*p) > 90 ) {
@@ -5169,7 +5168,7 @@ st213:
 	if ( ++p == pe )
 		goto _test_eof213;
 case 213:
-#line 5173 "inc/vcf/validator_detail_v41.hpp"
+#line 5172 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st214;
 	goto tr264;
@@ -5267,7 +5266,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 5271 "inc/vcf/validator_detail_v41.hpp"
+#line 5270 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr314;
 		case 92: goto tr315;
@@ -5295,7 +5294,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 5299 "inc/vcf/validator_detail_v41.hpp"
+#line 5298 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -5323,7 +5322,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 5327 "inc/vcf/validator_detail_v41.hpp"
+#line 5326 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st229;
 	goto tr312;
@@ -5356,7 +5355,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 5360 "inc/vcf/validator_detail_v41.hpp"
+#line 5359 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr318;
@@ -5378,7 +5377,7 @@ st231:
 	if ( ++p == pe )
 		goto _test_eof231;
 case 231:
-#line 5382 "inc/vcf/validator_detail_v41.hpp"
+#line 5381 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 62: goto tr321;
@@ -5397,7 +5396,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 5401 "inc/vcf/validator_detail_v41.hpp"
+#line 5400 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5431,7 +5430,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 5435 "inc/vcf/validator_detail_v41.hpp"
+#line 5434 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr289;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -5451,7 +5450,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 5455 "inc/vcf/validator_detail_v41.hpp"
+#line 5454 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr324;
@@ -5469,7 +5468,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 5473 "inc/vcf/validator_detail_v41.hpp"
+#line 5472 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr325;
@@ -5487,7 +5486,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 5491 "inc/vcf/validator_detail_v41.hpp"
+#line 5490 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr326;
@@ -5505,7 +5504,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 5509 "inc/vcf/validator_detail_v41.hpp"
+#line 5508 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr327;
@@ -5523,7 +5522,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 5527 "inc/vcf/validator_detail_v41.hpp"
+#line 5526 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr328;
@@ -5541,7 +5540,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 5545 "inc/vcf/validator_detail_v41.hpp"
+#line 5544 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr329;
@@ -5559,7 +5558,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 5563 "inc/vcf/validator_detail_v41.hpp"
+#line 5562 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st241;
@@ -5586,7 +5585,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 5590 "inc/vcf/validator_detail_v41.hpp"
+#line 5589 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st243;
 	goto tr323;
@@ -5600,7 +5599,7 @@ st243:
 	if ( ++p == pe )
 		goto _test_eof243;
 case 243:
-#line 5604 "inc/vcf/validator_detail_v41.hpp"
+#line 5603 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr334;
 	if ( (*p) < 48 ) {
@@ -5625,7 +5624,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 5629 "inc/vcf/validator_detail_v41.hpp"
+#line 5628 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st244;
 	if ( (*p) < 48 ) {
@@ -5660,7 +5659,7 @@ st245:
 	if ( ++p == pe )
 		goto _test_eof245;
 case 245:
-#line 5664 "inc/vcf/validator_detail_v41.hpp"
+#line 5663 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr338;
 		case 95: goto tr337;
@@ -5687,7 +5686,7 @@ st246:
 	if ( ++p == pe )
 		goto _test_eof246;
 case 246:
-#line 5691 "inc/vcf/validator_detail_v41.hpp"
+#line 5690 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr339;
 	if ( (*p) < 48 ) {
@@ -5712,7 +5711,7 @@ st247:
 	if ( ++p == pe )
 		goto _test_eof247;
 case 247:
-#line 5716 "inc/vcf/validator_detail_v41.hpp"
+#line 5715 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st247;
 	if ( (*p) < 48 ) {
@@ -5747,7 +5746,7 @@ st248:
 	if ( ++p == pe )
 		goto _test_eof248;
 case 248:
-#line 5751 "inc/vcf/validator_detail_v41.hpp"
+#line 5750 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr343;
 		case 62: goto tr344;
@@ -5775,7 +5774,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 5779 "inc/vcf/validator_detail_v41.hpp"
+#line 5778 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5795,7 +5794,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 5799 "inc/vcf/validator_detail_v41.hpp"
+#line 5798 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr346;
@@ -5813,7 +5812,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 5817 "inc/vcf/validator_detail_v41.hpp"
+#line 5816 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr347;
@@ -5831,7 +5830,7 @@ st252:
 	if ( ++p == pe )
 		goto _test_eof252;
 case 252:
-#line 5835 "inc/vcf/validator_detail_v41.hpp"
+#line 5834 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr348;
@@ -5849,7 +5848,7 @@ st253:
 	if ( ++p == pe )
 		goto _test_eof253;
 case 253:
-#line 5853 "inc/vcf/validator_detail_v41.hpp"
+#line 5852 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr349;
@@ -5867,7 +5866,7 @@ st254:
 	if ( ++p == pe )
 		goto _test_eof254;
 case 254:
-#line 5871 "inc/vcf/validator_detail_v41.hpp"
+#line 5870 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st255;
@@ -5894,7 +5893,7 @@ st256:
 	if ( ++p == pe )
 		goto _test_eof256;
 case 256:
-#line 5898 "inc/vcf/validator_detail_v41.hpp"
+#line 5897 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st257;
 	goto tr345;
@@ -5951,7 +5950,7 @@ st261:
 	if ( ++p == pe )
 		goto _test_eof261;
 case 261:
-#line 5955 "inc/vcf/validator_detail_v41.hpp"
+#line 5954 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st261;
 	if ( (*p) < 48 ) {
@@ -5990,7 +5989,7 @@ st262:
 	if ( ++p == pe )
 		goto _test_eof262;
 case 262:
-#line 5994 "inc/vcf/validator_detail_v41.hpp"
+#line 5993 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr362;
 		case 95: goto tr360;
@@ -6017,7 +6016,7 @@ st263:
 	if ( ++p == pe )
 		goto _test_eof263;
 case 263:
-#line 6021 "inc/vcf/validator_detail_v41.hpp"
+#line 6020 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 71 )
 		goto st264;
 	goto tr363;
@@ -6110,7 +6109,7 @@ st272:
 	if ( ++p == pe )
 		goto _test_eof272;
 case 272:
-#line 6114 "inc/vcf/validator_detail_v41.hpp"
+#line 6113 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr375;
 	if ( (*p) < 35 ) {
@@ -6132,7 +6131,7 @@ st273:
 	if ( ++p == pe )
 		goto _test_eof273;
 case 273:
-#line 6136 "inc/vcf/validator_detail_v41.hpp"
+#line 6135 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 77 )
 		goto st274;
 	goto tr376;
@@ -6225,7 +6224,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 6229 "inc/vcf/validator_detail_v41.hpp"
+#line 6228 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) < 35 ) {
@@ -6247,7 +6246,7 @@ st283:
 	if ( ++p == pe )
 		goto _test_eof283;
 case 283:
-#line 6251 "inc/vcf/validator_detail_v41.hpp"
+#line 6250 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 68 )
 		goto st284;
 	goto tr389;
@@ -6345,7 +6344,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 6349 "inc/vcf/validator_detail_v41.hpp"
+#line 6348 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr404;
 		case 92: goto tr405;
@@ -6373,7 +6372,7 @@ st297:
 	if ( ++p == pe )
 		goto _test_eof297;
 case 297:
-#line 6377 "inc/vcf/validator_detail_v41.hpp"
+#line 6376 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 92: goto tr408;
@@ -6401,7 +6400,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 6405 "inc/vcf/validator_detail_v41.hpp"
+#line 6404 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto st299;
 	goto tr389;
@@ -6434,7 +6433,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 6438 "inc/vcf/validator_detail_v41.hpp"
+#line 6437 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr410;
 		case 92: goto tr408;
@@ -6456,7 +6455,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 6460 "inc/vcf/validator_detail_v41.hpp"
+#line 6459 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr407;
 		case 62: goto tr411;
@@ -6475,7 +6474,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 6479 "inc/vcf/validator_detail_v41.hpp"
+#line 6478 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6499,7 +6498,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 6503 "inc/vcf/validator_detail_v41.hpp"
+#line 6502 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr413;
@@ -6517,7 +6516,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 6521 "inc/vcf/validator_detail_v41.hpp"
+#line 6520 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr414;
@@ -6535,7 +6534,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 6539 "inc/vcf/validator_detail_v41.hpp"
+#line 6538 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr415;
@@ -6553,7 +6552,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 6557 "inc/vcf/validator_detail_v41.hpp"
+#line 6556 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr416;
@@ -6571,7 +6570,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 6575 "inc/vcf/validator_detail_v41.hpp"
+#line 6574 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr417;
@@ -6589,7 +6588,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 6593 "inc/vcf/validator_detail_v41.hpp"
+#line 6592 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr418;
@@ -6607,7 +6606,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 6611 "inc/vcf/validator_detail_v41.hpp"
+#line 6610 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st310;
@@ -6634,7 +6633,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 6638 "inc/vcf/validator_detail_v41.hpp"
+#line 6637 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr422;
@@ -6651,7 +6650,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 6655 "inc/vcf/validator_detail_v41.hpp"
+#line 6654 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6677,7 +6676,7 @@ st313:
 	if ( ++p == pe )
 		goto _test_eof313;
 case 313:
-#line 6681 "inc/vcf/validator_detail_v41.hpp"
+#line 6680 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr421;
 		case 13: goto tr424;
@@ -6800,7 +6799,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 6804 "inc/vcf/validator_detail_v41.hpp"
+#line 6803 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr438;
@@ -6868,7 +6867,7 @@ st330:
 	if ( ++p == pe )
 		goto _test_eof330;
 case 330:
-#line 6872 "inc/vcf/validator_detail_v41.hpp"
+#line 6871 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr443;
@@ -6886,7 +6885,7 @@ st331:
 	if ( ++p == pe )
 		goto _test_eof331;
 case 331:
-#line 6890 "inc/vcf/validator_detail_v41.hpp"
+#line 6889 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr444;
@@ -6904,7 +6903,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 6908 "inc/vcf/validator_detail_v41.hpp"
+#line 6907 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr445;
@@ -6922,7 +6921,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 6926 "inc/vcf/validator_detail_v41.hpp"
+#line 6925 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr446;
@@ -6940,7 +6939,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 6944 "inc/vcf/validator_detail_v41.hpp"
+#line 6943 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st335;
@@ -6967,7 +6966,7 @@ st336:
 	if ( ++p == pe )
 		goto _test_eof336;
 case 336:
-#line 6971 "inc/vcf/validator_detail_v41.hpp"
+#line 6970 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st337;
 	goto tr442;
@@ -7029,7 +7028,7 @@ st341:
 	if ( ++p == pe )
 		goto _test_eof341;
 case 341:
-#line 7033 "inc/vcf/validator_detail_v41.hpp"
+#line 7032 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 59: goto tr455;
@@ -7051,7 +7050,7 @@ st342:
 	if ( ++p == pe )
 		goto _test_eof342;
 case 342:
-#line 7055 "inc/vcf/validator_detail_v41.hpp"
+#line 7054 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto tr458;
 	if ( (*p) < 48 ) {
@@ -7076,7 +7075,7 @@ st343:
 	if ( ++p == pe )
 		goto _test_eof343;
 case 343:
-#line 7080 "inc/vcf/validator_detail_v41.hpp"
+#line 7079 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 95 )
 		goto st343;
 	if ( (*p) < 48 ) {
@@ -7111,7 +7110,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 7115 "inc/vcf/validator_detail_v41.hpp"
+#line 7114 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr462;
 		case 95: goto tr461;
@@ -7138,7 +7137,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 7142 "inc/vcf/validator_detail_v41.hpp"
+#line 7141 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 34 )
 		goto st348;
 	if ( (*p) < 45 ) {
@@ -7170,7 +7169,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 7174 "inc/vcf/validator_detail_v41.hpp"
+#line 7173 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto tr456;
 		case 62: goto tr457;
@@ -7191,7 +7190,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 7195 "inc/vcf/validator_detail_v41.hpp"
+#line 7194 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7228,7 +7227,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 7232 "inc/vcf/validator_detail_v41.hpp"
+#line 7231 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 92: goto tr471;
@@ -7256,7 +7255,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 7260 "inc/vcf/validator_detail_v41.hpp"
+#line 7259 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 44: goto st342;
 		case 62: goto st347;
@@ -7282,7 +7281,7 @@ st351:
 	if ( ++p == pe )
 		goto _test_eof351;
 case 351:
-#line 7286 "inc/vcf/validator_detail_v41.hpp"
+#line 7285 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 92: goto tr471;
@@ -7304,7 +7303,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 7308 "inc/vcf/validator_detail_v41.hpp"
+#line 7307 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr475;
@@ -7344,7 +7343,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 7348 "inc/vcf/validator_detail_v41.hpp"
+#line 7347 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7395,7 +7394,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 7399 "inc/vcf/validator_detail_v41.hpp"
+#line 7398 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7446,7 +7445,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 7450 "inc/vcf/validator_detail_v41.hpp"
+#line 7449 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 47: goto tr469;
@@ -7489,7 +7488,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 7493 "inc/vcf/validator_detail_v41.hpp"
+#line 7492 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr483;
 		case 44: goto tr469;
@@ -7519,7 +7518,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 7523 "inc/vcf/validator_detail_v41.hpp"
+#line 7522 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr470;
 		case 44: goto tr486;
@@ -7559,7 +7558,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 7563 "inc/vcf/validator_detail_v41.hpp"
+#line 7562 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7589,7 +7588,7 @@ st359:
 	if ( ++p == pe )
 		goto _test_eof359;
 case 359:
-#line 7593 "inc/vcf/validator_detail_v41.hpp"
+#line 7592 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr474;
 		case 44: goto tr486;
@@ -7609,7 +7608,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 7613 "inc/vcf/validator_detail_v41.hpp"
+#line 7612 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 34: goto tr467;
 		case 44: goto tr489;
@@ -7633,7 +7632,7 @@ st361:
 	if ( ++p == pe )
 		goto _test_eof361;
 case 361:
-#line 7637 "inc/vcf/validator_detail_v41.hpp"
+#line 7636 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr492;
@@ -7651,7 +7650,7 @@ st362:
 	if ( ++p == pe )
 		goto _test_eof362;
 case 362:
-#line 7655 "inc/vcf/validator_detail_v41.hpp"
+#line 7654 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr493;
@@ -7669,7 +7668,7 @@ st363:
 	if ( ++p == pe )
 		goto _test_eof363;
 case 363:
-#line 7673 "inc/vcf/validator_detail_v41.hpp"
+#line 7672 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr494;
@@ -7687,7 +7686,7 @@ st364:
 	if ( ++p == pe )
 		goto _test_eof364;
 case 364:
-#line 7691 "inc/vcf/validator_detail_v41.hpp"
+#line 7690 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr495;
@@ -7705,7 +7704,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 7709 "inc/vcf/validator_detail_v41.hpp"
+#line 7708 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr496;
@@ -7723,7 +7722,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 7727 "inc/vcf/validator_detail_v41.hpp"
+#line 7726 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr497;
@@ -7741,7 +7740,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 7745 "inc/vcf/validator_detail_v41.hpp"
+#line 7744 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr498;
@@ -7759,7 +7758,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 7763 "inc/vcf/validator_detail_v41.hpp"
+#line 7762 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr499;
@@ -7777,7 +7776,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 7781 "inc/vcf/validator_detail_v41.hpp"
+#line 7780 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st370;
@@ -7804,7 +7803,7 @@ st371:
 	if ( ++p == pe )
 		goto _test_eof371;
 case 371:
-#line 7808 "inc/vcf/validator_detail_v41.hpp"
+#line 7807 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto st372;
 	goto tr491;
@@ -7828,7 +7827,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 7832 "inc/vcf/validator_detail_v41.hpp"
+#line 7831 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7854,7 +7853,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 7858 "inc/vcf/validator_detail_v41.hpp"
+#line 7857 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr506;
@@ -7965,7 +7964,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 7969 "inc/vcf/validator_detail_v41.hpp"
+#line 7968 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr503;
 		case 13: goto tr520;
@@ -7986,7 +7985,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 7990 "inc/vcf/validator_detail_v41.hpp"
+#line 7989 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr522;
@@ -8021,7 +8020,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 8025 "inc/vcf/validator_detail_v41.hpp"
+#line 8024 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr520;
@@ -8121,7 +8120,7 @@ st398:
 	if ( ++p == pe )
 		goto _test_eof398;
 case 398:
-#line 8125 "inc/vcf/validator_detail_v41.hpp"
+#line 8124 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 80 )
 		goto st399;
 	goto tr526;
@@ -8156,7 +8155,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 8160 "inc/vcf/validator_detail_v41.hpp"
+#line 8159 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st403;
 	goto tr526;
@@ -8184,7 +8183,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 8188 "inc/vcf/validator_detail_v41.hpp"
+#line 8187 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 82 )
 		goto st406;
 	goto tr526;
@@ -8219,7 +8218,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 8223 "inc/vcf/validator_detail_v41.hpp"
+#line 8222 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 65 )
 		goto st410;
 	goto tr526;
@@ -8254,7 +8253,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 8258 "inc/vcf/validator_detail_v41.hpp"
+#line 8257 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 81 )
 		goto st414;
 	goto tr526;
@@ -8296,7 +8295,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 8300 "inc/vcf/validator_detail_v41.hpp"
+#line 8299 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st419;
 	goto tr526;
@@ -8352,7 +8351,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 8356 "inc/vcf/validator_detail_v41.hpp"
+#line 8355 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto st426;
 	goto tr526;
@@ -8397,7 +8396,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 8401 "inc/vcf/validator_detail_v41.hpp"
+#line 8400 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 70 )
 		goto st431;
 	goto tr566;
@@ -8463,7 +8462,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 8467 "inc/vcf/validator_detail_v41.hpp"
+#line 8466 "inc/vcf/validator_detail_v41.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr574;
 	goto tr566;
@@ -8487,7 +8486,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 8491 "inc/vcf/validator_detail_v41.hpp"
+#line 8490 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr575;
 		case 10: goto tr576;
@@ -8536,7 +8535,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 8540 "inc/vcf/validator_detail_v41.hpp"
+#line 8539 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr795;
 		case 13: goto tr796;
@@ -8587,7 +8586,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 8591 "inc/vcf/validator_detail_v41.hpp"
+#line 8590 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr799;
 		case 13: goto tr800;
@@ -8629,7 +8628,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 8633 "inc/vcf/validator_detail_v41.hpp"
+#line 8632 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st582;
 	goto st0;
@@ -8671,7 +8670,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 8675 "inc/vcf/validator_detail_v41.hpp"
+#line 8674 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr582;
 		case 59: goto tr583;
@@ -8714,7 +8713,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 8718 "inc/vcf/validator_detail_v41.hpp"
+#line 8717 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr585;
 	goto tr584;
@@ -8738,7 +8737,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 8742 "inc/vcf/validator_detail_v41.hpp"
+#line 8741 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr586;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8768,7 +8767,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 8772 "inc/vcf/validator_detail_v41.hpp"
+#line 8771 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr589;
@@ -8795,7 +8794,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 8799 "inc/vcf/validator_detail_v41.hpp"
+#line 8798 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr590;
 		case 59: goto tr592;
@@ -8821,7 +8820,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 8825 "inc/vcf/validator_detail_v41.hpp"
+#line 8824 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr594;
 		case 67: goto tr594;
@@ -8855,7 +8854,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 8859 "inc/vcf/validator_detail_v41.hpp"
+#line 8858 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr595;
 		case 65: goto tr596;
@@ -8888,7 +8887,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 8892 "inc/vcf/validator_detail_v41.hpp"
+#line 8891 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr599;
@@ -8927,7 +8926,7 @@ st448:
 	if ( ++p == pe )
 		goto _test_eof448;
 case 448:
-#line 8931 "inc/vcf/validator_detail_v41.hpp"
+#line 8930 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -8951,7 +8950,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 8955 "inc/vcf/validator_detail_v41.hpp"
+#line 8954 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr607;
 		case 45: goto tr607;
@@ -8976,7 +8975,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 8980 "inc/vcf/validator_detail_v41.hpp"
+#line 8979 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr613;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9002,7 +9001,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 9006 "inc/vcf/validator_detail_v41.hpp"
+#line 9005 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 46: goto tr615;
@@ -9030,7 +9029,7 @@ st452:
 	if ( ++p == pe )
 		goto _test_eof452;
 case 452:
-#line 9034 "inc/vcf/validator_detail_v41.hpp"
+#line 9033 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr619;
 		case 58: goto tr618;
@@ -9066,7 +9065,7 @@ st453:
 	if ( ++p == pe )
 		goto _test_eof453;
 case 453:
-#line 9070 "inc/vcf/validator_detail_v41.hpp"
+#line 9069 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto st453;
 	if ( (*p) < 65 ) {
@@ -9110,7 +9109,7 @@ st454:
 	if ( ++p == pe )
 		goto _test_eof454;
 case 454:
-#line 9114 "inc/vcf/validator_detail_v41.hpp"
+#line 9113 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 59: goto tr624;
@@ -9136,7 +9135,7 @@ st455:
 	if ( ++p == pe )
 		goto _test_eof455;
 case 455:
-#line 9140 "inc/vcf/validator_detail_v41.hpp"
+#line 9139 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 46: goto tr627;
 		case 49: goto tr629;
@@ -9194,7 +9193,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 9198 "inc/vcf/validator_detail_v41.hpp"
+#line 9197 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr640;
 		case 60: goto tr640;
@@ -9240,7 +9239,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 9244 "inc/vcf/validator_detail_v41.hpp"
+#line 9243 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9275,7 +9274,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 9279 "inc/vcf/validator_detail_v41.hpp"
+#line 9278 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr643;
@@ -9305,7 +9304,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 9309 "inc/vcf/validator_detail_v41.hpp"
+#line 9308 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 58: goto tr646;
@@ -9337,7 +9336,7 @@ st459:
 	if ( ++p == pe )
 		goto _test_eof459;
 case 459:
-#line 9341 "inc/vcf/validator_detail_v41.hpp"
+#line 9340 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 46 )
 		goto tr649;
 	if ( (*p) < 48 ) {
@@ -9369,7 +9368,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 9373 "inc/vcf/validator_detail_v41.hpp"
+#line 9372 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9428,7 +9427,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 9432 "inc/vcf/validator_detail_v41.hpp"
+#line 9431 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr799;
 		case 13: goto tr800;
@@ -9457,7 +9456,7 @@ st460:
 	if ( ++p == pe )
 		goto _test_eof460;
 case 460:
-#line 9461 "inc/vcf/validator_detail_v41.hpp"
+#line 9460 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr651;
@@ -9487,7 +9486,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 9491 "inc/vcf/validator_detail_v41.hpp"
+#line 9490 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr652;
 		case 62: goto tr653;
@@ -9511,7 +9510,7 @@ st462:
 	if ( ++p == pe )
 		goto _test_eof462;
 case 462:
-#line 9515 "inc/vcf/validator_detail_v41.hpp"
+#line 9514 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr654;
 	goto tr581;
@@ -9564,7 +9563,7 @@ st463:
 	if ( ++p == pe )
 		goto _test_eof463;
 case 463:
-#line 9568 "inc/vcf/validator_detail_v41.hpp"
+#line 9567 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st585;
 	goto tr655;
@@ -9578,7 +9577,7 @@ st464:
 	if ( ++p == pe )
 		goto _test_eof464;
 case 464:
-#line 9582 "inc/vcf/validator_detail_v41.hpp"
+#line 9581 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr658;
@@ -9605,7 +9604,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 9609 "inc/vcf/validator_detail_v41.hpp"
+#line 9608 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9627,7 +9626,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 9631 "inc/vcf/validator_detail_v41.hpp"
+#line 9630 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9664,7 +9663,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 9668 "inc/vcf/validator_detail_v41.hpp"
+#line 9667 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr644;
 		case 10: goto tr802;
@@ -9692,7 +9691,7 @@ st465:
 	if ( ++p == pe )
 		goto _test_eof465;
 case 465:
-#line 9696 "inc/vcf/validator_detail_v41.hpp"
+#line 9695 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 49: goto tr629;
 		case 58: goto tr626;
@@ -9743,7 +9742,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 9747 "inc/vcf/validator_detail_v41.hpp"
+#line 9746 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9765,7 +9764,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 9769 "inc/vcf/validator_detail_v41.hpp"
+#line 9768 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9787,7 +9786,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 9791 "inc/vcf/validator_detail_v41.hpp"
+#line 9790 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9809,7 +9808,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 9813 "inc/vcf/validator_detail_v41.hpp"
+#line 9812 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9831,7 +9830,7 @@ st466:
 	if ( ++p == pe )
 		goto _test_eof466;
 case 466:
-#line 9835 "inc/vcf/validator_detail_v41.hpp"
+#line 9834 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr660;
@@ -9848,7 +9847,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 9852 "inc/vcf/validator_detail_v41.hpp"
+#line 9851 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9868,7 +9867,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 9872 "inc/vcf/validator_detail_v41.hpp"
+#line 9871 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9889,7 +9888,7 @@ st467:
 	if ( ++p == pe )
 		goto _test_eof467;
 case 467:
-#line 9893 "inc/vcf/validator_detail_v41.hpp"
+#line 9892 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr662;
 	goto tr661;
@@ -9903,7 +9902,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 9907 "inc/vcf/validator_detail_v41.hpp"
+#line 9906 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9925,7 +9924,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 9929 "inc/vcf/validator_detail_v41.hpp"
+#line 9928 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -9950,7 +9949,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 9954 "inc/vcf/validator_detail_v41.hpp"
+#line 9953 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr663;
 	if ( (*p) > 58 ) {
@@ -9969,7 +9968,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 9973 "inc/vcf/validator_detail_v41.hpp"
+#line 9972 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr665;
 	if ( (*p) < 45 ) {
@@ -9991,7 +9990,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 9995 "inc/vcf/validator_detail_v41.hpp"
+#line 9994 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10017,7 +10016,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10021 "inc/vcf/validator_detail_v41.hpp"
+#line 10020 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr666;
 	if ( (*p) > 58 ) {
@@ -10036,7 +10035,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 10040 "inc/vcf/validator_detail_v41.hpp"
+#line 10039 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr668;
 	goto tr667;
@@ -10050,7 +10049,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 10054 "inc/vcf/validator_detail_v41.hpp"
+#line 10053 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10071,7 +10070,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 10075 "inc/vcf/validator_detail_v41.hpp"
+#line 10074 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr669;
 	if ( (*p) > 58 ) {
@@ -10090,7 +10089,7 @@ st473:
 	if ( ++p == pe )
 		goto _test_eof473;
 case 473:
-#line 10094 "inc/vcf/validator_detail_v41.hpp"
+#line 10093 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr671;
 		case 45: goto tr671;
@@ -10110,7 +10109,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10114 "inc/vcf/validator_detail_v41.hpp"
+#line 10113 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr673;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10126,7 +10125,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 10130 "inc/vcf/validator_detail_v41.hpp"
+#line 10129 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10150,7 +10149,7 @@ st475:
 	if ( ++p == pe )
 		goto _test_eof475;
 case 475:
-#line 10154 "inc/vcf/validator_detail_v41.hpp"
+#line 10153 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr675;
 	goto tr670;
@@ -10164,7 +10163,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 10168 "inc/vcf/validator_detail_v41.hpp"
+#line 10167 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10187,7 +10186,7 @@ st476:
 	if ( ++p == pe )
 		goto _test_eof476;
 case 476:
-#line 10191 "inc/vcf/validator_detail_v41.hpp"
+#line 10190 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr676;
 		case 45: goto tr676;
@@ -10205,7 +10204,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 10209 "inc/vcf/validator_detail_v41.hpp"
+#line 10208 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr677;
 	goto tr670;
@@ -10219,7 +10218,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 10223 "inc/vcf/validator_detail_v41.hpp"
+#line 10222 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10240,7 +10239,7 @@ st478:
 	if ( ++p == pe )
 		goto _test_eof478;
 case 478:
-#line 10244 "inc/vcf/validator_detail_v41.hpp"
+#line 10243 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr678;
 	goto tr670;
@@ -10254,7 +10253,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 10258 "inc/vcf/validator_detail_v41.hpp"
+#line 10257 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr679;
 	goto tr670;
@@ -10268,7 +10267,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 10272 "inc/vcf/validator_detail_v41.hpp"
+#line 10271 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10287,7 +10286,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 10291 "inc/vcf/validator_detail_v41.hpp"
+#line 10290 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr680;
 	goto tr670;
@@ -10301,7 +10300,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10305 "inc/vcf/validator_detail_v41.hpp"
+#line 10304 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr679;
 	goto tr670;
@@ -10315,7 +10314,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 10319 "inc/vcf/validator_detail_v41.hpp"
+#line 10318 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr681;
 	if ( (*p) > 58 ) {
@@ -10334,7 +10333,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 10338 "inc/vcf/validator_detail_v41.hpp"
+#line 10337 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr683;
 	goto tr682;
@@ -10348,7 +10347,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 10352 "inc/vcf/validator_detail_v41.hpp"
+#line 10351 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10372,7 +10371,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 10376 "inc/vcf/validator_detail_v41.hpp"
+#line 10375 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10394,7 +10393,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10398 "inc/vcf/validator_detail_v41.hpp"
+#line 10397 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr684;
 	if ( (*p) > 58 ) {
@@ -10413,7 +10412,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10417 "inc/vcf/validator_detail_v41.hpp"
+#line 10416 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr686;
 		case 45: goto tr686;
@@ -10433,7 +10432,7 @@ st486:
 	if ( ++p == pe )
 		goto _test_eof486;
 case 486:
-#line 10437 "inc/vcf/validator_detail_v41.hpp"
+#line 10436 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr688;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -10449,7 +10448,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 10453 "inc/vcf/validator_detail_v41.hpp"
+#line 10452 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10472,7 +10471,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 10476 "inc/vcf/validator_detail_v41.hpp"
+#line 10475 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr690;
 	goto tr685;
@@ -10486,7 +10485,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 10490 "inc/vcf/validator_detail_v41.hpp"
+#line 10489 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10508,7 +10507,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 10512 "inc/vcf/validator_detail_v41.hpp"
+#line 10511 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr691;
 		case 45: goto tr691;
@@ -10526,7 +10525,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 10530 "inc/vcf/validator_detail_v41.hpp"
+#line 10529 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr692;
 	goto tr685;
@@ -10540,7 +10539,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 10544 "inc/vcf/validator_detail_v41.hpp"
+#line 10543 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10560,7 +10559,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10564 "inc/vcf/validator_detail_v41.hpp"
+#line 10563 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr693;
 	goto tr685;
@@ -10574,7 +10573,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 10578 "inc/vcf/validator_detail_v41.hpp"
+#line 10577 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr694;
 	goto tr685;
@@ -10588,7 +10587,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 10592 "inc/vcf/validator_detail_v41.hpp"
+#line 10591 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10606,7 +10605,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 10610 "inc/vcf/validator_detail_v41.hpp"
+#line 10609 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr695;
 	goto tr685;
@@ -10620,7 +10619,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 10624 "inc/vcf/validator_detail_v41.hpp"
+#line 10623 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr694;
 	goto tr685;
@@ -10638,7 +10637,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 10642 "inc/vcf/validator_detail_v41.hpp"
+#line 10641 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10660,7 +10659,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 10664 "inc/vcf/validator_detail_v41.hpp"
+#line 10663 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10682,7 +10681,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 10686 "inc/vcf/validator_detail_v41.hpp"
+#line 10685 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10704,7 +10703,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 10708 "inc/vcf/validator_detail_v41.hpp"
+#line 10707 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10726,7 +10725,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 10730 "inc/vcf/validator_detail_v41.hpp"
+#line 10729 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr696;
 	if ( (*p) > 58 ) {
@@ -10745,7 +10744,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 10749 "inc/vcf/validator_detail_v41.hpp"
+#line 10748 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr698;
 	goto tr697;
@@ -10759,7 +10758,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 10763 "inc/vcf/validator_detail_v41.hpp"
+#line 10762 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 68: goto tr699;
 		case 80: goto tr699;
@@ -10785,7 +10784,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 10789 "inc/vcf/validator_detail_v41.hpp"
+#line 10788 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10810,7 +10809,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 10814 "inc/vcf/validator_detail_v41.hpp"
+#line 10813 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10833,7 +10832,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 10837 "inc/vcf/validator_detail_v41.hpp"
+#line 10836 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10854,7 +10853,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10858 "inc/vcf/validator_detail_v41.hpp"
+#line 10857 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr701;
 	goto tr700;
@@ -10868,7 +10867,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 10872 "inc/vcf/validator_detail_v41.hpp"
+#line 10871 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10886,7 +10885,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 10890 "inc/vcf/validator_detail_v41.hpp"
+#line 10889 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr702;
 	if ( (*p) > 58 ) {
@@ -10905,7 +10904,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 10909 "inc/vcf/validator_detail_v41.hpp"
+#line 10908 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr704;
 	goto tr703;
@@ -10919,7 +10918,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 10923 "inc/vcf/validator_detail_v41.hpp"
+#line 10922 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10943,7 +10942,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 10947 "inc/vcf/validator_detail_v41.hpp"
+#line 10946 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10965,7 +10964,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 10969 "inc/vcf/validator_detail_v41.hpp"
+#line 10968 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -10987,7 +10986,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 10991 "inc/vcf/validator_detail_v41.hpp"
+#line 10990 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr705;
 	if ( (*p) > 58 ) {
@@ -11006,7 +11005,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 11010 "inc/vcf/validator_detail_v41.hpp"
+#line 11009 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr707;
 	goto tr706;
@@ -11020,7 +11019,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 11024 "inc/vcf/validator_detail_v41.hpp"
+#line 11023 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11044,7 +11043,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 11048 "inc/vcf/validator_detail_v41.hpp"
+#line 11047 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11067,7 +11066,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 11071 "inc/vcf/validator_detail_v41.hpp"
+#line 11070 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11088,7 +11087,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 11092 "inc/vcf/validator_detail_v41.hpp"
+#line 11091 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr709;
 	goto tr708;
@@ -11102,7 +11101,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 11106 "inc/vcf/validator_detail_v41.hpp"
+#line 11105 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11120,7 +11119,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 11124 "inc/vcf/validator_detail_v41.hpp"
+#line 11123 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11141,7 +11140,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11145 "inc/vcf/validator_detail_v41.hpp"
+#line 11144 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr711;
 	goto tr710;
@@ -11155,7 +11154,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 11159 "inc/vcf/validator_detail_v41.hpp"
+#line 11158 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11177,7 +11176,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 11181 "inc/vcf/validator_detail_v41.hpp"
+#line 11180 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11199,7 +11198,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11203 "inc/vcf/validator_detail_v41.hpp"
+#line 11202 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 48: goto tr712;
 		case 61: goto tr713;
@@ -11220,7 +11219,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11224 "inc/vcf/validator_detail_v41.hpp"
+#line 11223 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr714;
 	if ( (*p) > 58 ) {
@@ -11239,7 +11238,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11243 "inc/vcf/validator_detail_v41.hpp"
+#line 11242 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr716;
 	goto tr715;
@@ -11253,7 +11252,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 11257 "inc/vcf/validator_detail_v41.hpp"
+#line 11256 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11273,7 +11272,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11277 "inc/vcf/validator_detail_v41.hpp"
+#line 11276 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr718;
 		case 45: goto tr718;
@@ -11293,7 +11292,7 @@ st508:
 	if ( ++p == pe )
 		goto _test_eof508;
 case 508:
-#line 11297 "inc/vcf/validator_detail_v41.hpp"
+#line 11296 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr720;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11309,7 +11308,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 11313 "inc/vcf/validator_detail_v41.hpp"
+#line 11312 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11332,7 +11331,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11336 "inc/vcf/validator_detail_v41.hpp"
+#line 11335 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr722;
 	goto tr717;
@@ -11346,7 +11345,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 11350 "inc/vcf/validator_detail_v41.hpp"
+#line 11349 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11368,7 +11367,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 11372 "inc/vcf/validator_detail_v41.hpp"
+#line 11371 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr723;
 		case 45: goto tr723;
@@ -11386,7 +11385,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11390 "inc/vcf/validator_detail_v41.hpp"
+#line 11389 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr724;
 	goto tr717;
@@ -11400,7 +11399,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 11404 "inc/vcf/validator_detail_v41.hpp"
+#line 11403 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11420,7 +11419,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11424 "inc/vcf/validator_detail_v41.hpp"
+#line 11423 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr725;
 	goto tr717;
@@ -11434,7 +11433,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11438 "inc/vcf/validator_detail_v41.hpp"
+#line 11437 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr726;
 	goto tr717;
@@ -11448,7 +11447,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 11452 "inc/vcf/validator_detail_v41.hpp"
+#line 11451 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11466,7 +11465,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11470 "inc/vcf/validator_detail_v41.hpp"
+#line 11469 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr727;
 	goto tr717;
@@ -11480,7 +11479,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11484 "inc/vcf/validator_detail_v41.hpp"
+#line 11483 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr726;
 	goto tr717;
@@ -11498,7 +11497,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 11502 "inc/vcf/validator_detail_v41.hpp"
+#line 11501 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11520,7 +11519,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11524 "inc/vcf/validator_detail_v41.hpp"
+#line 11523 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr728;
 	if ( (*p) > 58 ) {
@@ -11539,7 +11538,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11543 "inc/vcf/validator_detail_v41.hpp"
+#line 11542 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr730;
 	goto tr729;
@@ -11553,7 +11552,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 11557 "inc/vcf/validator_detail_v41.hpp"
+#line 11556 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11577,7 +11576,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 11581 "inc/vcf/validator_detail_v41.hpp"
+#line 11580 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11600,7 +11599,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11604 "inc/vcf/validator_detail_v41.hpp"
+#line 11603 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr731;
 	if ( (*p) > 58 ) {
@@ -11619,7 +11618,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11623 "inc/vcf/validator_detail_v41.hpp"
+#line 11622 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr733;
 		case 45: goto tr733;
@@ -11639,7 +11638,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11643 "inc/vcf/validator_detail_v41.hpp"
+#line 11642 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 73 )
 		goto tr735;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11655,7 +11654,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 11659 "inc/vcf/validator_detail_v41.hpp"
+#line 11658 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11678,7 +11677,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11682 "inc/vcf/validator_detail_v41.hpp"
+#line 11681 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr737;
 	goto tr732;
@@ -11692,7 +11691,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 11696 "inc/vcf/validator_detail_v41.hpp"
+#line 11695 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11714,7 +11713,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11718 "inc/vcf/validator_detail_v41.hpp"
+#line 11717 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr738;
 		case 45: goto tr738;
@@ -11732,7 +11731,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11736 "inc/vcf/validator_detail_v41.hpp"
+#line 11735 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr739;
 	goto tr732;
@@ -11746,7 +11745,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 11750 "inc/vcf/validator_detail_v41.hpp"
+#line 11749 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11766,7 +11765,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11770 "inc/vcf/validator_detail_v41.hpp"
+#line 11769 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr740;
 	goto tr732;
@@ -11780,7 +11779,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11784 "inc/vcf/validator_detail_v41.hpp"
+#line 11783 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr741;
 	goto tr732;
@@ -11794,7 +11793,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 11798 "inc/vcf/validator_detail_v41.hpp"
+#line 11797 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11812,7 +11811,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11816 "inc/vcf/validator_detail_v41.hpp"
+#line 11815 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr742;
 	goto tr732;
@@ -11826,7 +11825,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11830 "inc/vcf/validator_detail_v41.hpp"
+#line 11829 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr741;
 	goto tr732;
@@ -11840,7 +11839,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 11844 "inc/vcf/validator_detail_v41.hpp"
+#line 11843 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11862,7 +11861,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 11866 "inc/vcf/validator_detail_v41.hpp"
+#line 11865 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11884,7 +11883,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 11888 "inc/vcf/validator_detail_v41.hpp"
+#line 11887 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11906,7 +11905,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 11910 "inc/vcf/validator_detail_v41.hpp"
+#line 11909 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11928,7 +11927,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 11932 "inc/vcf/validator_detail_v41.hpp"
+#line 11931 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11950,7 +11949,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 11954 "inc/vcf/validator_detail_v41.hpp"
+#line 11953 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -11971,7 +11970,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11975 "inc/vcf/validator_detail_v41.hpp"
+#line 11974 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr744;
 	goto tr743;
@@ -11985,7 +11984,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 11989 "inc/vcf/validator_detail_v41.hpp"
+#line 11988 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12007,7 +12006,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 12011 "inc/vcf/validator_detail_v41.hpp"
+#line 12010 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12029,7 +12028,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 12033 "inc/vcf/validator_detail_v41.hpp"
+#line 12032 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12051,7 +12050,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 12055 "inc/vcf/validator_detail_v41.hpp"
+#line 12054 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12073,7 +12072,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 12077 "inc/vcf/validator_detail_v41.hpp"
+#line 12076 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12095,7 +12094,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 12099 "inc/vcf/validator_detail_v41.hpp"
+#line 12098 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12117,7 +12116,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 12121 "inc/vcf/validator_detail_v41.hpp"
+#line 12120 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12139,7 +12138,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 12143 "inc/vcf/validator_detail_v41.hpp"
+#line 12142 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12161,7 +12160,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 12165 "inc/vcf/validator_detail_v41.hpp"
+#line 12164 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12183,7 +12182,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 12187 "inc/vcf/validator_detail_v41.hpp"
+#line 12186 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12204,7 +12203,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 12208 "inc/vcf/validator_detail_v41.hpp"
+#line 12207 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr746;
 	goto tr745;
@@ -12218,7 +12217,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 12222 "inc/vcf/validator_detail_v41.hpp"
+#line 12221 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12240,7 +12239,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 12244 "inc/vcf/validator_detail_v41.hpp"
+#line 12243 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr801;
 		case 10: goto tr802;
@@ -12279,7 +12278,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 12283 "inc/vcf/validator_detail_v41.hpp"
+#line 12282 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr618;
 	if ( (*p) < 65 ) {
@@ -12317,7 +12316,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 12321 "inc/vcf/validator_detail_v41.hpp"
+#line 12320 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr623;
 		case 58: goto st453;
@@ -12353,7 +12352,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 12357 "inc/vcf/validator_detail_v41.hpp"
+#line 12356 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr747;
 	goto tr606;
@@ -12367,7 +12366,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 12371 "inc/vcf/validator_detail_v41.hpp"
+#line 12370 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr614;
 		case 69: goto tr616;
@@ -12386,7 +12385,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 12390 "inc/vcf/validator_detail_v41.hpp"
+#line 12389 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 43: goto tr748;
 		case 45: goto tr748;
@@ -12404,7 +12403,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 12408 "inc/vcf/validator_detail_v41.hpp"
+#line 12407 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr749;
 	goto tr606;
@@ -12418,7 +12417,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12422 "inc/vcf/validator_detail_v41.hpp"
+#line 12421 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12444,7 +12443,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12448 "inc/vcf/validator_detail_v41.hpp"
+#line 12447 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 110 )
 		goto tr750;
 	goto tr606;
@@ -12458,7 +12457,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12462 "inc/vcf/validator_detail_v41.hpp"
+#line 12461 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 102 )
 		goto tr751;
 	goto tr606;
@@ -12482,7 +12481,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12486 "inc/vcf/validator_detail_v41.hpp"
+#line 12485 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 9 )
 		goto tr614;
 	goto tr606;
@@ -12500,7 +12499,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12504 "inc/vcf/validator_detail_v41.hpp"
+#line 12503 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 97 )
 		goto tr752;
 	goto tr606;
@@ -12514,7 +12513,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12518 "inc/vcf/validator_detail_v41.hpp"
+#line 12517 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 78 )
 		goto tr751;
 	goto tr606;
@@ -12528,7 +12527,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12532 "inc/vcf/validator_detail_v41.hpp"
+#line 12531 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 42: goto tr598;
 		case 46: goto tr753;
@@ -12567,7 +12566,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12571 "inc/vcf/validator_detail_v41.hpp"
+#line 12570 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 65: goto tr754;
 		case 67: goto tr754;
@@ -12591,7 +12590,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12595 "inc/vcf/validator_detail_v41.hpp"
+#line 12594 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12627,7 +12626,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12631 "inc/vcf/validator_detail_v41.hpp"
+#line 12630 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 61 )
 		goto tr755;
 	if ( (*p) < 63 ) {
@@ -12667,7 +12666,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12671 "inc/vcf/validator_detail_v41.hpp"
+#line 12670 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 62 )
 		goto tr757;
 	if ( (*p) < 45 ) {
@@ -12699,7 +12698,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12703 "inc/vcf/validator_detail_v41.hpp"
+#line 12702 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 44: goto tr605;
@@ -12728,7 +12727,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12732 "inc/vcf/validator_detail_v41.hpp"
+#line 12731 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr762;
 	if ( (*p) < 65 ) {
@@ -12750,7 +12749,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12754 "inc/vcf/validator_detail_v41.hpp"
+#line 12753 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr763;
 		case 61: goto tr761;
@@ -12774,7 +12773,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12778 "inc/vcf/validator_detail_v41.hpp"
+#line 12777 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr764;
 	goto tr597;
@@ -12788,7 +12787,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12792 "inc/vcf/validator_detail_v41.hpp"
+#line 12791 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr757;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12804,7 +12803,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12808 "inc/vcf/validator_detail_v41.hpp"
+#line 12807 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr765;
@@ -12824,7 +12823,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12828 "inc/vcf/validator_detail_v41.hpp"
+#line 12827 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr765;
 		case 62: goto tr766;
@@ -12848,7 +12847,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12852 "inc/vcf/validator_detail_v41.hpp"
+#line 12851 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr763;
 	goto tr597;
@@ -12862,7 +12861,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12866 "inc/vcf/validator_detail_v41.hpp"
+#line 12865 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr768;
 	if ( (*p) < 65 ) {
@@ -12884,7 +12883,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12888 "inc/vcf/validator_detail_v41.hpp"
+#line 12887 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr769;
 		case 61: goto tr767;
@@ -12908,7 +12907,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12912 "inc/vcf/validator_detail_v41.hpp"
+#line 12911 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr770;
 	goto tr597;
@@ -12922,7 +12921,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12926 "inc/vcf/validator_detail_v41.hpp"
+#line 12925 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr757;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12938,7 +12937,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12942 "inc/vcf/validator_detail_v41.hpp"
+#line 12941 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr771;
@@ -12958,7 +12957,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 12962 "inc/vcf/validator_detail_v41.hpp"
+#line 12961 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr771;
 		case 62: goto tr772;
@@ -12982,7 +12981,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 12986 "inc/vcf/validator_detail_v41.hpp"
+#line 12985 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr769;
 	goto tr597;
@@ -13000,7 +12999,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 13004 "inc/vcf/validator_detail_v41.hpp"
+#line 13003 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr774;
 	if ( (*p) < 65 ) {
@@ -13022,7 +13021,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 13026 "inc/vcf/validator_detail_v41.hpp"
+#line 13025 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr775;
 		case 61: goto tr773;
@@ -13046,7 +13045,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 13050 "inc/vcf/validator_detail_v41.hpp"
+#line 13049 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr776;
 	goto tr597;
@@ -13060,7 +13059,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 13064 "inc/vcf/validator_detail_v41.hpp"
+#line 13063 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 91 )
 		goto tr777;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13076,7 +13075,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 13080 "inc/vcf/validator_detail_v41.hpp"
+#line 13079 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr778;
@@ -13096,7 +13095,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 13100 "inc/vcf/validator_detail_v41.hpp"
+#line 13099 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr778;
 		case 62: goto tr779;
@@ -13120,7 +13119,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 13124 "inc/vcf/validator_detail_v41.hpp"
+#line 13123 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr775;
 	goto tr597;
@@ -13138,7 +13137,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 13142 "inc/vcf/validator_detail_v41.hpp"
+#line 13141 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 60 )
 		goto tr781;
 	if ( (*p) < 65 ) {
@@ -13160,7 +13159,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 13164 "inc/vcf/validator_detail_v41.hpp"
+#line 13163 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 58: goto tr782;
 		case 61: goto tr780;
@@ -13184,7 +13183,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 13188 "inc/vcf/validator_detail_v41.hpp"
+#line 13187 "inc/vcf/validator_detail_v41.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr783;
 	goto tr597;
@@ -13198,7 +13197,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 13202 "inc/vcf/validator_detail_v41.hpp"
+#line 13201 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 93 )
 		goto tr777;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13214,7 +13213,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 13218 "inc/vcf/validator_detail_v41.hpp"
+#line 13217 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr784;
@@ -13234,7 +13233,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 13238 "inc/vcf/validator_detail_v41.hpp"
+#line 13237 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 59: goto tr784;
 		case 62: goto tr785;
@@ -13258,7 +13257,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 13262 "inc/vcf/validator_detail_v41.hpp"
+#line 13261 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 58 )
 		goto tr782;
 	goto tr597;
@@ -13276,7 +13275,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 13280 "inc/vcf/validator_detail_v41.hpp"
+#line 13279 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 9: goto tr604;
 		case 65: goto tr754;
@@ -13331,7 +13330,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 13335 "inc/vcf/validator_detail_v41.hpp"
+#line 13334 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st581;
 	goto tr566;
@@ -13360,7 +13359,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 13364 "inc/vcf/validator_detail_v41.hpp"
+#line 13363 "inc/vcf/validator_detail_v41.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -13380,7 +13379,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 13384 "inc/vcf/validator_detail_v41.hpp"
+#line 13383 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr789;
 		case 13: goto tr790;
@@ -13397,14 +13396,14 @@ tr789:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 822 "src/vcf/vcf_v41.ragel"
+#line 821 "src/vcf/vcf_v41.ragel"
 	{ {goto st28;} }
 	goto st657;
 st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 13408 "inc/vcf/validator_detail_v41.hpp"
+#line 13407 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 tr793:
 #line 43 "src/vcf/vcf_v41.ragel"
@@ -13422,7 +13421,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 13426 "inc/vcf/validator_detail_v41.hpp"
+#line 13425 "inc/vcf/validator_detail_v41.hpp"
 	switch( (*p) ) {
 		case 10: goto tr792;
 		case 13: goto tr793;
@@ -13439,14 +13438,14 @@ tr792:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 823 "src/vcf/vcf_v41.ragel"
+#line 822 "src/vcf/vcf_v41.ragel"
 	{ {goto st585;} }
 	goto st658;
 st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 13450 "inc/vcf/validator_detail_v41.hpp"
+#line 13449 "inc/vcf/validator_detail_v41.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -14237,8 +14236,7 @@ case 658:
 #line 227 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         p--; {goto st579;}
     }
 #line 60 "src/vcf/vcf_v41.ragel"
@@ -14268,7 +14266,7 @@ case 658:
 	case 95: 
 	case 96: 
 	case 100: 
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -14287,7 +14285,7 @@ case 658:
 	case 308: 
 	case 309: 
 	case 310: 
-#line 247 "src/vcf/vcf_v41.ragel"
+#line 246 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -14327,7 +14325,7 @@ case 658:
 	case 358: 
 	case 359: 
 	case 360: 
-#line 253 "src/vcf/vcf_v41.ragel"
+#line 252 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -14361,7 +14359,7 @@ case 658:
 	case 128: 
 	case 129: 
 	case 133: 
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -14407,7 +14405,7 @@ case 658:
 	case 176: 
 	case 177: 
 	case 181: 
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14452,7 +14450,7 @@ case 658:
 	case 224: 
 	case 225: 
 	case 229: 
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -14473,7 +14471,7 @@ case 658:
 	case 241: 
 	case 242: 
 	case 249: 
-#line 297 "src/vcf/vcf_v41.ragel"
+#line 296 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -14495,7 +14493,7 @@ case 658:
 	case 369: 
 	case 370: 
 	case 371: 
-#line 303 "src/vcf/vcf_v41.ragel"
+#line 302 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -14517,7 +14515,7 @@ case 658:
 	case 258: 
 	case 259: 
 	case 299: 
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -14565,7 +14563,7 @@ case 658:
 	case 427: 
 	case 428: 
 	case 429: 
-#line 341 "src/vcf/vcf_v41.ragel"
+#line 340 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14597,7 +14595,7 @@ case 658:
 	case 460: 
 	case 461: 
 	case 462: 
-#line 358 "src/vcf/vcf_v41.ragel"
+#line 357 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st580;}
@@ -14610,7 +14608,7 @@ case 658:
 	break;
 	case 441: 
 	case 442: 
-#line 364 "src/vcf/vcf_v41.ragel"
+#line 363 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st580;}
@@ -14623,7 +14621,7 @@ case 658:
 	break;
 	case 443: 
 	case 444: 
-#line 370 "src/vcf/vcf_v41.ragel"
+#line 369 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st580;}
@@ -14636,7 +14634,7 @@ case 658:
 	break;
 	case 445: 
 	case 446: 
-#line 376 "src/vcf/vcf_v41.ragel"
+#line 375 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st580;}
@@ -14684,7 +14682,7 @@ case 658:
 	case 574: 
 	case 575: 
 	case 576: 
-#line 382 "src/vcf/vcf_v41.ragel"
+#line 381 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st580;}
@@ -14708,7 +14706,7 @@ case 658:
 	case 539: 
 	case 540: 
 	case 541: 
-#line 388 "src/vcf/vcf_v41.ragel"
+#line 387 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st580;}
@@ -14724,7 +14722,7 @@ case 658:
 	case 454: 
 	case 530: 
 	case 531: 
-#line 394 "src/vcf/vcf_v41.ragel"
+#line 393 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st580;}
@@ -14737,7 +14735,7 @@ case 658:
 	break;
 	case 457: 
 	case 458: 
-#line 560 "src/vcf/vcf_v41.ragel"
+#line 559 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st580;}
@@ -14749,7 +14747,7 @@ case 658:
     }
 	break;
 	case 464: 
-#line 566 "src/vcf/vcf_v41.ragel"
+#line 565 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -14876,7 +14874,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 341 "src/vcf/vcf_v41.ragel"
+#line 340 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -14907,13 +14905,13 @@ case 658:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 240 "src/vcf/vcf_v41.ragel"
+#line 239 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st579;}
     }
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -14925,12 +14923,12 @@ case 658:
     }
 	break;
 	case 104: 
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14944,12 +14942,12 @@ case 658:
 	case 156: 
 	case 157: 
 	case 185: 
-#line 270 "src/vcf/vcf_v41.ragel"
+#line 269 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14963,12 +14961,12 @@ case 658:
 	case 204: 
 	case 205: 
 	case 233: 
-#line 286 "src/vcf/vcf_v41.ragel"
+#line 285 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, G or dot"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -14981,12 +14979,12 @@ case 658:
 	break;
 	case 163: 
 	case 164: 
-#line 291 "src/vcf/vcf_v41.ragel"
+#line 290 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -14999,12 +14997,12 @@ case 658:
 	break;
 	case 211: 
 	case 212: 
-#line 291 "src/vcf/vcf_v41.ragel"
+#line 290 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -15024,12 +15022,12 @@ case 658:
 	case 269: 
 	case 270: 
 	case 271: 
-#line 314 "src/vcf/vcf_v41.ragel"
+#line 313 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15049,12 +15047,12 @@ case 658:
 	case 279: 
 	case 280: 
 	case 281: 
-#line 319 "src/vcf/vcf_v41.ragel"
+#line 318 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15067,12 +15065,12 @@ case 658:
 	break;
 	case 340: 
 	case 341: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 253 "src/vcf/vcf_v41.ragel"
+#line 252 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
@@ -15086,12 +15084,12 @@ case 658:
 	case 114: 
 	case 115: 
 	case 116: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -15105,12 +15103,12 @@ case 658:
 	case 146: 
 	case 147: 
 	case 148: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -15124,12 +15122,12 @@ case 658:
 	case 194: 
 	case 195: 
 	case 196: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -15146,12 +15144,12 @@ case 658:
 	case 246: 
 	case 247: 
 	case 248: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 297 "src/vcf/vcf_v41.ragel"
+#line 296 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
@@ -15164,12 +15162,12 @@ case 658:
 	break;
 	case 260: 
 	case 261: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15186,12 +15184,12 @@ case 658:
 	case 101: 
 	case 102: 
 	case 103: 
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
@@ -15208,12 +15206,12 @@ case 658:
 	case 134: 
 	case 135: 
 	case 136: 
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
@@ -15230,12 +15228,12 @@ case 658:
 	case 182: 
 	case 183: 
 	case 184: 
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
@@ -15252,12 +15250,12 @@ case 658:
 	case 230: 
 	case 231: 
 	case 232: 
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
@@ -15287,12 +15285,12 @@ case 658:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15322,12 +15320,12 @@ case 658:
 	case 327: 
 	case 328: 
 	case 329: 
-#line 335 "src/vcf/vcf_v41.ragel"
+#line 334 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 247 "src/vcf/vcf_v41.ragel"
+#line 246 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
@@ -15359,12 +15357,12 @@ case 658:
 	case 390: 
 	case 391: 
 	case 392: 
-#line 335 "src/vcf/vcf_v41.ragel"
+#line 334 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st579;}
     }
-#line 303 "src/vcf/vcf_v41.ragel"
+#line 302 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -15390,12 +15388,12 @@ case 658:
 	case 505: 
 	case 516: 
 	case 518: 
-#line 405 "src/vcf/vcf_v41.ragel"
+#line 404 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15407,12 +15405,12 @@ case 658:
     }
 	break;
 	case 466: 
-#line 410 "src/vcf/vcf_v41.ragel"
+#line 409 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15424,7 +15422,7 @@ case 658:
     }
 	break;
 	case 469: 
-#line 415 "src/vcf/vcf_v41.ragel"
+#line 414 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15432,7 +15430,7 @@ case 658:
                 "AA"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15444,7 +15442,7 @@ case 658:
     }
 	break;
 	case 471: 
-#line 423 "src/vcf/vcf_v41.ragel"
+#line 422 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15452,7 +15450,7 @@ case 658:
                 "AC"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15472,7 +15470,7 @@ case 658:
 	case 479: 
 	case 480: 
 	case 481: 
-#line 431 "src/vcf/vcf_v41.ragel"
+#line 430 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15480,7 +15478,7 @@ case 658:
                 "AF"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15492,7 +15490,7 @@ case 658:
     }
 	break;
 	case 483: 
-#line 439 "src/vcf/vcf_v41.ragel"
+#line 438 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15500,7 +15498,7 @@ case 658:
                 "AN"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15520,7 +15518,7 @@ case 658:
 	case 491: 
 	case 492: 
 	case 493: 
-#line 447 "src/vcf/vcf_v41.ragel"
+#line 446 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15528,7 +15526,7 @@ case 658:
                 "BQ"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15541,7 +15539,7 @@ case 658:
 	break;
 	case 495: 
 	case 496: 
-#line 455 "src/vcf/vcf_v41.ragel"
+#line 454 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15549,7 +15547,7 @@ case 658:
                 "CIGAR"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15561,7 +15559,7 @@ case 658:
     }
 	break;
 	case 497: 
-#line 463 "src/vcf/vcf_v41.ragel"
+#line 462 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15569,7 +15567,7 @@ case 658:
                 "DB"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15581,7 +15579,7 @@ case 658:
     }
 	break;
 	case 499: 
-#line 471 "src/vcf/vcf_v41.ragel"
+#line 470 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15589,7 +15587,7 @@ case 658:
                 "DP"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15601,7 +15599,7 @@ case 658:
     }
 	break;
 	case 501: 
-#line 479 "src/vcf/vcf_v41.ragel"
+#line 478 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15609,7 +15607,7 @@ case 658:
                 "END"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15621,7 +15619,7 @@ case 658:
     }
 	break;
 	case 502: 
-#line 487 "src/vcf/vcf_v41.ragel"
+#line 486 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15629,7 +15627,7 @@ case 658:
                 "H2"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15641,7 +15639,7 @@ case 658:
     }
 	break;
 	case 503: 
-#line 495 "src/vcf/vcf_v41.ragel"
+#line 494 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15649,7 +15647,7 @@ case 658:
                 "H3"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15669,7 +15667,7 @@ case 658:
 	case 513: 
 	case 514: 
 	case 515: 
-#line 503 "src/vcf/vcf_v41.ragel"
+#line 502 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15677,7 +15675,7 @@ case 658:
                 "MQ"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15689,7 +15687,7 @@ case 658:
     }
 	break;
 	case 506: 
-#line 511 "src/vcf/vcf_v41.ragel"
+#line 510 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15697,7 +15695,7 @@ case 658:
                 "MQ0"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15709,7 +15707,7 @@ case 658:
     }
 	break;
 	case 517: 
-#line 519 "src/vcf/vcf_v41.ragel"
+#line 518 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15717,7 +15715,7 @@ case 658:
                 "NS"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15737,7 +15735,7 @@ case 658:
 	case 525: 
 	case 526: 
 	case 527: 
-#line 527 "src/vcf/vcf_v41.ragel"
+#line 526 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15745,7 +15743,7 @@ case 658:
                 "SB"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15757,7 +15755,7 @@ case 658:
     }
 	break;
 	case 528: 
-#line 535 "src/vcf/vcf_v41.ragel"
+#line 534 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15765,7 +15763,7 @@ case 658:
                 "SOMATIC"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15777,7 +15775,7 @@ case 658:
     }
 	break;
 	case 529: 
-#line 543 "src/vcf/vcf_v41.ragel"
+#line 542 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15785,7 +15783,7 @@ case 658:
                 "VALIDATED"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15797,7 +15795,7 @@ case 658:
     }
 	break;
 	case 467: 
-#line 551 "src/vcf/vcf_v41.ragel"
+#line 550 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -15805,7 +15803,7 @@ case 658:
                 "1000G"});
         p--; {goto st580;}
     }
-#line 400 "src/vcf/vcf_v41.ragel"
+#line 399 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st580;}
@@ -15817,14 +15815,14 @@ case 658:
     }
 	break;
 	case 459: 
-#line 573 "src/vcf/vcf_v41.ragel"
+#line 572 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st580;}
     }
-#line 566 "src/vcf/vcf_v41.ragel"
+#line 565 "src/vcf/vcf_v41.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -15848,7 +15846,7 @@ case 658:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st579;}
     }
-#line 341 "src/vcf/vcf_v41.ragel"
+#line 340 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -15877,17 +15875,17 @@ case 658:
     }
 	break;
 	case 272: 
-#line 314 "src/vcf/vcf_v41.ragel"
+#line 313 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 319 "src/vcf/vcf_v41.ragel"
+#line 318 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15899,17 +15897,17 @@ case 658:
     }
 	break;
 	case 282: 
-#line 319 "src/vcf/vcf_v41.ragel"
+#line 318 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 330 "src/vcf/vcf_v41.ragel"
+#line 329 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15921,17 +15919,17 @@ case 658:
     }
 	break;
 	case 262: 
-#line 325 "src/vcf/vcf_v41.ragel"
+#line 324 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st579;}
     }
-#line 314 "src/vcf/vcf_v41.ragel"
+#line 313 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
@@ -15943,47 +15941,47 @@ case 658:
     }
 	break;
 	case 24: 
-#line 235 "src/vcf/vcf_v41.ragel"
+#line 234 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st579;}
     }
-#line 259 "src/vcf/vcf_v41.ragel"
+#line 258 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st579;}
     }
-#line 265 "src/vcf/vcf_v41.ragel"
+#line 264 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st579;}
     }
-#line 281 "src/vcf/vcf_v41.ragel"
+#line 280 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st579;}
     }
-#line 247 "src/vcf/vcf_v41.ragel"
+#line 246 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st579;}
     }
-#line 253 "src/vcf/vcf_v41.ragel"
+#line 252 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st579;}
     }
-#line 309 "src/vcf/vcf_v41.ragel"
+#line 308 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st579;}
     }
-#line 297 "src/vcf/vcf_v41.ragel"
+#line 296 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st579;}
     }
-#line 303 "src/vcf/vcf_v41.ragel"
+#line 302 "src/vcf/vcf_v41.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st579;}
@@ -15994,14 +15992,14 @@ case 658:
         p--; {goto st579;}
     }
 	break;
-#line 15998 "inc/vcf/validator_detail_v41.hpp"
+#line 15996 "inc/vcf/validator_detail_v41.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 852 "src/vcf/vcf_v41.ragel"
+#line 851 "src/vcf/vcf_v41.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 827 "src/vcf/vcf_v42.ragel"
+#line 828 "src/vcf/vcf_v42.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v42_en_meta_section_skip = 651;
 static const int vcf_v42_en_body_section_skip = 652;
 
 
-#line 833 "src/vcf/vcf_v42.ragel"
+#line 834 "src/vcf/vcf_v42.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v42_start;
 	}
 
-#line 847 "src/vcf/vcf_v42.ragel"
+#line 848 "src/vcf/vcf_v42.ragel"
 
     }
 
@@ -87,7 +87,8 @@ tr14:
 #line 227 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         p--; {goto st651;}
     }
 #line 60 "src/vcf/vcf_v42.ragel"
@@ -107,7 +108,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 341 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -141,7 +142,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 341 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -170,47 +171,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 247 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 253 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 297 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 303 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -229,7 +230,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -241,13 +242,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 239 "src/vcf/vcf_v42.ragel"
+#line 240 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -259,12 +260,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -276,12 +277,12 @@ tr152:
     }
 	goto st0;
 tr161:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -293,17 +294,17 @@ tr161:
     }
 	goto st0;
 tr175:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -315,17 +316,17 @@ tr175:
     }
 	goto st0;
 tr187:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -337,12 +338,12 @@ tr187:
     }
 	goto st0;
 tr193:
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -354,7 +355,7 @@ tr193:
     }
 	goto st0;
 tr196:
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -366,12 +367,12 @@ tr196:
     }
 	goto st0;
 tr206:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -383,12 +384,12 @@ tr206:
     }
 	goto st0;
 tr225:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -400,17 +401,17 @@ tr225:
     }
 	goto st0;
 tr247:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -422,17 +423,17 @@ tr247:
     }
 	goto st0;
 tr259:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -444,7 +445,7 @@ tr259:
     }
 	goto st0;
 tr265:
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -456,12 +457,12 @@ tr265:
     }
 	goto st0;
 tr275:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -473,12 +474,12 @@ tr275:
     }
 	goto st0;
 tr288:
-#line 269 "src/vcf/vcf_v42.ragel"
+#line 270 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -490,12 +491,12 @@ tr288:
     }
 	goto st0;
 tr297:
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 291 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -507,12 +508,12 @@ tr297:
     }
 	goto st0;
 tr314:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -524,17 +525,17 @@ tr314:
     }
 	goto st0;
 tr336:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -546,17 +547,17 @@ tr336:
     }
 	goto st0;
 tr348:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -568,7 +569,7 @@ tr348:
     }
 	goto st0;
 tr355:
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -580,12 +581,12 @@ tr355:
     }
 	goto st0;
 tr364:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -597,12 +598,12 @@ tr364:
     }
 	goto st0;
 tr377:
-#line 285 "src/vcf/vcf_v42.ragel"
+#line 286 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -614,12 +615,12 @@ tr377:
     }
 	goto st0;
 tr386:
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 291 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -631,12 +632,12 @@ tr386:
     }
 	goto st0;
 tr403:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -648,17 +649,17 @@ tr403:
     }
 	goto st0;
 tr425:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -670,17 +671,17 @@ tr425:
     }
 	goto st0;
 tr437:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -692,7 +693,7 @@ tr437:
     }
 	goto st0;
 tr444:
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 297 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -704,12 +705,12 @@ tr444:
     }
 	goto st0;
 tr454:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 297 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -721,7 +722,7 @@ tr454:
     }
 	goto st0;
 tr466:
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -733,12 +734,12 @@ tr466:
     }
 	goto st0;
 tr477:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -750,17 +751,17 @@ tr477:
     }
 	goto st0;
 tr482:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -772,12 +773,12 @@ tr482:
     }
 	goto st0;
 tr484:
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -789,17 +790,17 @@ tr484:
     }
 	goto st0;
 tr494:
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 319 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -811,12 +812,12 @@ tr494:
     }
 	goto st0;
 tr497:
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 319 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -828,17 +829,17 @@ tr497:
     }
 	goto st0;
 tr507:
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 319 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -850,12 +851,12 @@ tr507:
     }
 	goto st0;
 tr510:
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -867,7 +868,7 @@ tr510:
     }
 	goto st0;
 tr533:
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 247 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -879,12 +880,12 @@ tr533:
     }
 	goto st0;
 tr542:
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 335 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 247 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -896,7 +897,7 @@ tr542:
     }
 	goto st0;
 tr563:
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 253 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -908,12 +909,12 @@ tr563:
     }
 	goto st0;
 tr574:
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 253 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -925,7 +926,7 @@ tr574:
     }
 	goto st0;
 tr612:
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 303 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -937,12 +938,12 @@ tr612:
     }
 	goto st0;
 tr624:
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 335 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 303 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -954,7 +955,7 @@ tr624:
     }
 	goto st0;
 tr647:
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 341 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -998,7 +999,7 @@ tr687:
     }
 	goto st0;
 tr702:
-#line 357 "src/vcf/vcf_v42.ragel"
+#line 358 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st652;}
@@ -1010,7 +1011,7 @@ tr702:
     }
 	goto st0;
 tr705:
-#line 363 "src/vcf/vcf_v42.ragel"
+#line 364 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st652;}
@@ -1022,7 +1023,7 @@ tr705:
     }
 	goto st0;
 tr709:
-#line 369 "src/vcf/vcf_v42.ragel"
+#line 370 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st652;}
@@ -1034,7 +1035,7 @@ tr709:
     }
 	goto st0;
 tr714:
-#line 375 "src/vcf/vcf_v42.ragel"
+#line 376 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st652;}
@@ -1046,7 +1047,7 @@ tr714:
     }
 	goto st0;
 tr718:
-#line 381 "src/vcf/vcf_v42.ragel"
+#line 382 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st652;}
@@ -1058,7 +1059,7 @@ tr718:
     }
 	goto st0;
 tr727:
-#line 387 "src/vcf/vcf_v42.ragel"
+#line 388 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st652;}
@@ -1070,7 +1071,7 @@ tr727:
     }
 	goto st0;
 tr738:
-#line 393 "src/vcf/vcf_v42.ragel"
+#line 394 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st652;}
@@ -1082,12 +1083,12 @@ tr738:
     }
 	goto st0;
 tr746:
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1099,7 +1100,7 @@ tr746:
     }
 	goto st0;
 tr763:
-#line 559 "src/vcf/vcf_v42.ragel"
+#line 560 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st652;}
@@ -1111,14 +1112,14 @@ tr763:
     }
 	goto st0;
 tr768:
-#line 572 "src/vcf/vcf_v42.ragel"
+#line 573 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st652;}
     }
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 566 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1139,7 +1140,7 @@ tr776:
     }
 	goto st0;
 tr778:
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 566 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1153,12 +1154,12 @@ tr778:
     }
 	goto st0;
 tr780:
-#line 409 "src/vcf/vcf_v42.ragel"
+#line 410 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1170,7 +1171,7 @@ tr780:
     }
 	goto st0;
 tr782:
-#line 550 "src/vcf/vcf_v42.ragel"
+#line 551 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1178,7 +1179,7 @@ tr782:
                 "1000G"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1190,7 +1191,7 @@ tr782:
     }
 	goto st0;
 tr785:
-#line 414 "src/vcf/vcf_v42.ragel"
+#line 415 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1198,7 +1199,7 @@ tr785:
                 "AA"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1210,7 +1211,7 @@ tr785:
     }
 	goto st0;
 tr788:
-#line 422 "src/vcf/vcf_v42.ragel"
+#line 423 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1218,7 +1219,7 @@ tr788:
                 "AC"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1230,7 +1231,7 @@ tr788:
     }
 	goto st0;
 tr791:
-#line 430 "src/vcf/vcf_v42.ragel"
+#line 431 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1238,7 +1239,7 @@ tr791:
                 "AF"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1250,7 +1251,7 @@ tr791:
     }
 	goto st0;
 tr803:
-#line 438 "src/vcf/vcf_v42.ragel"
+#line 439 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1258,7 +1259,7 @@ tr803:
                 "AN"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1270,7 +1271,7 @@ tr803:
     }
 	goto st0;
 tr806:
-#line 446 "src/vcf/vcf_v42.ragel"
+#line 447 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1278,7 +1279,7 @@ tr806:
                 "BQ"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1290,7 +1291,7 @@ tr806:
     }
 	goto st0;
 tr818:
-#line 454 "src/vcf/vcf_v42.ragel"
+#line 455 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1298,7 +1299,7 @@ tr818:
                 "CIGAR"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1310,7 +1311,7 @@ tr818:
     }
 	goto st0;
 tr821:
-#line 462 "src/vcf/vcf_v42.ragel"
+#line 463 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1318,7 +1319,7 @@ tr821:
                 "DB"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1330,7 +1331,7 @@ tr821:
     }
 	goto st0;
 tr824:
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 471 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1338,7 +1339,7 @@ tr824:
                 "DP"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1350,7 +1351,7 @@ tr824:
     }
 	goto st0;
 tr827:
-#line 478 "src/vcf/vcf_v42.ragel"
+#line 479 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1358,7 +1359,7 @@ tr827:
                 "END"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1370,7 +1371,7 @@ tr827:
     }
 	goto st0;
 tr829:
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 487 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1378,7 +1379,7 @@ tr829:
                 "H2"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1390,7 +1391,7 @@ tr829:
     }
 	goto st0;
 tr831:
-#line 494 "src/vcf/vcf_v42.ragel"
+#line 495 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1398,7 +1399,7 @@ tr831:
                 "H3"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1410,7 +1411,7 @@ tr831:
     }
 	goto st0;
 tr836:
-#line 510 "src/vcf/vcf_v42.ragel"
+#line 511 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1418,7 +1419,7 @@ tr836:
                 "MQ0"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1430,7 +1431,7 @@ tr836:
     }
 	goto st0;
 tr838:
-#line 502 "src/vcf/vcf_v42.ragel"
+#line 503 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1438,7 +1439,7 @@ tr838:
                 "MQ"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1450,7 +1451,7 @@ tr838:
     }
 	goto st0;
 tr850:
-#line 518 "src/vcf/vcf_v42.ragel"
+#line 519 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1458,7 +1459,7 @@ tr850:
                 "NS"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1470,7 +1471,7 @@ tr850:
     }
 	goto st0;
 tr853:
-#line 526 "src/vcf/vcf_v42.ragel"
+#line 527 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1478,7 +1479,7 @@ tr853:
                 "SB"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1490,7 +1491,7 @@ tr853:
     }
 	goto st0;
 tr864:
-#line 534 "src/vcf/vcf_v42.ragel"
+#line 535 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1498,7 +1499,7 @@ tr864:
                 "SOMATIC"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1510,7 +1511,7 @@ tr864:
     }
 	goto st0;
 tr866:
-#line 542 "src/vcf/vcf_v42.ragel"
+#line 543 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1518,7 +1519,7 @@ tr866:
                 "VALIDATED"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1543,7 +1544,7 @@ tr915:
         
         p--; {goto st652;}
     }
-#line 357 "src/vcf/vcf_v42.ragel"
+#line 358 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st652;}
@@ -1555,7 +1556,7 @@ tr915:
     }
 	goto st0;
 tr937:
-#line 550 "src/vcf/vcf_v42.ragel"
+#line 551 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1563,12 +1564,12 @@ tr937:
                 "1000G"});
         p--; {goto st652;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1580,7 +1581,7 @@ tr937:
     }
 	goto st0;
 tr954:
-#line 462 "src/vcf/vcf_v42.ragel"
+#line 463 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1588,12 +1589,12 @@ tr954:
                 "DB"});
         p--; {goto st652;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1605,7 +1606,7 @@ tr954:
     }
 	goto st0;
 tr960:
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 487 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1613,12 +1614,12 @@ tr960:
                 "H2"});
         p--; {goto st652;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1630,7 +1631,7 @@ tr960:
     }
 	goto st0;
 tr962:
-#line 494 "src/vcf/vcf_v42.ragel"
+#line 495 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1638,12 +1639,12 @@ tr962:
                 "H3"});
         p--; {goto st652;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1655,7 +1656,7 @@ tr962:
     }
 	goto st0;
 tr977:
-#line 534 "src/vcf/vcf_v42.ragel"
+#line 535 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1663,12 +1664,12 @@ tr977:
                 "SOMATIC"});
         p--; {goto st652;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1680,7 +1681,7 @@ tr977:
     }
 	goto st0;
 tr987:
-#line 542 "src/vcf/vcf_v42.ragel"
+#line 543 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1688,12 +1689,12 @@ tr987:
                 "VALIDATED"});
         p--; {goto st652;}
     }
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1704,7 +1705,7 @@ tr987:
         p--; {goto st652;}
     }
 	goto st0;
-#line 1708 "inc/vcf/validator_detail_v42.hpp"
+#line 1709 "inc/vcf/validator_detail_v42.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1813,7 +1814,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1817 "inc/vcf/validator_detail_v42.hpp"
+#line 1818 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1827,7 +1828,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1831 "inc/vcf/validator_detail_v42.hpp"
+#line 1832 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1841,7 +1842,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1845 "inc/vcf/validator_detail_v42.hpp"
+#line 1846 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1855,7 +1856,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1859 "inc/vcf/validator_detail_v42.hpp"
+#line 1860 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1869,7 +1870,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1873 "inc/vcf/validator_detail_v42.hpp"
+#line 1874 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1883,7 +1884,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1887 "inc/vcf/validator_detail_v42.hpp"
+#line 1888 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 50 )
 		goto tr21;
 	goto tr14;
@@ -1897,7 +1898,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1901 "inc/vcf/validator_detail_v42.hpp"
+#line 1902 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -1928,7 +1929,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1932 "inc/vcf/validator_detail_v42.hpp"
+#line 1933 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1981,7 +1982,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1985 "inc/vcf/validator_detail_v42.hpp"
+#line 1986 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1997,7 +1998,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2001 "inc/vcf/validator_detail_v42.hpp"
+#line 2002 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2025,7 +2026,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2029 "inc/vcf/validator_detail_v42.hpp"
+#line 2030 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -2081,7 +2082,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2085 "inc/vcf/validator_detail_v42.hpp"
+#line 2086 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -2133,7 +2134,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2137 "inc/vcf/validator_detail_v42.hpp"
+#line 2138 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -2168,7 +2169,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2172 "inc/vcf/validator_detail_v42.hpp"
+#line 2173 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2196,7 +2197,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2200 "inc/vcf/validator_detail_v42.hpp"
+#line 2201 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2222,7 +2223,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2226 "inc/vcf/validator_detail_v42.hpp"
+#line 2227 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2244,7 +2245,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2248 "inc/vcf/validator_detail_v42.hpp"
+#line 2249 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2305,7 +2306,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2309 "inc/vcf/validator_detail_v42.hpp"
+#line 2310 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2333,7 +2334,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2337 "inc/vcf/validator_detail_v42.hpp"
+#line 2338 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
@@ -2357,7 +2358,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2361 "inc/vcf/validator_detail_v42.hpp"
+#line 2362 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2379,7 +2380,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2383 "inc/vcf/validator_detail_v42.hpp"
+#line 2384 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2398,7 +2399,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2402 "inc/vcf/validator_detail_v42.hpp"
+#line 2403 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2418,7 +2419,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2422 "inc/vcf/validator_detail_v42.hpp"
+#line 2423 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2453,7 +2454,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2457 "inc/vcf/validator_detail_v42.hpp"
+#line 2458 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2480,7 +2481,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2484 "inc/vcf/validator_detail_v42.hpp"
+#line 2485 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2512,7 +2513,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2516 "inc/vcf/validator_detail_v42.hpp"
+#line 2517 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2533,7 +2534,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2537 "inc/vcf/validator_detail_v42.hpp"
+#line 2538 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2558,7 +2559,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2562 "inc/vcf/validator_detail_v42.hpp"
+#line 2563 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2593,7 +2594,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2597 "inc/vcf/validator_detail_v42.hpp"
+#line 2598 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2620,7 +2621,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2624 "inc/vcf/validator_detail_v42.hpp"
+#line 2625 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2663,7 +2664,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2667 "inc/vcf/validator_detail_v42.hpp"
+#line 2668 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2691,7 +2692,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2695 "inc/vcf/validator_detail_v42.hpp"
+#line 2696 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2717,7 +2718,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2721 "inc/vcf/validator_detail_v42.hpp"
+#line 2722 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2739,7 +2740,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2743 "inc/vcf/validator_detail_v42.hpp"
+#line 2744 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2779,7 +2780,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2783 "inc/vcf/validator_detail_v42.hpp"
+#line 2784 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2830,7 +2831,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2834 "inc/vcf/validator_detail_v42.hpp"
+#line 2835 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2881,7 +2882,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2885 "inc/vcf/validator_detail_v42.hpp"
+#line 2886 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2924,7 +2925,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2928 "inc/vcf/validator_detail_v42.hpp"
+#line 2929 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2954,7 +2955,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2958 "inc/vcf/validator_detail_v42.hpp"
+#line 2959 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2994,7 +2995,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2998 "inc/vcf/validator_detail_v42.hpp"
+#line 2999 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3024,7 +3025,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3028 "inc/vcf/validator_detail_v42.hpp"
+#line 3029 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -3044,7 +3045,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3048 "inc/vcf/validator_detail_v42.hpp"
+#line 3049 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -3085,7 +3086,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3089 "inc/vcf/validator_detail_v42.hpp"
+#line 3090 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -3113,7 +3114,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3117 "inc/vcf/validator_detail_v42.hpp"
+#line 3118 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -3135,7 +3136,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3139 "inc/vcf/validator_detail_v42.hpp"
+#line 3140 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -3165,7 +3166,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3169 "inc/vcf/validator_detail_v42.hpp"
+#line 3170 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3216,7 +3217,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3220 "inc/vcf/validator_detail_v42.hpp"
+#line 3221 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3267,7 +3268,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3271 "inc/vcf/validator_detail_v42.hpp"
+#line 3272 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3310,7 +3311,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3314 "inc/vcf/validator_detail_v42.hpp"
+#line 3315 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3340,7 +3341,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3344 "inc/vcf/validator_detail_v42.hpp"
+#line 3345 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3370,7 +3371,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3374 "inc/vcf/validator_detail_v42.hpp"
+#line 3375 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3400,7 +3401,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3404 "inc/vcf/validator_detail_v42.hpp"
+#line 3405 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3424,7 +3425,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3428 "inc/vcf/validator_detail_v42.hpp"
+#line 3429 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3442,7 +3443,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3446 "inc/vcf/validator_detail_v42.hpp"
+#line 3447 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3469,7 +3470,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3473 "inc/vcf/validator_detail_v42.hpp"
+#line 3474 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3541,7 +3542,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3545 "inc/vcf/validator_detail_v42.hpp"
+#line 3546 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3595,7 +3596,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3599 "inc/vcf/validator_detail_v42.hpp"
+#line 3600 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3616,7 +3617,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3620 "inc/vcf/validator_detail_v42.hpp"
+#line 3621 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3714,7 +3715,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3718 "inc/vcf/validator_detail_v42.hpp"
+#line 3719 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3742,7 +3743,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3746 "inc/vcf/validator_detail_v42.hpp"
+#line 3747 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3770,7 +3771,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3774 "inc/vcf/validator_detail_v42.hpp"
+#line 3775 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3804,7 +3805,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3808 "inc/vcf/validator_detail_v42.hpp"
+#line 3809 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3839,7 +3840,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3843 "inc/vcf/validator_detail_v42.hpp"
+#line 3844 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr166;
 		case 95: goto tr165;
@@ -3866,7 +3867,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3870 "inc/vcf/validator_detail_v42.hpp"
+#line 3871 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr125;
@@ -3901,7 +3902,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3905 "inc/vcf/validator_detail_v42.hpp"
+#line 3906 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr171;
@@ -3929,7 +3930,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3933 "inc/vcf/validator_detail_v42.hpp"
+#line 3934 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr172;
 		case 92: goto tr171;
@@ -3951,7 +3952,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3955 "inc/vcf/validator_detail_v42.hpp"
+#line 3956 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr173;
@@ -3981,7 +3982,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3985 "inc/vcf/validator_detail_v42.hpp"
+#line 3986 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4032,7 +4033,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4036 "inc/vcf/validator_detail_v42.hpp"
+#line 4037 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4083,7 +4084,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4087 "inc/vcf/validator_detail_v42.hpp"
+#line 4088 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4126,7 +4127,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4130 "inc/vcf/validator_detail_v42.hpp"
+#line 4131 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr171;
@@ -4144,7 +4145,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4148 "inc/vcf/validator_detail_v42.hpp"
+#line 4149 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 44: goto tr182;
@@ -4174,7 +4175,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4178 "inc/vcf/validator_detail_v42.hpp"
+#line 4179 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4213,7 +4214,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4217 "inc/vcf/validator_detail_v42.hpp"
+#line 4218 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr184;
 		case 92: goto tr158;
@@ -4235,7 +4236,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4239 "inc/vcf/validator_detail_v42.hpp"
+#line 4240 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr185;
@@ -4255,7 +4256,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4259 "inc/vcf/validator_detail_v42.hpp"
+#line 4260 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4306,7 +4307,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4310 "inc/vcf/validator_detail_v42.hpp"
+#line 4311 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4357,7 +4358,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4361 "inc/vcf/validator_detail_v42.hpp"
+#line 4362 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4400,7 +4401,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4404 "inc/vcf/validator_detail_v42.hpp"
+#line 4405 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr158;
@@ -4418,7 +4419,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4422 "inc/vcf/validator_detail_v42.hpp"
+#line 4423 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4442,7 +4443,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4446 "inc/vcf/validator_detail_v42.hpp"
+#line 4447 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr194;
@@ -4461,7 +4462,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4465 "inc/vcf/validator_detail_v42.hpp"
+#line 4466 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr197;
@@ -4479,7 +4480,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4483 "inc/vcf/validator_detail_v42.hpp"
+#line 4484 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr198;
@@ -4497,7 +4498,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4501 "inc/vcf/validator_detail_v42.hpp"
+#line 4502 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr199;
@@ -4515,7 +4516,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4519 "inc/vcf/validator_detail_v42.hpp"
+#line 4520 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st127;
@@ -4542,7 +4543,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4546 "inc/vcf/validator_detail_v42.hpp"
+#line 4547 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr196;
@@ -4599,7 +4600,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4603 "inc/vcf/validator_detail_v42.hpp"
+#line 4604 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4638,7 +4639,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4642 "inc/vcf/validator_detail_v42.hpp"
+#line 4643 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr211;
 		case 95: goto tr210;
@@ -4665,7 +4666,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4669 "inc/vcf/validator_detail_v42.hpp"
+#line 4670 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr196;
@@ -4763,7 +4764,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4767 "inc/vcf/validator_detail_v42.hpp"
+#line 4768 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 92: goto tr228;
@@ -4791,7 +4792,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4795 "inc/vcf/validator_detail_v42.hpp"
+#line 4796 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr231;
@@ -4819,7 +4820,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4823 "inc/vcf/validator_detail_v42.hpp"
+#line 4824 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4853,7 +4854,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4857 "inc/vcf/validator_detail_v42.hpp"
+#line 4858 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4888,7 +4889,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4892 "inc/vcf/validator_detail_v42.hpp"
+#line 4893 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr238;
 		case 95: goto tr237;
@@ -4915,7 +4916,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 4919 "inc/vcf/validator_detail_v42.hpp"
+#line 4920 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr196;
@@ -4950,7 +4951,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 4954 "inc/vcf/validator_detail_v42.hpp"
+#line 4955 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr243;
@@ -4978,7 +4979,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4982 "inc/vcf/validator_detail_v42.hpp"
+#line 4983 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr244;
 		case 92: goto tr243;
@@ -5000,7 +5001,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5004 "inc/vcf/validator_detail_v42.hpp"
+#line 5005 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr245;
@@ -5030,7 +5031,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5034 "inc/vcf/validator_detail_v42.hpp"
+#line 5035 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5081,7 +5082,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5085 "inc/vcf/validator_detail_v42.hpp"
+#line 5086 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5132,7 +5133,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5136 "inc/vcf/validator_detail_v42.hpp"
+#line 5137 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5175,7 +5176,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5179 "inc/vcf/validator_detail_v42.hpp"
+#line 5180 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr243;
@@ -5193,7 +5194,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5197 "inc/vcf/validator_detail_v42.hpp"
+#line 5198 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 44: goto tr254;
@@ -5223,7 +5224,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5227 "inc/vcf/validator_detail_v42.hpp"
+#line 5228 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5262,7 +5263,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5266 "inc/vcf/validator_detail_v42.hpp"
+#line 5267 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr256;
 		case 92: goto tr231;
@@ -5284,7 +5285,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5288 "inc/vcf/validator_detail_v42.hpp"
+#line 5289 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr257;
@@ -5304,7 +5305,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5308 "inc/vcf/validator_detail_v42.hpp"
+#line 5309 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5355,7 +5356,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5359 "inc/vcf/validator_detail_v42.hpp"
+#line 5360 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5406,7 +5407,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5410 "inc/vcf/validator_detail_v42.hpp"
+#line 5411 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5449,7 +5450,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5453 "inc/vcf/validator_detail_v42.hpp"
+#line 5454 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr231;
@@ -5467,7 +5468,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5471 "inc/vcf/validator_detail_v42.hpp"
+#line 5472 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5487,7 +5488,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5491 "inc/vcf/validator_detail_v42.hpp"
+#line 5492 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr266;
@@ -5505,7 +5506,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5509 "inc/vcf/validator_detail_v42.hpp"
+#line 5510 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr267;
@@ -5523,7 +5524,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5527 "inc/vcf/validator_detail_v42.hpp"
+#line 5528 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr268;
@@ -5541,7 +5542,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5545 "inc/vcf/validator_detail_v42.hpp"
+#line 5546 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st177;
@@ -5568,7 +5569,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5572 "inc/vcf/validator_detail_v42.hpp"
+#line 5573 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr265;
@@ -5625,7 +5626,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5629 "inc/vcf/validator_detail_v42.hpp"
+#line 5630 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5664,7 +5665,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5668 "inc/vcf/validator_detail_v42.hpp"
+#line 5669 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr280;
 		case 95: goto tr279;
@@ -5691,7 +5692,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5695 "inc/vcf/validator_detail_v42.hpp"
+#line 5696 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr265;
@@ -5768,7 +5769,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5772 "inc/vcf/validator_detail_v42.hpp"
+#line 5773 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	goto tr288;
@@ -5782,7 +5783,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5786 "inc/vcf/validator_detail_v42.hpp"
+#line 5787 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr265;
@@ -5848,7 +5849,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5852 "inc/vcf/validator_detail_v42.hpp"
+#line 5853 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr299;
 	if ( (*p) > 90 ) {
@@ -5867,7 +5868,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5871 "inc/vcf/validator_detail_v42.hpp"
+#line 5872 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr265;
@@ -5965,7 +5966,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 5969 "inc/vcf/validator_detail_v42.hpp"
+#line 5970 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 92: goto tr317;
@@ -5993,7 +5994,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 5997 "inc/vcf/validator_detail_v42.hpp"
+#line 5998 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr320;
@@ -6021,7 +6022,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6025 "inc/vcf/validator_detail_v42.hpp"
+#line 6026 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6055,7 +6056,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6059 "inc/vcf/validator_detail_v42.hpp"
+#line 6060 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6090,7 +6091,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6094 "inc/vcf/validator_detail_v42.hpp"
+#line 6095 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr327;
 		case 95: goto tr326;
@@ -6117,7 +6118,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6121 "inc/vcf/validator_detail_v42.hpp"
+#line 6122 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr265;
@@ -6152,7 +6153,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6156 "inc/vcf/validator_detail_v42.hpp"
+#line 6157 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr332;
@@ -6180,7 +6181,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6184 "inc/vcf/validator_detail_v42.hpp"
+#line 6185 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr333;
 		case 92: goto tr332;
@@ -6202,7 +6203,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6206 "inc/vcf/validator_detail_v42.hpp"
+#line 6207 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr334;
@@ -6232,7 +6233,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6236 "inc/vcf/validator_detail_v42.hpp"
+#line 6237 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6283,7 +6284,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6287 "inc/vcf/validator_detail_v42.hpp"
+#line 6288 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6334,7 +6335,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6338 "inc/vcf/validator_detail_v42.hpp"
+#line 6339 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6377,7 +6378,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6381 "inc/vcf/validator_detail_v42.hpp"
+#line 6382 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr332;
@@ -6395,7 +6396,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6399 "inc/vcf/validator_detail_v42.hpp"
+#line 6400 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 44: goto tr343;
@@ -6425,7 +6426,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6429 "inc/vcf/validator_detail_v42.hpp"
+#line 6430 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6464,7 +6465,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6468 "inc/vcf/validator_detail_v42.hpp"
+#line 6469 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr345;
 		case 92: goto tr320;
@@ -6486,7 +6487,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6490 "inc/vcf/validator_detail_v42.hpp"
+#line 6491 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr346;
@@ -6506,7 +6507,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6510 "inc/vcf/validator_detail_v42.hpp"
+#line 6511 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6557,7 +6558,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6561 "inc/vcf/validator_detail_v42.hpp"
+#line 6562 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6608,7 +6609,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6612 "inc/vcf/validator_detail_v42.hpp"
+#line 6613 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6651,7 +6652,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6655 "inc/vcf/validator_detail_v42.hpp"
+#line 6656 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr320;
@@ -6669,7 +6670,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6673 "inc/vcf/validator_detail_v42.hpp"
+#line 6674 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6703,7 +6704,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6707 "inc/vcf/validator_detail_v42.hpp"
+#line 6708 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6723,7 +6724,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6727 "inc/vcf/validator_detail_v42.hpp"
+#line 6728 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr356;
@@ -6741,7 +6742,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6745 "inc/vcf/validator_detail_v42.hpp"
+#line 6746 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr357;
@@ -6759,7 +6760,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6763 "inc/vcf/validator_detail_v42.hpp"
+#line 6764 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st243;
@@ -6786,7 +6787,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6790 "inc/vcf/validator_detail_v42.hpp"
+#line 6791 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr355;
@@ -6843,7 +6844,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6847 "inc/vcf/validator_detail_v42.hpp"
+#line 6848 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6882,7 +6883,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6886 "inc/vcf/validator_detail_v42.hpp"
+#line 6887 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr369;
 		case 95: goto tr368;
@@ -6909,7 +6910,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 6913 "inc/vcf/validator_detail_v42.hpp"
+#line 6914 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr355;
@@ -6986,7 +6987,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 6990 "inc/vcf/validator_detail_v42.hpp"
+#line 6991 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	goto tr377;
@@ -7000,7 +7001,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7004 "inc/vcf/validator_detail_v42.hpp"
+#line 7005 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr355;
@@ -7066,7 +7067,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7070 "inc/vcf/validator_detail_v42.hpp"
+#line 7071 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) > 90 ) {
@@ -7085,7 +7086,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7089 "inc/vcf/validator_detail_v42.hpp"
+#line 7090 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr355;
@@ -7183,7 +7184,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7187 "inc/vcf/validator_detail_v42.hpp"
+#line 7188 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 92: goto tr406;
@@ -7211,7 +7212,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7215 "inc/vcf/validator_detail_v42.hpp"
+#line 7216 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr409;
@@ -7239,7 +7240,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7243 "inc/vcf/validator_detail_v42.hpp"
+#line 7244 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7273,7 +7274,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7277 "inc/vcf/validator_detail_v42.hpp"
+#line 7278 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7308,7 +7309,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7312 "inc/vcf/validator_detail_v42.hpp"
+#line 7313 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr416;
 		case 95: goto tr415;
@@ -7335,7 +7336,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7339 "inc/vcf/validator_detail_v42.hpp"
+#line 7340 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr355;
@@ -7370,7 +7371,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7374 "inc/vcf/validator_detail_v42.hpp"
+#line 7375 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr421;
@@ -7398,7 +7399,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7402 "inc/vcf/validator_detail_v42.hpp"
+#line 7403 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr422;
 		case 92: goto tr421;
@@ -7420,7 +7421,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7424 "inc/vcf/validator_detail_v42.hpp"
+#line 7425 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr423;
@@ -7450,7 +7451,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7454 "inc/vcf/validator_detail_v42.hpp"
+#line 7455 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7501,7 +7502,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7505 "inc/vcf/validator_detail_v42.hpp"
+#line 7506 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7552,7 +7553,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7556 "inc/vcf/validator_detail_v42.hpp"
+#line 7557 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7595,7 +7596,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7599 "inc/vcf/validator_detail_v42.hpp"
+#line 7600 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr421;
@@ -7613,7 +7614,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7617 "inc/vcf/validator_detail_v42.hpp"
+#line 7618 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 44: goto tr432;
@@ -7643,7 +7644,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7647 "inc/vcf/validator_detail_v42.hpp"
+#line 7648 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7682,7 +7683,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7686 "inc/vcf/validator_detail_v42.hpp"
+#line 7687 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr434;
 		case 92: goto tr409;
@@ -7704,7 +7705,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7708 "inc/vcf/validator_detail_v42.hpp"
+#line 7709 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr435;
@@ -7724,7 +7725,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7728 "inc/vcf/validator_detail_v42.hpp"
+#line 7729 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7775,7 +7776,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7779 "inc/vcf/validator_detail_v42.hpp"
+#line 7780 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7826,7 +7827,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7830 "inc/vcf/validator_detail_v42.hpp"
+#line 7831 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7869,7 +7870,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7873 "inc/vcf/validator_detail_v42.hpp"
+#line 7874 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr409;
@@ -7887,7 +7888,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7891 "inc/vcf/validator_detail_v42.hpp"
+#line 7892 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7921,7 +7922,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 7925 "inc/vcf/validator_detail_v42.hpp"
+#line 7926 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -7941,7 +7942,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 7945 "inc/vcf/validator_detail_v42.hpp"
+#line 7946 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr445;
@@ -7959,7 +7960,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 7963 "inc/vcf/validator_detail_v42.hpp"
+#line 7964 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr446;
@@ -7977,7 +7978,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 7981 "inc/vcf/validator_detail_v42.hpp"
+#line 7982 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr447;
@@ -7995,7 +7996,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 7999 "inc/vcf/validator_detail_v42.hpp"
+#line 8000 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr448;
@@ -8013,7 +8014,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8017 "inc/vcf/validator_detail_v42.hpp"
+#line 8018 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr449;
@@ -8031,7 +8032,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 8035 "inc/vcf/validator_detail_v42.hpp"
+#line 8036 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr450;
@@ -8049,7 +8050,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 8053 "inc/vcf/validator_detail_v42.hpp"
+#line 8054 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st313;
@@ -8076,7 +8077,7 @@ st314:
 	if ( ++p == pe )
 		goto _test_eof314;
 case 314:
-#line 8080 "inc/vcf/validator_detail_v42.hpp"
+#line 8081 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st315;
 	goto tr444;
@@ -8090,7 +8091,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8094 "inc/vcf/validator_detail_v42.hpp"
+#line 8095 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr455;
 	if ( (*p) < 48 ) {
@@ -8115,7 +8116,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8119 "inc/vcf/validator_detail_v42.hpp"
+#line 8120 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st316;
 	if ( (*p) < 48 ) {
@@ -8150,7 +8151,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8154 "inc/vcf/validator_detail_v42.hpp"
+#line 8155 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr459;
 		case 95: goto tr458;
@@ -8177,7 +8178,7 @@ st318:
 	if ( ++p == pe )
 		goto _test_eof318;
 case 318:
-#line 8181 "inc/vcf/validator_detail_v42.hpp"
+#line 8182 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr460;
 	if ( (*p) < 48 ) {
@@ -8202,7 +8203,7 @@ st319:
 	if ( ++p == pe )
 		goto _test_eof319;
 case 319:
-#line 8206 "inc/vcf/validator_detail_v42.hpp"
+#line 8207 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st319;
 	if ( (*p) < 48 ) {
@@ -8237,7 +8238,7 @@ st320:
 	if ( ++p == pe )
 		goto _test_eof320;
 case 320:
-#line 8241 "inc/vcf/validator_detail_v42.hpp"
+#line 8242 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr464;
 		case 62: goto tr465;
@@ -8265,7 +8266,7 @@ st321:
 	if ( ++p == pe )
 		goto _test_eof321;
 case 321:
-#line 8269 "inc/vcf/validator_detail_v42.hpp"
+#line 8270 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8285,7 +8286,7 @@ st322:
 	if ( ++p == pe )
 		goto _test_eof322;
 case 322:
-#line 8289 "inc/vcf/validator_detail_v42.hpp"
+#line 8290 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr467;
@@ -8303,7 +8304,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 8307 "inc/vcf/validator_detail_v42.hpp"
+#line 8308 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr468;
@@ -8321,7 +8322,7 @@ st324:
 	if ( ++p == pe )
 		goto _test_eof324;
 case 324:
-#line 8325 "inc/vcf/validator_detail_v42.hpp"
+#line 8326 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr469;
@@ -8339,7 +8340,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8343 "inc/vcf/validator_detail_v42.hpp"
+#line 8344 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr470;
@@ -8357,7 +8358,7 @@ st326:
 	if ( ++p == pe )
 		goto _test_eof326;
 case 326:
-#line 8361 "inc/vcf/validator_detail_v42.hpp"
+#line 8362 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st327;
@@ -8384,7 +8385,7 @@ st328:
 	if ( ++p == pe )
 		goto _test_eof328;
 case 328:
-#line 8388 "inc/vcf/validator_detail_v42.hpp"
+#line 8389 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st329;
 	goto tr466;
@@ -8441,7 +8442,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 8445 "inc/vcf/validator_detail_v42.hpp"
+#line 8446 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st333;
 	if ( (*p) < 48 ) {
@@ -8480,7 +8481,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 8484 "inc/vcf/validator_detail_v42.hpp"
+#line 8485 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr483;
 		case 95: goto tr481;
@@ -8507,7 +8508,7 @@ st335:
 	if ( ++p == pe )
 		goto _test_eof335;
 case 335:
-#line 8511 "inc/vcf/validator_detail_v42.hpp"
+#line 8512 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 71 )
 		goto st336;
 	goto tr484;
@@ -8600,7 +8601,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 8604 "inc/vcf/validator_detail_v42.hpp"
+#line 8605 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr496;
 	if ( (*p) < 35 ) {
@@ -8622,7 +8623,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 8626 "inc/vcf/validator_detail_v42.hpp"
+#line 8627 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 77 )
 		goto st346;
 	goto tr497;
@@ -8715,7 +8716,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8719 "inc/vcf/validator_detail_v42.hpp"
+#line 8720 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr509;
 	if ( (*p) < 35 ) {
@@ -8737,7 +8738,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8741 "inc/vcf/validator_detail_v42.hpp"
+#line 8742 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st356;
 	goto tr510;
@@ -8835,7 +8836,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 8839 "inc/vcf/validator_detail_v42.hpp"
+#line 8840 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr525;
 		case 92: goto tr526;
@@ -8863,7 +8864,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 8867 "inc/vcf/validator_detail_v42.hpp"
+#line 8868 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 92: goto tr529;
@@ -8891,7 +8892,7 @@ st370:
 	if ( ++p == pe )
 		goto _test_eof370;
 case 370:
-#line 8895 "inc/vcf/validator_detail_v42.hpp"
+#line 8896 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st371;
 	goto tr510;
@@ -8924,7 +8925,7 @@ st372:
 	if ( ++p == pe )
 		goto _test_eof372;
 case 372:
-#line 8928 "inc/vcf/validator_detail_v42.hpp"
+#line 8929 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr531;
 		case 92: goto tr529;
@@ -8946,7 +8947,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 8950 "inc/vcf/validator_detail_v42.hpp"
+#line 8951 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 62: goto tr532;
@@ -8965,7 +8966,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 8969 "inc/vcf/validator_detail_v42.hpp"
+#line 8970 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8989,7 +8990,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8993 "inc/vcf/validator_detail_v42.hpp"
+#line 8994 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr534;
@@ -9007,7 +9008,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 9011 "inc/vcf/validator_detail_v42.hpp"
+#line 9012 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr535;
@@ -9025,7 +9026,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 9029 "inc/vcf/validator_detail_v42.hpp"
+#line 9030 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr536;
@@ -9043,7 +9044,7 @@ st378:
 	if ( ++p == pe )
 		goto _test_eof378;
 case 378:
-#line 9047 "inc/vcf/validator_detail_v42.hpp"
+#line 9048 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr537;
@@ -9061,7 +9062,7 @@ st379:
 	if ( ++p == pe )
 		goto _test_eof379;
 case 379:
-#line 9065 "inc/vcf/validator_detail_v42.hpp"
+#line 9066 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr538;
@@ -9079,7 +9080,7 @@ st380:
 	if ( ++p == pe )
 		goto _test_eof380;
 case 380:
-#line 9083 "inc/vcf/validator_detail_v42.hpp"
+#line 9084 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr539;
@@ -9097,7 +9098,7 @@ st381:
 	if ( ++p == pe )
 		goto _test_eof381;
 case 381:
-#line 9101 "inc/vcf/validator_detail_v42.hpp"
+#line 9102 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st382;
@@ -9124,7 +9125,7 @@ st383:
 	if ( ++p == pe )
 		goto _test_eof383;
 case 383:
-#line 9128 "inc/vcf/validator_detail_v42.hpp"
+#line 9129 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr543;
@@ -9141,7 +9142,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 9145 "inc/vcf/validator_detail_v42.hpp"
+#line 9146 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9167,7 +9168,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9171 "inc/vcf/validator_detail_v42.hpp"
+#line 9172 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9290,7 +9291,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9294 "inc/vcf/validator_detail_v42.hpp"
+#line 9295 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr559;
@@ -9358,7 +9359,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 9362 "inc/vcf/validator_detail_v42.hpp"
+#line 9363 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr564;
@@ -9376,7 +9377,7 @@ st403:
 	if ( ++p == pe )
 		goto _test_eof403;
 case 403:
-#line 9380 "inc/vcf/validator_detail_v42.hpp"
+#line 9381 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr565;
@@ -9394,7 +9395,7 @@ st404:
 	if ( ++p == pe )
 		goto _test_eof404;
 case 404:
-#line 9398 "inc/vcf/validator_detail_v42.hpp"
+#line 9399 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr566;
@@ -9412,7 +9413,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 9416 "inc/vcf/validator_detail_v42.hpp"
+#line 9417 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr567;
@@ -9430,7 +9431,7 @@ st406:
 	if ( ++p == pe )
 		goto _test_eof406;
 case 406:
-#line 9434 "inc/vcf/validator_detail_v42.hpp"
+#line 9435 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st407;
@@ -9457,7 +9458,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9461 "inc/vcf/validator_detail_v42.hpp"
+#line 9462 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st409;
 	goto tr563;
@@ -9519,7 +9520,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9523 "inc/vcf/validator_detail_v42.hpp"
+#line 9524 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 59: goto tr576;
@@ -9541,7 +9542,7 @@ st414:
 	if ( ++p == pe )
 		goto _test_eof414;
 case 414:
-#line 9545 "inc/vcf/validator_detail_v42.hpp"
+#line 9546 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr579;
 	if ( (*p) < 48 ) {
@@ -9566,7 +9567,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9570 "inc/vcf/validator_detail_v42.hpp"
+#line 9571 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st415;
 	if ( (*p) < 48 ) {
@@ -9601,7 +9602,7 @@ st416:
 	if ( ++p == pe )
 		goto _test_eof416;
 case 416:
-#line 9605 "inc/vcf/validator_detail_v42.hpp"
+#line 9606 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr583;
 		case 95: goto tr582;
@@ -9628,7 +9629,7 @@ st417:
 	if ( ++p == pe )
 		goto _test_eof417;
 case 417:
-#line 9632 "inc/vcf/validator_detail_v42.hpp"
+#line 9633 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st420;
 	if ( (*p) < 45 ) {
@@ -9660,7 +9661,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 9664 "inc/vcf/validator_detail_v42.hpp"
+#line 9665 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 62: goto tr578;
@@ -9681,7 +9682,7 @@ st419:
 	if ( ++p == pe )
 		goto _test_eof419;
 case 419:
-#line 9685 "inc/vcf/validator_detail_v42.hpp"
+#line 9686 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -9718,7 +9719,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9722 "inc/vcf/validator_detail_v42.hpp"
+#line 9723 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 92: goto tr592;
@@ -9746,7 +9747,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9750 "inc/vcf/validator_detail_v42.hpp"
+#line 9751 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st414;
 		case 62: goto st419;
@@ -9772,7 +9773,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9776 "inc/vcf/validator_detail_v42.hpp"
+#line 9777 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 92: goto tr592;
@@ -9794,7 +9795,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9798 "inc/vcf/validator_detail_v42.hpp"
+#line 9799 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr596;
@@ -9834,7 +9835,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9838 "inc/vcf/validator_detail_v42.hpp"
+#line 9839 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9885,7 +9886,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9889 "inc/vcf/validator_detail_v42.hpp"
+#line 9890 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9936,7 +9937,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9940 "inc/vcf/validator_detail_v42.hpp"
+#line 9941 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9979,7 +9980,7 @@ st428:
 	if ( ++p == pe )
 		goto _test_eof428;
 case 428:
-#line 9983 "inc/vcf/validator_detail_v42.hpp"
+#line 9984 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr604;
 		case 44: goto tr590;
@@ -10009,7 +10010,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 10013 "inc/vcf/validator_detail_v42.hpp"
+#line 10014 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr607;
@@ -10049,7 +10050,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 10053 "inc/vcf/validator_detail_v42.hpp"
+#line 10054 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -10079,7 +10080,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 10083 "inc/vcf/validator_detail_v42.hpp"
+#line 10084 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 44: goto tr607;
@@ -10099,7 +10100,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 10103 "inc/vcf/validator_detail_v42.hpp"
+#line 10104 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr588;
 		case 44: goto tr610;
@@ -10123,7 +10124,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10127 "inc/vcf/validator_detail_v42.hpp"
+#line 10128 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr613;
@@ -10141,7 +10142,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10145 "inc/vcf/validator_detail_v42.hpp"
+#line 10146 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr614;
@@ -10159,7 +10160,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10163 "inc/vcf/validator_detail_v42.hpp"
+#line 10164 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr615;
@@ -10177,7 +10178,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10181 "inc/vcf/validator_detail_v42.hpp"
+#line 10182 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr616;
@@ -10195,7 +10196,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10199 "inc/vcf/validator_detail_v42.hpp"
+#line 10200 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr617;
@@ -10213,7 +10214,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10217 "inc/vcf/validator_detail_v42.hpp"
+#line 10218 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr618;
@@ -10231,7 +10232,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10235 "inc/vcf/validator_detail_v42.hpp"
+#line 10236 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr619;
@@ -10249,7 +10250,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10253 "inc/vcf/validator_detail_v42.hpp"
+#line 10254 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr620;
@@ -10267,7 +10268,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10271 "inc/vcf/validator_detail_v42.hpp"
+#line 10272 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st442;
@@ -10294,7 +10295,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10298 "inc/vcf/validator_detail_v42.hpp"
+#line 10299 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st444;
 	goto tr612;
@@ -10318,7 +10319,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10322 "inc/vcf/validator_detail_v42.hpp"
+#line 10323 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10344,7 +10345,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10348 "inc/vcf/validator_detail_v42.hpp"
+#line 10349 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10455,7 +10456,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 10459 "inc/vcf/validator_detail_v42.hpp"
+#line 10460 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr641;
@@ -10476,7 +10477,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 10480 "inc/vcf/validator_detail_v42.hpp"
+#line 10481 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr643;
@@ -10511,7 +10512,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 10515 "inc/vcf/validator_detail_v42.hpp"
+#line 10516 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr641;
@@ -10611,7 +10612,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10615 "inc/vcf/validator_detail_v42.hpp"
+#line 10616 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 80 )
 		goto st471;
 	goto tr647;
@@ -10646,7 +10647,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10650 "inc/vcf/validator_detail_v42.hpp"
+#line 10651 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st475;
 	goto tr647;
@@ -10674,7 +10675,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 10678 "inc/vcf/validator_detail_v42.hpp"
+#line 10679 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 82 )
 		goto st478;
 	goto tr647;
@@ -10709,7 +10710,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10713 "inc/vcf/validator_detail_v42.hpp"
+#line 10714 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 65 )
 		goto st482;
 	goto tr647;
@@ -10744,7 +10745,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10748 "inc/vcf/validator_detail_v42.hpp"
+#line 10749 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 81 )
 		goto st486;
 	goto tr647;
@@ -10786,7 +10787,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10790 "inc/vcf/validator_detail_v42.hpp"
+#line 10791 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st491;
 	goto tr647;
@@ -10842,7 +10843,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10846 "inc/vcf/validator_detail_v42.hpp"
+#line 10847 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st498;
 	goto tr647;
@@ -10887,7 +10888,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10891 "inc/vcf/validator_detail_v42.hpp"
+#line 10892 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st503;
 	goto tr687;
@@ -10953,7 +10954,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10957 "inc/vcf/validator_detail_v42.hpp"
+#line 10958 "inc/vcf/validator_detail_v42.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr695;
 	goto tr687;
@@ -10977,7 +10978,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10981 "inc/vcf/validator_detail_v42.hpp"
+#line 10982 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr696;
 		case 10: goto tr697;
@@ -11026,7 +11027,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 11030 "inc/vcf/validator_detail_v42.hpp"
+#line 11031 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr916;
 		case 13: goto tr917;
@@ -11077,7 +11078,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 11081 "inc/vcf/validator_detail_v42.hpp"
+#line 11082 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr920;
 		case 13: goto tr921;
@@ -11119,7 +11120,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11123 "inc/vcf/validator_detail_v42.hpp"
+#line 11124 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st654;
 	goto st0;
@@ -11161,7 +11162,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11165 "inc/vcf/validator_detail_v42.hpp"
+#line 11166 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr703;
 		case 59: goto tr704;
@@ -11204,7 +11205,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11208 "inc/vcf/validator_detail_v42.hpp"
+#line 11209 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr706;
 	goto tr705;
@@ -11228,7 +11229,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11232 "inc/vcf/validator_detail_v42.hpp"
+#line 11233 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr707;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11258,7 +11259,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11262 "inc/vcf/validator_detail_v42.hpp"
+#line 11263 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr710;
@@ -11285,7 +11286,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11289 "inc/vcf/validator_detail_v42.hpp"
+#line 11290 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr711;
 		case 59: goto tr713;
@@ -11311,7 +11312,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11315 "inc/vcf/validator_detail_v42.hpp"
+#line 11316 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr715;
 		case 67: goto tr715;
@@ -11345,7 +11346,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11349 "inc/vcf/validator_detail_v42.hpp"
+#line 11350 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr716;
 		case 65: goto tr717;
@@ -11378,7 +11379,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11382 "inc/vcf/validator_detail_v42.hpp"
+#line 11383 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr720;
@@ -11417,7 +11418,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11421 "inc/vcf/validator_detail_v42.hpp"
+#line 11422 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -11441,7 +11442,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11445 "inc/vcf/validator_detail_v42.hpp"
+#line 11446 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr728;
 		case 45: goto tr728;
@@ -11466,7 +11467,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11470 "inc/vcf/validator_detail_v42.hpp"
+#line 11471 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr734;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11492,7 +11493,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11496 "inc/vcf/validator_detail_v42.hpp"
+#line 11497 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 46: goto tr736;
@@ -11520,7 +11521,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11524 "inc/vcf/validator_detail_v42.hpp"
+#line 11525 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr740;
 		case 58: goto tr739;
@@ -11556,7 +11557,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11560 "inc/vcf/validator_detail_v42.hpp"
+#line 11561 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto st525;
 	if ( (*p) < 65 ) {
@@ -11600,7 +11601,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11604 "inc/vcf/validator_detail_v42.hpp"
+#line 11605 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 59: goto tr745;
@@ -11626,7 +11627,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11630 "inc/vcf/validator_detail_v42.hpp"
+#line 11631 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr748;
 		case 49: goto tr750;
@@ -11684,7 +11685,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11688 "inc/vcf/validator_detail_v42.hpp"
+#line 11689 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr761;
 		case 60: goto tr761;
@@ -11730,7 +11731,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 11734 "inc/vcf/validator_detail_v42.hpp"
+#line 11735 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -11765,7 +11766,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 11769 "inc/vcf/validator_detail_v42.hpp"
+#line 11770 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr764;
@@ -11795,7 +11796,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 11799 "inc/vcf/validator_detail_v42.hpp"
+#line 11800 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 58: goto tr767;
@@ -11827,7 +11828,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 11831 "inc/vcf/validator_detail_v42.hpp"
+#line 11832 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr770;
 	if ( (*p) < 48 ) {
@@ -11859,7 +11860,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 11863 "inc/vcf/validator_detail_v42.hpp"
+#line 11864 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -11918,7 +11919,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 11922 "inc/vcf/validator_detail_v42.hpp"
+#line 11923 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr920;
 		case 13: goto tr921;
@@ -11947,7 +11948,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 11951 "inc/vcf/validator_detail_v42.hpp"
+#line 11952 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr772;
@@ -11977,7 +11978,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 11981 "inc/vcf/validator_detail_v42.hpp"
+#line 11982 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr773;
 		case 62: goto tr774;
@@ -12001,7 +12002,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 12005 "inc/vcf/validator_detail_v42.hpp"
+#line 12006 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr775;
 	goto tr702;
@@ -12054,7 +12055,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 12058 "inc/vcf/validator_detail_v42.hpp"
+#line 12059 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st657;
 	goto tr776;
@@ -12068,7 +12069,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12072 "inc/vcf/validator_detail_v42.hpp"
+#line 12073 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr779;
@@ -12095,7 +12096,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 12099 "inc/vcf/validator_detail_v42.hpp"
+#line 12100 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -12117,7 +12118,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 12121 "inc/vcf/validator_detail_v42.hpp"
+#line 12122 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -12154,7 +12155,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 12158 "inc/vcf/validator_detail_v42.hpp"
+#line 12159 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -12182,7 +12183,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12186 "inc/vcf/validator_detail_v42.hpp"
+#line 12187 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 49: goto tr750;
 		case 58: goto tr747;
@@ -12233,7 +12234,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 12237 "inc/vcf/validator_detail_v42.hpp"
+#line 12238 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12255,7 +12256,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 12259 "inc/vcf/validator_detail_v42.hpp"
+#line 12260 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12277,7 +12278,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 12281 "inc/vcf/validator_detail_v42.hpp"
+#line 12282 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12299,7 +12300,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 12303 "inc/vcf/validator_detail_v42.hpp"
+#line 12304 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12321,7 +12322,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12325 "inc/vcf/validator_detail_v42.hpp"
+#line 12326 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr781;
@@ -12338,7 +12339,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 12342 "inc/vcf/validator_detail_v42.hpp"
+#line 12343 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12358,7 +12359,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 12362 "inc/vcf/validator_detail_v42.hpp"
+#line 12363 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12379,7 +12380,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12383 "inc/vcf/validator_detail_v42.hpp"
+#line 12384 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr783;
 	goto tr782;
@@ -12393,7 +12394,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 12397 "inc/vcf/validator_detail_v42.hpp"
+#line 12398 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12415,7 +12416,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 12419 "inc/vcf/validator_detail_v42.hpp"
+#line 12420 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12440,7 +12441,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12444 "inc/vcf/validator_detail_v42.hpp"
+#line 12445 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr784;
 	if ( (*p) > 58 ) {
@@ -12459,7 +12460,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12463 "inc/vcf/validator_detail_v42.hpp"
+#line 12464 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr786;
 	if ( (*p) < 45 ) {
@@ -12481,7 +12482,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 12485 "inc/vcf/validator_detail_v42.hpp"
+#line 12486 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12507,7 +12508,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12511 "inc/vcf/validator_detail_v42.hpp"
+#line 12512 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr787;
 	if ( (*p) > 58 ) {
@@ -12526,7 +12527,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12530 "inc/vcf/validator_detail_v42.hpp"
+#line 12531 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr789;
 	goto tr788;
@@ -12540,7 +12541,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 12544 "inc/vcf/validator_detail_v42.hpp"
+#line 12545 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12561,7 +12562,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12565 "inc/vcf/validator_detail_v42.hpp"
+#line 12566 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr790;
 	if ( (*p) > 58 ) {
@@ -12580,7 +12581,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12584 "inc/vcf/validator_detail_v42.hpp"
+#line 12585 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr792;
 		case 45: goto tr792;
@@ -12600,7 +12601,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12604 "inc/vcf/validator_detail_v42.hpp"
+#line 12605 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr794;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12616,7 +12617,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 12620 "inc/vcf/validator_detail_v42.hpp"
+#line 12621 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12640,7 +12641,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12644 "inc/vcf/validator_detail_v42.hpp"
+#line 12645 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr796;
 	goto tr791;
@@ -12654,7 +12655,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 12658 "inc/vcf/validator_detail_v42.hpp"
+#line 12659 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12677,7 +12678,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12681 "inc/vcf/validator_detail_v42.hpp"
+#line 12682 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr797;
 		case 45: goto tr797;
@@ -12695,7 +12696,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12699 "inc/vcf/validator_detail_v42.hpp"
+#line 12700 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr798;
 	goto tr791;
@@ -12709,7 +12710,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 12713 "inc/vcf/validator_detail_v42.hpp"
+#line 12714 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12730,7 +12731,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12734 "inc/vcf/validator_detail_v42.hpp"
+#line 12735 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr799;
 	goto tr791;
@@ -12744,7 +12745,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12748 "inc/vcf/validator_detail_v42.hpp"
+#line 12749 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr800;
 	goto tr791;
@@ -12758,7 +12759,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 12762 "inc/vcf/validator_detail_v42.hpp"
+#line 12763 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12777,7 +12778,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12781 "inc/vcf/validator_detail_v42.hpp"
+#line 12782 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr801;
 	goto tr791;
@@ -12791,7 +12792,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12795 "inc/vcf/validator_detail_v42.hpp"
+#line 12796 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr800;
 	goto tr791;
@@ -12805,7 +12806,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12809 "inc/vcf/validator_detail_v42.hpp"
+#line 12810 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr802;
 	if ( (*p) > 58 ) {
@@ -12824,7 +12825,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12828 "inc/vcf/validator_detail_v42.hpp"
+#line 12829 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr804;
 	goto tr803;
@@ -12838,7 +12839,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 12842 "inc/vcf/validator_detail_v42.hpp"
+#line 12843 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12862,7 +12863,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 12866 "inc/vcf/validator_detail_v42.hpp"
+#line 12867 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12884,7 +12885,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12888 "inc/vcf/validator_detail_v42.hpp"
+#line 12889 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr805;
 	if ( (*p) > 58 ) {
@@ -12903,7 +12904,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12907 "inc/vcf/validator_detail_v42.hpp"
+#line 12908 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr807;
 		case 45: goto tr807;
@@ -12923,7 +12924,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12927 "inc/vcf/validator_detail_v42.hpp"
+#line 12928 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr809;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12939,7 +12940,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 12943 "inc/vcf/validator_detail_v42.hpp"
+#line 12944 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12962,7 +12963,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12966 "inc/vcf/validator_detail_v42.hpp"
+#line 12967 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr811;
 	goto tr806;
@@ -12976,7 +12977,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 12980 "inc/vcf/validator_detail_v42.hpp"
+#line 12981 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12998,7 +12999,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 13002 "inc/vcf/validator_detail_v42.hpp"
+#line 13003 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr812;
 		case 45: goto tr812;
@@ -13016,7 +13017,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 13020 "inc/vcf/validator_detail_v42.hpp"
+#line 13021 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr813;
 	goto tr806;
@@ -13030,7 +13031,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 13034 "inc/vcf/validator_detail_v42.hpp"
+#line 13035 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13050,7 +13051,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 13054 "inc/vcf/validator_detail_v42.hpp"
+#line 13055 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr814;
 	goto tr806;
@@ -13064,7 +13065,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 13068 "inc/vcf/validator_detail_v42.hpp"
+#line 13069 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr815;
 	goto tr806;
@@ -13078,7 +13079,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 13082 "inc/vcf/validator_detail_v42.hpp"
+#line 13083 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13096,7 +13097,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 13100 "inc/vcf/validator_detail_v42.hpp"
+#line 13101 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr816;
 	goto tr806;
@@ -13110,7 +13111,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 13114 "inc/vcf/validator_detail_v42.hpp"
+#line 13115 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr815;
 	goto tr806;
@@ -13128,7 +13129,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 13132 "inc/vcf/validator_detail_v42.hpp"
+#line 13133 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13150,7 +13151,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 13154 "inc/vcf/validator_detail_v42.hpp"
+#line 13155 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13172,7 +13173,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 13176 "inc/vcf/validator_detail_v42.hpp"
+#line 13177 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13194,7 +13195,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 13198 "inc/vcf/validator_detail_v42.hpp"
+#line 13199 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13216,7 +13217,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 13220 "inc/vcf/validator_detail_v42.hpp"
+#line 13221 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr817;
 	if ( (*p) > 58 ) {
@@ -13235,7 +13236,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 13239 "inc/vcf/validator_detail_v42.hpp"
+#line 13240 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr819;
 	goto tr818;
@@ -13249,7 +13250,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 13253 "inc/vcf/validator_detail_v42.hpp"
+#line 13254 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 68: goto tr820;
 		case 80: goto tr820;
@@ -13275,7 +13276,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 13279 "inc/vcf/validator_detail_v42.hpp"
+#line 13280 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13300,7 +13301,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 13304 "inc/vcf/validator_detail_v42.hpp"
+#line 13305 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13323,7 +13324,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 13327 "inc/vcf/validator_detail_v42.hpp"
+#line 13328 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13344,7 +13345,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 13348 "inc/vcf/validator_detail_v42.hpp"
+#line 13349 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr822;
 	goto tr821;
@@ -13358,7 +13359,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 13362 "inc/vcf/validator_detail_v42.hpp"
+#line 13363 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13376,7 +13377,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 13380 "inc/vcf/validator_detail_v42.hpp"
+#line 13381 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr823;
 	if ( (*p) > 58 ) {
@@ -13395,7 +13396,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 13399 "inc/vcf/validator_detail_v42.hpp"
+#line 13400 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr825;
 	goto tr824;
@@ -13409,7 +13410,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 13413 "inc/vcf/validator_detail_v42.hpp"
+#line 13414 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13433,7 +13434,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 13437 "inc/vcf/validator_detail_v42.hpp"
+#line 13438 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13455,7 +13456,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 13459 "inc/vcf/validator_detail_v42.hpp"
+#line 13460 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13477,7 +13478,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 13481 "inc/vcf/validator_detail_v42.hpp"
+#line 13482 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr826;
 	if ( (*p) > 58 ) {
@@ -13496,7 +13497,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 13500 "inc/vcf/validator_detail_v42.hpp"
+#line 13501 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr828;
 	goto tr827;
@@ -13510,7 +13511,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 13514 "inc/vcf/validator_detail_v42.hpp"
+#line 13515 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13534,7 +13535,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 13538 "inc/vcf/validator_detail_v42.hpp"
+#line 13539 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13557,7 +13558,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 13561 "inc/vcf/validator_detail_v42.hpp"
+#line 13562 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13578,7 +13579,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 13582 "inc/vcf/validator_detail_v42.hpp"
+#line 13583 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr830;
 	goto tr829;
@@ -13592,7 +13593,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 13596 "inc/vcf/validator_detail_v42.hpp"
+#line 13597 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13610,7 +13611,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 13614 "inc/vcf/validator_detail_v42.hpp"
+#line 13615 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13631,7 +13632,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 13635 "inc/vcf/validator_detail_v42.hpp"
+#line 13636 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr832;
 	goto tr831;
@@ -13645,7 +13646,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 13649 "inc/vcf/validator_detail_v42.hpp"
+#line 13650 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13667,7 +13668,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 13671 "inc/vcf/validator_detail_v42.hpp"
+#line 13672 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13689,7 +13690,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 13693 "inc/vcf/validator_detail_v42.hpp"
+#line 13694 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 48: goto tr833;
 		case 61: goto tr834;
@@ -13710,7 +13711,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 13714 "inc/vcf/validator_detail_v42.hpp"
+#line 13715 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr835;
 	if ( (*p) > 58 ) {
@@ -13729,7 +13730,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 13733 "inc/vcf/validator_detail_v42.hpp"
+#line 13734 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr837;
 	goto tr836;
@@ -13743,7 +13744,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 13747 "inc/vcf/validator_detail_v42.hpp"
+#line 13748 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13763,7 +13764,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 13767 "inc/vcf/validator_detail_v42.hpp"
+#line 13768 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr839;
 		case 45: goto tr839;
@@ -13783,7 +13784,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 13787 "inc/vcf/validator_detail_v42.hpp"
+#line 13788 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr841;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13799,7 +13800,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 13803 "inc/vcf/validator_detail_v42.hpp"
+#line 13804 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13822,7 +13823,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 13826 "inc/vcf/validator_detail_v42.hpp"
+#line 13827 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr843;
 	goto tr838;
@@ -13836,7 +13837,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 13840 "inc/vcf/validator_detail_v42.hpp"
+#line 13841 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13858,7 +13859,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 13862 "inc/vcf/validator_detail_v42.hpp"
+#line 13863 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr844;
 		case 45: goto tr844;
@@ -13876,7 +13877,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 13880 "inc/vcf/validator_detail_v42.hpp"
+#line 13881 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr845;
 	goto tr838;
@@ -13890,7 +13891,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 13894 "inc/vcf/validator_detail_v42.hpp"
+#line 13895 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13910,7 +13911,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 13914 "inc/vcf/validator_detail_v42.hpp"
+#line 13915 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr846;
 	goto tr838;
@@ -13924,7 +13925,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 13928 "inc/vcf/validator_detail_v42.hpp"
+#line 13929 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr847;
 	goto tr838;
@@ -13938,7 +13939,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 13942 "inc/vcf/validator_detail_v42.hpp"
+#line 13943 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13956,7 +13957,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 13960 "inc/vcf/validator_detail_v42.hpp"
+#line 13961 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr848;
 	goto tr838;
@@ -13970,7 +13971,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 13974 "inc/vcf/validator_detail_v42.hpp"
+#line 13975 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr847;
 	goto tr838;
@@ -13988,7 +13989,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 13992 "inc/vcf/validator_detail_v42.hpp"
+#line 13993 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14010,7 +14011,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 14014 "inc/vcf/validator_detail_v42.hpp"
+#line 14015 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr849;
 	if ( (*p) > 58 ) {
@@ -14029,7 +14030,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 14033 "inc/vcf/validator_detail_v42.hpp"
+#line 14034 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr851;
 	goto tr850;
@@ -14043,7 +14044,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 14047 "inc/vcf/validator_detail_v42.hpp"
+#line 14048 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14067,7 +14068,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 14071 "inc/vcf/validator_detail_v42.hpp"
+#line 14072 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14090,7 +14091,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 14094 "inc/vcf/validator_detail_v42.hpp"
+#line 14095 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr852;
 	if ( (*p) > 58 ) {
@@ -14109,7 +14110,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 14113 "inc/vcf/validator_detail_v42.hpp"
+#line 14114 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr854;
 		case 45: goto tr854;
@@ -14129,7 +14130,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 14133 "inc/vcf/validator_detail_v42.hpp"
+#line 14134 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr856;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14145,7 +14146,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 14149 "inc/vcf/validator_detail_v42.hpp"
+#line 14150 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14168,7 +14169,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 14172 "inc/vcf/validator_detail_v42.hpp"
+#line 14173 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr858;
 	goto tr853;
@@ -14182,7 +14183,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 14186 "inc/vcf/validator_detail_v42.hpp"
+#line 14187 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14204,7 +14205,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 14208 "inc/vcf/validator_detail_v42.hpp"
+#line 14209 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr859;
 		case 45: goto tr859;
@@ -14222,7 +14223,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 14226 "inc/vcf/validator_detail_v42.hpp"
+#line 14227 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr860;
 	goto tr853;
@@ -14236,7 +14237,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 14240 "inc/vcf/validator_detail_v42.hpp"
+#line 14241 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14256,7 +14257,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 14260 "inc/vcf/validator_detail_v42.hpp"
+#line 14261 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr861;
 	goto tr853;
@@ -14270,7 +14271,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 14274 "inc/vcf/validator_detail_v42.hpp"
+#line 14275 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr862;
 	goto tr853;
@@ -14284,7 +14285,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 14288 "inc/vcf/validator_detail_v42.hpp"
+#line 14289 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14302,7 +14303,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 14306 "inc/vcf/validator_detail_v42.hpp"
+#line 14307 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr863;
 	goto tr853;
@@ -14316,7 +14317,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 14320 "inc/vcf/validator_detail_v42.hpp"
+#line 14321 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr862;
 	goto tr853;
@@ -14330,7 +14331,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 14334 "inc/vcf/validator_detail_v42.hpp"
+#line 14335 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14352,7 +14353,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 14356 "inc/vcf/validator_detail_v42.hpp"
+#line 14357 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14374,7 +14375,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 14378 "inc/vcf/validator_detail_v42.hpp"
+#line 14379 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14396,7 +14397,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 14400 "inc/vcf/validator_detail_v42.hpp"
+#line 14401 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14418,7 +14419,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 14422 "inc/vcf/validator_detail_v42.hpp"
+#line 14423 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14440,7 +14441,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 14444 "inc/vcf/validator_detail_v42.hpp"
+#line 14445 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14461,7 +14462,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 14465 "inc/vcf/validator_detail_v42.hpp"
+#line 14466 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr865;
 	goto tr864;
@@ -14475,7 +14476,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 14479 "inc/vcf/validator_detail_v42.hpp"
+#line 14480 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14497,7 +14498,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 14501 "inc/vcf/validator_detail_v42.hpp"
+#line 14502 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14519,7 +14520,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 14523 "inc/vcf/validator_detail_v42.hpp"
+#line 14524 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14541,7 +14542,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 14545 "inc/vcf/validator_detail_v42.hpp"
+#line 14546 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14563,7 +14564,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 14567 "inc/vcf/validator_detail_v42.hpp"
+#line 14568 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14585,7 +14586,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 14589 "inc/vcf/validator_detail_v42.hpp"
+#line 14590 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14607,7 +14608,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 14611 "inc/vcf/validator_detail_v42.hpp"
+#line 14612 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14629,7 +14630,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 14633 "inc/vcf/validator_detail_v42.hpp"
+#line 14634 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14651,7 +14652,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 14655 "inc/vcf/validator_detail_v42.hpp"
+#line 14656 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14673,7 +14674,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 14677 "inc/vcf/validator_detail_v42.hpp"
+#line 14678 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14694,7 +14695,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 14698 "inc/vcf/validator_detail_v42.hpp"
+#line 14699 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr867;
 	goto tr866;
@@ -14708,7 +14709,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 14712 "inc/vcf/validator_detail_v42.hpp"
+#line 14713 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14730,7 +14731,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 14734 "inc/vcf/validator_detail_v42.hpp"
+#line 14735 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14769,7 +14770,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 14773 "inc/vcf/validator_detail_v42.hpp"
+#line 14774 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr739;
 	if ( (*p) < 65 ) {
@@ -14807,7 +14808,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 14811 "inc/vcf/validator_detail_v42.hpp"
+#line 14812 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 58: goto st525;
@@ -14843,7 +14844,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 14847 "inc/vcf/validator_detail_v42.hpp"
+#line 14848 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr868;
 	goto tr727;
@@ -14857,7 +14858,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 14861 "inc/vcf/validator_detail_v42.hpp"
+#line 14862 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 69: goto tr737;
@@ -14876,7 +14877,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 14880 "inc/vcf/validator_detail_v42.hpp"
+#line 14881 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr869;
 		case 45: goto tr869;
@@ -14894,7 +14895,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 14898 "inc/vcf/validator_detail_v42.hpp"
+#line 14899 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr870;
 	goto tr727;
@@ -14908,7 +14909,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 14912 "inc/vcf/validator_detail_v42.hpp"
+#line 14913 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14934,7 +14935,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 14938 "inc/vcf/validator_detail_v42.hpp"
+#line 14939 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr871;
 	goto tr727;
@@ -14948,7 +14949,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 14952 "inc/vcf/validator_detail_v42.hpp"
+#line 14953 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr872;
 	goto tr727;
@@ -14972,7 +14973,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 14976 "inc/vcf/validator_detail_v42.hpp"
+#line 14977 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	goto tr727;
@@ -14990,7 +14991,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 14994 "inc/vcf/validator_detail_v42.hpp"
+#line 14995 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr873;
 	goto tr727;
@@ -15004,7 +15005,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 15008 "inc/vcf/validator_detail_v42.hpp"
+#line 15009 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr872;
 	goto tr727;
@@ -15018,7 +15019,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 15022 "inc/vcf/validator_detail_v42.hpp"
+#line 15023 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr874;
@@ -15057,7 +15058,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 15061 "inc/vcf/validator_detail_v42.hpp"
+#line 15062 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr875;
 		case 67: goto tr875;
@@ -15081,7 +15082,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 15085 "inc/vcf/validator_detail_v42.hpp"
+#line 15086 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15117,7 +15118,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 15121 "inc/vcf/validator_detail_v42.hpp"
+#line 15122 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr876;
 	if ( (*p) < 63 ) {
@@ -15157,7 +15158,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 15161 "inc/vcf/validator_detail_v42.hpp"
+#line 15162 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto tr878;
 	if ( (*p) < 45 ) {
@@ -15189,7 +15190,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 15193 "inc/vcf/validator_detail_v42.hpp"
+#line 15194 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15218,7 +15219,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 15222 "inc/vcf/validator_detail_v42.hpp"
+#line 15223 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr883;
 	if ( (*p) < 65 ) {
@@ -15240,7 +15241,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 15244 "inc/vcf/validator_detail_v42.hpp"
+#line 15245 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr884;
 		case 61: goto tr882;
@@ -15264,7 +15265,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 15268 "inc/vcf/validator_detail_v42.hpp"
+#line 15269 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr885;
 	goto tr718;
@@ -15278,7 +15279,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 15282 "inc/vcf/validator_detail_v42.hpp"
+#line 15283 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr878;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15294,7 +15295,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 15298 "inc/vcf/validator_detail_v42.hpp"
+#line 15299 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr886;
@@ -15314,7 +15315,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 15318 "inc/vcf/validator_detail_v42.hpp"
+#line 15319 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr886;
 		case 62: goto tr887;
@@ -15338,7 +15339,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 15342 "inc/vcf/validator_detail_v42.hpp"
+#line 15343 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr884;
 	goto tr718;
@@ -15352,7 +15353,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 15356 "inc/vcf/validator_detail_v42.hpp"
+#line 15357 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr889;
 	if ( (*p) < 65 ) {
@@ -15374,7 +15375,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 15378 "inc/vcf/validator_detail_v42.hpp"
+#line 15379 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr890;
 		case 61: goto tr888;
@@ -15398,7 +15399,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 15402 "inc/vcf/validator_detail_v42.hpp"
+#line 15403 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr891;
 	goto tr718;
@@ -15412,7 +15413,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 15416 "inc/vcf/validator_detail_v42.hpp"
+#line 15417 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr878;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15428,7 +15429,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 15432 "inc/vcf/validator_detail_v42.hpp"
+#line 15433 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr892;
@@ -15448,7 +15449,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 15452 "inc/vcf/validator_detail_v42.hpp"
+#line 15453 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr892;
 		case 62: goto tr893;
@@ -15472,7 +15473,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 15476 "inc/vcf/validator_detail_v42.hpp"
+#line 15477 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr890;
 	goto tr718;
@@ -15490,7 +15491,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 15494 "inc/vcf/validator_detail_v42.hpp"
+#line 15495 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr895;
 	if ( (*p) < 65 ) {
@@ -15512,7 +15513,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 15516 "inc/vcf/validator_detail_v42.hpp"
+#line 15517 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr896;
 		case 61: goto tr894;
@@ -15536,7 +15537,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 15540 "inc/vcf/validator_detail_v42.hpp"
+#line 15541 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr897;
 	goto tr718;
@@ -15550,7 +15551,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 15554 "inc/vcf/validator_detail_v42.hpp"
+#line 15555 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr898;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15566,7 +15567,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 15570 "inc/vcf/validator_detail_v42.hpp"
+#line 15571 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr899;
@@ -15586,7 +15587,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 15590 "inc/vcf/validator_detail_v42.hpp"
+#line 15591 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr899;
 		case 62: goto tr900;
@@ -15610,7 +15611,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 15614 "inc/vcf/validator_detail_v42.hpp"
+#line 15615 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr896;
 	goto tr718;
@@ -15628,7 +15629,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 15632 "inc/vcf/validator_detail_v42.hpp"
+#line 15633 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr902;
 	if ( (*p) < 65 ) {
@@ -15650,7 +15651,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 15654 "inc/vcf/validator_detail_v42.hpp"
+#line 15655 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr903;
 		case 61: goto tr901;
@@ -15674,7 +15675,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 15678 "inc/vcf/validator_detail_v42.hpp"
+#line 15679 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr904;
 	goto tr718;
@@ -15688,7 +15689,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 15692 "inc/vcf/validator_detail_v42.hpp"
+#line 15693 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr898;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15704,7 +15705,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 15708 "inc/vcf/validator_detail_v42.hpp"
+#line 15709 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr905;
@@ -15724,7 +15725,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 15728 "inc/vcf/validator_detail_v42.hpp"
+#line 15729 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr905;
 		case 62: goto tr906;
@@ -15748,7 +15749,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 15752 "inc/vcf/validator_detail_v42.hpp"
+#line 15753 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr903;
 	goto tr718;
@@ -15766,7 +15767,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 15770 "inc/vcf/validator_detail_v42.hpp"
+#line 15771 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 65: goto tr875;
@@ -15821,7 +15822,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 15825 "inc/vcf/validator_detail_v42.hpp"
+#line 15826 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st653;
 	goto tr687;
@@ -15850,7 +15851,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 15854 "inc/vcf/validator_detail_v42.hpp"
+#line 15855 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -15870,7 +15871,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 15874 "inc/vcf/validator_detail_v42.hpp"
+#line 15875 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr910;
 		case 13: goto tr911;
@@ -15887,14 +15888,14 @@ tr910:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 825 "src/vcf/vcf_v42.ragel"
+#line 826 "src/vcf/vcf_v42.ragel"
 	{ {goto st28;} }
 	goto st729;
 st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 15898 "inc/vcf/validator_detail_v42.hpp"
+#line 15899 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 tr914:
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -15912,7 +15913,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 15916 "inc/vcf/validator_detail_v42.hpp"
+#line 15917 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr913;
 		case 13: goto tr914;
@@ -15929,14 +15930,14 @@ tr913:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 826 "src/vcf/vcf_v42.ragel"
+#line 827 "src/vcf/vcf_v42.ragel"
 	{ {goto st657;} }
 	goto st730;
 st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 15940 "inc/vcf/validator_detail_v42.hpp"
+#line 15941 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -16799,7 +16800,8 @@ case 730:
 #line 227 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         p--; {goto st651;}
     }
 #line 60 "src/vcf/vcf_v42.ragel"
@@ -16830,7 +16832,7 @@ case 730:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -16849,7 +16851,7 @@ case 730:
 	case 380: 
 	case 381: 
 	case 382: 
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 247 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -16889,7 +16891,7 @@ case 730:
 	case 430: 
 	case 431: 
 	case 432: 
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 253 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -16924,7 +16926,7 @@ case 730:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -16971,7 +16973,7 @@ case 730:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17017,7 +17019,7 @@ case 730:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17038,7 +17040,7 @@ case 730:
 	case 313: 
 	case 314: 
 	case 321: 
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 297 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -17060,7 +17062,7 @@ case 730:
 	case 441: 
 	case 442: 
 	case 443: 
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 303 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -17082,7 +17084,7 @@ case 730:
 	case 330: 
 	case 331: 
 	case 371: 
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17130,7 +17132,7 @@ case 730:
 	case 499: 
 	case 500: 
 	case 501: 
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 341 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17162,7 +17164,7 @@ case 730:
 	case 532: 
 	case 533: 
 	case 534: 
-#line 357 "src/vcf/vcf_v42.ragel"
+#line 358 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st652;}
@@ -17175,7 +17177,7 @@ case 730:
 	break;
 	case 513: 
 	case 514: 
-#line 363 "src/vcf/vcf_v42.ragel"
+#line 364 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st652;}
@@ -17188,7 +17190,7 @@ case 730:
 	break;
 	case 515: 
 	case 516: 
-#line 369 "src/vcf/vcf_v42.ragel"
+#line 370 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st652;}
@@ -17201,7 +17203,7 @@ case 730:
 	break;
 	case 517: 
 	case 518: 
-#line 375 "src/vcf/vcf_v42.ragel"
+#line 376 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st652;}
@@ -17249,7 +17251,7 @@ case 730:
 	case 646: 
 	case 647: 
 	case 648: 
-#line 381 "src/vcf/vcf_v42.ragel"
+#line 382 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st652;}
@@ -17273,7 +17275,7 @@ case 730:
 	case 611: 
 	case 612: 
 	case 613: 
-#line 387 "src/vcf/vcf_v42.ragel"
+#line 388 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st652;}
@@ -17289,7 +17291,7 @@ case 730:
 	case 526: 
 	case 602: 
 	case 603: 
-#line 393 "src/vcf/vcf_v42.ragel"
+#line 394 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st652;}
@@ -17302,7 +17304,7 @@ case 730:
 	break;
 	case 529: 
 	case 530: 
-#line 559 "src/vcf/vcf_v42.ragel"
+#line 560 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st652;}
@@ -17314,7 +17316,7 @@ case 730:
     }
 	break;
 	case 536: 
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 566 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -17441,7 +17443,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 341 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17472,13 +17474,13 @@ case 730:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 239 "src/vcf/vcf_v42.ragel"
+#line 240 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -17490,12 +17492,12 @@ case 730:
     }
 	break;
 	case 122: 
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17509,12 +17511,12 @@ case 730:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 269 "src/vcf/vcf_v42.ragel"
+#line 270 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17528,12 +17530,12 @@ case 730:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 285 "src/vcf/vcf_v42.ragel"
+#line 286 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17546,12 +17548,12 @@ case 730:
 	break;
 	case 199: 
 	case 200: 
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 291 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17564,12 +17566,12 @@ case 730:
 	break;
 	case 265: 
 	case 266: 
-#line 290 "src/vcf/vcf_v42.ragel"
+#line 291 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17589,12 +17591,12 @@ case 730:
 	case 341: 
 	case 342: 
 	case 343: 
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17614,12 +17616,12 @@ case 730:
 	case 351: 
 	case 352: 
 	case 353: 
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 319 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17633,12 +17635,12 @@ case 730:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -17651,12 +17653,12 @@ case 730:
 	break;
 	case 412: 
 	case 413: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 253 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -17673,12 +17675,12 @@ case 730:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -17695,12 +17697,12 @@ case 730:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17717,12 +17719,12 @@ case 730:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17739,12 +17741,12 @@ case 730:
 	case 318: 
 	case 319: 
 	case 320: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 297 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -17757,12 +17759,12 @@ case 730:
 	break;
 	case 332: 
 	case 333: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17787,12 +17789,12 @@ case 730:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -17817,12 +17819,12 @@ case 730:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -17847,12 +17849,12 @@ case 730:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17877,12 +17879,12 @@ case 730:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17912,12 +17914,12 @@ case 730:
 	case 372: 
 	case 373: 
 	case 374: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17947,12 +17949,12 @@ case 730:
 	case 399: 
 	case 400: 
 	case 401: 
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 335 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 247 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -17984,12 +17986,12 @@ case 730:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 334 "src/vcf/vcf_v42.ragel"
+#line 335 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 303 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -18015,12 +18017,12 @@ case 730:
 	case 577: 
 	case 588: 
 	case 590: 
-#line 404 "src/vcf/vcf_v42.ragel"
+#line 405 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18032,12 +18034,12 @@ case 730:
     }
 	break;
 	case 538: 
-#line 409 "src/vcf/vcf_v42.ragel"
+#line 410 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18049,7 +18051,7 @@ case 730:
     }
 	break;
 	case 541: 
-#line 414 "src/vcf/vcf_v42.ragel"
+#line 415 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18057,7 +18059,7 @@ case 730:
                 "AA"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18069,7 +18071,7 @@ case 730:
     }
 	break;
 	case 543: 
-#line 422 "src/vcf/vcf_v42.ragel"
+#line 423 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18077,7 +18079,7 @@ case 730:
                 "AC"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18097,7 +18099,7 @@ case 730:
 	case 551: 
 	case 552: 
 	case 553: 
-#line 430 "src/vcf/vcf_v42.ragel"
+#line 431 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18105,7 +18107,7 @@ case 730:
                 "AF"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18117,7 +18119,7 @@ case 730:
     }
 	break;
 	case 555: 
-#line 438 "src/vcf/vcf_v42.ragel"
+#line 439 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18125,7 +18127,7 @@ case 730:
                 "AN"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18145,7 +18147,7 @@ case 730:
 	case 563: 
 	case 564: 
 	case 565: 
-#line 446 "src/vcf/vcf_v42.ragel"
+#line 447 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18153,7 +18155,7 @@ case 730:
                 "BQ"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18166,7 +18168,7 @@ case 730:
 	break;
 	case 567: 
 	case 568: 
-#line 454 "src/vcf/vcf_v42.ragel"
+#line 455 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18174,7 +18176,7 @@ case 730:
                 "CIGAR"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18186,7 +18188,7 @@ case 730:
     }
 	break;
 	case 569: 
-#line 462 "src/vcf/vcf_v42.ragel"
+#line 463 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18194,7 +18196,7 @@ case 730:
                 "DB"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18206,7 +18208,7 @@ case 730:
     }
 	break;
 	case 571: 
-#line 470 "src/vcf/vcf_v42.ragel"
+#line 471 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18214,7 +18216,7 @@ case 730:
                 "DP"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18226,7 +18228,7 @@ case 730:
     }
 	break;
 	case 573: 
-#line 478 "src/vcf/vcf_v42.ragel"
+#line 479 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18234,7 +18236,7 @@ case 730:
                 "END"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18246,7 +18248,7 @@ case 730:
     }
 	break;
 	case 574: 
-#line 486 "src/vcf/vcf_v42.ragel"
+#line 487 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18254,7 +18256,7 @@ case 730:
                 "H2"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18266,7 +18268,7 @@ case 730:
     }
 	break;
 	case 575: 
-#line 494 "src/vcf/vcf_v42.ragel"
+#line 495 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18274,7 +18276,7 @@ case 730:
                 "H3"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18294,7 +18296,7 @@ case 730:
 	case 585: 
 	case 586: 
 	case 587: 
-#line 502 "src/vcf/vcf_v42.ragel"
+#line 503 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18302,7 +18304,7 @@ case 730:
                 "MQ"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18314,7 +18316,7 @@ case 730:
     }
 	break;
 	case 578: 
-#line 510 "src/vcf/vcf_v42.ragel"
+#line 511 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18322,7 +18324,7 @@ case 730:
                 "MQ0"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18334,7 +18336,7 @@ case 730:
     }
 	break;
 	case 589: 
-#line 518 "src/vcf/vcf_v42.ragel"
+#line 519 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18342,7 +18344,7 @@ case 730:
                 "NS"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18362,7 +18364,7 @@ case 730:
 	case 597: 
 	case 598: 
 	case 599: 
-#line 526 "src/vcf/vcf_v42.ragel"
+#line 527 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18370,7 +18372,7 @@ case 730:
                 "SB"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18382,7 +18384,7 @@ case 730:
     }
 	break;
 	case 600: 
-#line 534 "src/vcf/vcf_v42.ragel"
+#line 535 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18390,7 +18392,7 @@ case 730:
                 "SOMATIC"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18402,7 +18404,7 @@ case 730:
     }
 	break;
 	case 601: 
-#line 542 "src/vcf/vcf_v42.ragel"
+#line 543 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18410,7 +18412,7 @@ case 730:
                 "VALIDATED"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18422,7 +18424,7 @@ case 730:
     }
 	break;
 	case 539: 
-#line 550 "src/vcf/vcf_v42.ragel"
+#line 551 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18430,7 +18432,7 @@ case 730:
                 "1000G"});
         p--; {goto st652;}
     }
-#line 399 "src/vcf/vcf_v42.ragel"
+#line 400 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18442,14 +18444,14 @@ case 730:
     }
 	break;
 	case 531: 
-#line 572 "src/vcf/vcf_v42.ragel"
+#line 573 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st652;}
     }
-#line 565 "src/vcf/vcf_v42.ragel"
+#line 566 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -18473,7 +18475,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 340 "src/vcf/vcf_v42.ragel"
+#line 341 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -18502,17 +18504,17 @@ case 730:
     }
 	break;
 	case 344: 
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 319 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -18524,17 +18526,17 @@ case 730:
     }
 	break;
 	case 354: 
-#line 318 "src/vcf/vcf_v42.ragel"
+#line 319 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -18546,17 +18548,17 @@ case 730:
     }
 	break;
 	case 334: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 313 "src/vcf/vcf_v42.ragel"
+#line 314 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -18570,17 +18572,17 @@ case 730:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -18594,17 +18596,17 @@ case 730:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -18618,17 +18620,17 @@ case 730:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -18642,17 +18644,17 @@ case 730:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -18666,17 +18668,17 @@ case 730:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -18690,17 +18692,17 @@ case 730:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -18714,17 +18716,17 @@ case 730:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -18738,17 +18740,17 @@ case 730:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 329 "src/vcf/vcf_v42.ragel"
+#line 330 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 324 "src/vcf/vcf_v42.ragel"
+#line 325 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -18760,47 +18762,47 @@ case 730:
     }
 	break;
 	case 24: 
-#line 234 "src/vcf/vcf_v42.ragel"
+#line 235 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
     }
-#line 258 "src/vcf/vcf_v42.ragel"
+#line 259 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 264 "src/vcf/vcf_v42.ragel"
+#line 265 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
     }
-#line 280 "src/vcf/vcf_v42.ragel"
+#line 281 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
     }
-#line 246 "src/vcf/vcf_v42.ragel"
+#line 247 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
     }
-#line 252 "src/vcf/vcf_v42.ragel"
+#line 253 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
     }
-#line 308 "src/vcf/vcf_v42.ragel"
+#line 309 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
     }
-#line 296 "src/vcf/vcf_v42.ragel"
+#line 297 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
     }
-#line 302 "src/vcf/vcf_v42.ragel"
+#line 303 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -18811,14 +18813,14 @@ case 730:
         p--; {goto st651;}
     }
 	break;
-#line 18815 "inc/vcf/validator_detail_v42.hpp"
+#line 18817 "inc/vcf/validator_detail_v42.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 855 "src/vcf/vcf_v42.ragel"
+#line 856 "src/vcf/vcf_v42.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v42.hpp
+++ b/inc/vcf/validator_detail_v42.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 828 "src/vcf/vcf_v42.ragel"
+#line 827 "src/vcf/vcf_v42.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v42_en_meta_section_skip = 651;
 static const int vcf_v42_en_body_section_skip = 652;
 
 
-#line 834 "src/vcf/vcf_v42.ragel"
+#line 833 "src/vcf/vcf_v42.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v42_start;
 	}
 
-#line 848 "src/vcf/vcf_v42.ragel"
+#line 847 "src/vcf/vcf_v42.ragel"
 
     }
 
@@ -87,8 +87,7 @@ tr14:
 #line 227 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         p--; {goto st651;}
     }
 #line 60 "src/vcf/vcf_v42.ragel"
@@ -108,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 341 "src/vcf/vcf_v42.ragel"
+#line 340 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -142,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 341 "src/vcf/vcf_v42.ragel"
+#line 340 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -171,47 +170,47 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
     }
-#line 247 "src/vcf/vcf_v42.ragel"
+#line 246 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
     }
-#line 253 "src/vcf/vcf_v42.ragel"
+#line 252 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
     }
-#line 297 "src/vcf/vcf_v42.ragel"
+#line 296 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
     }
-#line 303 "src/vcf/vcf_v42.ragel"
+#line 302 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -230,7 +229,7 @@ tr39:
     }
 	goto st0;
 tr125:
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -242,13 +241,13 @@ tr125:
     }
 	goto st0;
 tr133:
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -260,12 +259,12 @@ tr133:
     }
 	goto st0;
 tr152:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -277,12 +276,12 @@ tr152:
     }
 	goto st0;
 tr161:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -294,17 +293,17 @@ tr161:
     }
 	goto st0;
 tr175:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -316,17 +315,17 @@ tr175:
     }
 	goto st0;
 tr187:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -338,12 +337,12 @@ tr187:
     }
 	goto st0;
 tr193:
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -355,7 +354,7 @@ tr193:
     }
 	goto st0;
 tr196:
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -367,12 +366,12 @@ tr196:
     }
 	goto st0;
 tr206:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -384,12 +383,12 @@ tr206:
     }
 	goto st0;
 tr225:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -401,17 +400,17 @@ tr225:
     }
 	goto st0;
 tr247:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -423,17 +422,17 @@ tr247:
     }
 	goto st0;
 tr259:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -445,7 +444,7 @@ tr259:
     }
 	goto st0;
 tr265:
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -457,12 +456,12 @@ tr265:
     }
 	goto st0;
 tr275:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -474,12 +473,12 @@ tr275:
     }
 	goto st0;
 tr288:
-#line 270 "src/vcf/vcf_v42.ragel"
+#line 269 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -491,12 +490,12 @@ tr288:
     }
 	goto st0;
 tr297:
-#line 291 "src/vcf/vcf_v42.ragel"
+#line 290 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -508,12 +507,12 @@ tr297:
     }
 	goto st0;
 tr314:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -525,17 +524,17 @@ tr314:
     }
 	goto st0;
 tr336:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -547,17 +546,17 @@ tr336:
     }
 	goto st0;
 tr348:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -569,7 +568,7 @@ tr348:
     }
 	goto st0;
 tr355:
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -581,12 +580,12 @@ tr355:
     }
 	goto st0;
 tr364:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -598,12 +597,12 @@ tr364:
     }
 	goto st0;
 tr377:
-#line 286 "src/vcf/vcf_v42.ragel"
+#line 285 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -615,12 +614,12 @@ tr377:
     }
 	goto st0;
 tr386:
-#line 291 "src/vcf/vcf_v42.ragel"
+#line 290 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -632,12 +631,12 @@ tr386:
     }
 	goto st0;
 tr403:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -649,17 +648,17 @@ tr403:
     }
 	goto st0;
 tr425:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -671,17 +670,17 @@ tr425:
     }
 	goto st0;
 tr437:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -693,7 +692,7 @@ tr437:
     }
 	goto st0;
 tr444:
-#line 297 "src/vcf/vcf_v42.ragel"
+#line 296 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -705,12 +704,12 @@ tr444:
     }
 	goto st0;
 tr454:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 297 "src/vcf/vcf_v42.ragel"
+#line 296 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -722,7 +721,7 @@ tr454:
     }
 	goto st0;
 tr466:
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -734,12 +733,12 @@ tr466:
     }
 	goto st0;
 tr477:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -751,17 +750,17 @@ tr477:
     }
 	goto st0;
 tr482:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 314 "src/vcf/vcf_v42.ragel"
+#line 313 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -773,12 +772,12 @@ tr482:
     }
 	goto st0;
 tr484:
-#line 314 "src/vcf/vcf_v42.ragel"
+#line 313 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -790,17 +789,17 @@ tr484:
     }
 	goto st0;
 tr494:
-#line 314 "src/vcf/vcf_v42.ragel"
+#line 313 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 319 "src/vcf/vcf_v42.ragel"
+#line 318 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -812,12 +811,12 @@ tr494:
     }
 	goto st0;
 tr497:
-#line 319 "src/vcf/vcf_v42.ragel"
+#line 318 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -829,17 +828,17 @@ tr497:
     }
 	goto st0;
 tr507:
-#line 319 "src/vcf/vcf_v42.ragel"
+#line 318 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -851,12 +850,12 @@ tr507:
     }
 	goto st0;
 tr510:
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -868,7 +867,7 @@ tr510:
     }
 	goto st0;
 tr533:
-#line 247 "src/vcf/vcf_v42.ragel"
+#line 246 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -880,12 +879,12 @@ tr533:
     }
 	goto st0;
 tr542:
-#line 335 "src/vcf/vcf_v42.ragel"
+#line 334 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 247 "src/vcf/vcf_v42.ragel"
+#line 246 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -897,7 +896,7 @@ tr542:
     }
 	goto st0;
 tr563:
-#line 253 "src/vcf/vcf_v42.ragel"
+#line 252 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -909,12 +908,12 @@ tr563:
     }
 	goto st0;
 tr574:
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 253 "src/vcf/vcf_v42.ragel"
+#line 252 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -926,7 +925,7 @@ tr574:
     }
 	goto st0;
 tr612:
-#line 303 "src/vcf/vcf_v42.ragel"
+#line 302 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -938,12 +937,12 @@ tr612:
     }
 	goto st0;
 tr624:
-#line 335 "src/vcf/vcf_v42.ragel"
+#line 334 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 303 "src/vcf/vcf_v42.ragel"
+#line 302 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -955,7 +954,7 @@ tr624:
     }
 	goto st0;
 tr647:
-#line 341 "src/vcf/vcf_v42.ragel"
+#line 340 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -999,7 +998,7 @@ tr687:
     }
 	goto st0;
 tr702:
-#line 358 "src/vcf/vcf_v42.ragel"
+#line 357 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st652;}
@@ -1011,7 +1010,7 @@ tr702:
     }
 	goto st0;
 tr705:
-#line 364 "src/vcf/vcf_v42.ragel"
+#line 363 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st652;}
@@ -1023,7 +1022,7 @@ tr705:
     }
 	goto st0;
 tr709:
-#line 370 "src/vcf/vcf_v42.ragel"
+#line 369 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st652;}
@@ -1035,7 +1034,7 @@ tr709:
     }
 	goto st0;
 tr714:
-#line 376 "src/vcf/vcf_v42.ragel"
+#line 375 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st652;}
@@ -1047,7 +1046,7 @@ tr714:
     }
 	goto st0;
 tr718:
-#line 382 "src/vcf/vcf_v42.ragel"
+#line 381 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st652;}
@@ -1059,7 +1058,7 @@ tr718:
     }
 	goto st0;
 tr727:
-#line 388 "src/vcf/vcf_v42.ragel"
+#line 387 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st652;}
@@ -1071,7 +1070,7 @@ tr727:
     }
 	goto st0;
 tr738:
-#line 394 "src/vcf/vcf_v42.ragel"
+#line 393 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st652;}
@@ -1083,12 +1082,12 @@ tr738:
     }
 	goto st0;
 tr746:
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1100,7 +1099,7 @@ tr746:
     }
 	goto st0;
 tr763:
-#line 560 "src/vcf/vcf_v42.ragel"
+#line 559 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st652;}
@@ -1112,14 +1111,14 @@ tr763:
     }
 	goto st0;
 tr768:
-#line 573 "src/vcf/vcf_v42.ragel"
+#line 572 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st652;}
     }
-#line 566 "src/vcf/vcf_v42.ragel"
+#line 565 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1140,7 +1139,7 @@ tr776:
     }
 	goto st0;
 tr778:
-#line 566 "src/vcf/vcf_v42.ragel"
+#line 565 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1154,12 +1153,12 @@ tr778:
     }
 	goto st0;
 tr780:
-#line 410 "src/vcf/vcf_v42.ragel"
+#line 409 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1171,7 +1170,7 @@ tr780:
     }
 	goto st0;
 tr782:
-#line 551 "src/vcf/vcf_v42.ragel"
+#line 550 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1179,7 +1178,7 @@ tr782:
                 "1000G"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1191,7 +1190,7 @@ tr782:
     }
 	goto st0;
 tr785:
-#line 415 "src/vcf/vcf_v42.ragel"
+#line 414 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1199,7 +1198,7 @@ tr785:
                 "AA"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1211,7 +1210,7 @@ tr785:
     }
 	goto st0;
 tr788:
-#line 423 "src/vcf/vcf_v42.ragel"
+#line 422 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1219,7 +1218,7 @@ tr788:
                 "AC"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1231,7 +1230,7 @@ tr788:
     }
 	goto st0;
 tr791:
-#line 431 "src/vcf/vcf_v42.ragel"
+#line 430 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1239,7 +1238,7 @@ tr791:
                 "AF"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1251,7 +1250,7 @@ tr791:
     }
 	goto st0;
 tr803:
-#line 439 "src/vcf/vcf_v42.ragel"
+#line 438 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1259,7 +1258,7 @@ tr803:
                 "AN"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1271,7 +1270,7 @@ tr803:
     }
 	goto st0;
 tr806:
-#line 447 "src/vcf/vcf_v42.ragel"
+#line 446 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1279,7 +1278,7 @@ tr806:
                 "BQ"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1291,7 +1290,7 @@ tr806:
     }
 	goto st0;
 tr818:
-#line 455 "src/vcf/vcf_v42.ragel"
+#line 454 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1299,7 +1298,7 @@ tr818:
                 "CIGAR"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1311,7 +1310,7 @@ tr818:
     }
 	goto st0;
 tr821:
-#line 463 "src/vcf/vcf_v42.ragel"
+#line 462 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1319,7 +1318,7 @@ tr821:
                 "DB"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1331,7 +1330,7 @@ tr821:
     }
 	goto st0;
 tr824:
-#line 471 "src/vcf/vcf_v42.ragel"
+#line 470 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1339,7 +1338,7 @@ tr824:
                 "DP"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1351,7 +1350,7 @@ tr824:
     }
 	goto st0;
 tr827:
-#line 479 "src/vcf/vcf_v42.ragel"
+#line 478 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1359,7 +1358,7 @@ tr827:
                 "END"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1371,7 +1370,7 @@ tr827:
     }
 	goto st0;
 tr829:
-#line 487 "src/vcf/vcf_v42.ragel"
+#line 486 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1379,7 +1378,7 @@ tr829:
                 "H2"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1391,7 +1390,7 @@ tr829:
     }
 	goto st0;
 tr831:
-#line 495 "src/vcf/vcf_v42.ragel"
+#line 494 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1399,7 +1398,7 @@ tr831:
                 "H3"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1411,7 +1410,7 @@ tr831:
     }
 	goto st0;
 tr836:
-#line 511 "src/vcf/vcf_v42.ragel"
+#line 510 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1419,7 +1418,7 @@ tr836:
                 "MQ0"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1431,7 +1430,7 @@ tr836:
     }
 	goto st0;
 tr838:
-#line 503 "src/vcf/vcf_v42.ragel"
+#line 502 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1439,7 +1438,7 @@ tr838:
                 "MQ"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1451,7 +1450,7 @@ tr838:
     }
 	goto st0;
 tr850:
-#line 519 "src/vcf/vcf_v42.ragel"
+#line 518 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1459,7 +1458,7 @@ tr850:
                 "NS"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1471,7 +1470,7 @@ tr850:
     }
 	goto st0;
 tr853:
-#line 527 "src/vcf/vcf_v42.ragel"
+#line 526 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1479,7 +1478,7 @@ tr853:
                 "SB"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1491,7 +1490,7 @@ tr853:
     }
 	goto st0;
 tr864:
-#line 535 "src/vcf/vcf_v42.ragel"
+#line 534 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1499,7 +1498,7 @@ tr864:
                 "SOMATIC"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1511,7 +1510,7 @@ tr864:
     }
 	goto st0;
 tr866:
-#line 543 "src/vcf/vcf_v42.ragel"
+#line 542 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1519,7 +1518,7 @@ tr866:
                 "VALIDATED"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1544,7 +1543,7 @@ tr915:
         
         p--; {goto st652;}
     }
-#line 358 "src/vcf/vcf_v42.ragel"
+#line 357 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st652;}
@@ -1556,7 +1555,7 @@ tr915:
     }
 	goto st0;
 tr937:
-#line 551 "src/vcf/vcf_v42.ragel"
+#line 550 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1564,12 +1563,12 @@ tr937:
                 "1000G"});
         p--; {goto st652;}
     }
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1581,7 +1580,7 @@ tr937:
     }
 	goto st0;
 tr954:
-#line 463 "src/vcf/vcf_v42.ragel"
+#line 462 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1589,12 +1588,12 @@ tr954:
                 "DB"});
         p--; {goto st652;}
     }
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1606,7 +1605,7 @@ tr954:
     }
 	goto st0;
 tr960:
-#line 487 "src/vcf/vcf_v42.ragel"
+#line 486 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1614,12 +1613,12 @@ tr960:
                 "H2"});
         p--; {goto st652;}
     }
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1631,7 +1630,7 @@ tr960:
     }
 	goto st0;
 tr962:
-#line 495 "src/vcf/vcf_v42.ragel"
+#line 494 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1639,12 +1638,12 @@ tr962:
                 "H3"});
         p--; {goto st652;}
     }
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1656,7 +1655,7 @@ tr962:
     }
 	goto st0;
 tr977:
-#line 535 "src/vcf/vcf_v42.ragel"
+#line 534 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1664,12 +1663,12 @@ tr977:
                 "SOMATIC"});
         p--; {goto st652;}
     }
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1681,7 +1680,7 @@ tr977:
     }
 	goto st0;
 tr987:
-#line 543 "src/vcf/vcf_v42.ragel"
+#line 542 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1689,12 +1688,12 @@ tr987:
                 "VALIDATED"});
         p--; {goto st652;}
     }
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -1705,7 +1704,7 @@ tr987:
         p--; {goto st652;}
     }
 	goto st0;
-#line 1709 "inc/vcf/validator_detail_v42.hpp"
+#line 1708 "inc/vcf/validator_detail_v42.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1814,7 +1813,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1818 "inc/vcf/validator_detail_v42.hpp"
+#line 1817 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1828,7 +1827,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1832 "inc/vcf/validator_detail_v42.hpp"
+#line 1831 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1842,7 +1841,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1846 "inc/vcf/validator_detail_v42.hpp"
+#line 1845 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1856,7 +1855,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1860 "inc/vcf/validator_detail_v42.hpp"
+#line 1859 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1870,7 +1869,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1874 "inc/vcf/validator_detail_v42.hpp"
+#line 1873 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1884,7 +1883,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1888 "inc/vcf/validator_detail_v42.hpp"
+#line 1887 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 50 )
 		goto tr21;
 	goto tr14;
@@ -1898,7 +1897,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1902 "inc/vcf/validator_detail_v42.hpp"
+#line 1901 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -1929,7 +1928,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 1933 "inc/vcf/validator_detail_v42.hpp"
+#line 1932 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -1982,7 +1981,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 1986 "inc/vcf/validator_detail_v42.hpp"
+#line 1985 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr41;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -1998,7 +1997,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2002 "inc/vcf/validator_detail_v42.hpp"
+#line 2001 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2026,7 +2025,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2030 "inc/vcf/validator_detail_v42.hpp"
+#line 2029 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr46;
@@ -2082,7 +2081,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2086 "inc/vcf/validator_detail_v42.hpp"
+#line 2085 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -2134,7 +2133,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2138 "inc/vcf/validator_detail_v42.hpp"
+#line 2137 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr39;
@@ -2169,7 +2168,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2173 "inc/vcf/validator_detail_v42.hpp"
+#line 2172 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr53;
 		case 92: goto tr54;
@@ -2197,7 +2196,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2201 "inc/vcf/validator_detail_v42.hpp"
+#line 2200 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2223,7 +2222,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2227 "inc/vcf/validator_detail_v42.hpp"
+#line 2226 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr57;
 		case 92: goto tr54;
@@ -2245,7 +2244,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2249 "inc/vcf/validator_detail_v42.hpp"
+#line 2248 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2306,7 +2305,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2310 "inc/vcf/validator_detail_v42.hpp"
+#line 2309 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 92: goto tr66;
@@ -2334,7 +2333,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2338 "inc/vcf/validator_detail_v42.hpp"
+#line 2337 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr39;
@@ -2358,7 +2357,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2362 "inc/vcf/validator_detail_v42.hpp"
+#line 2361 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr68;
 		case 92: goto tr66;
@@ -2380,7 +2379,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2384 "inc/vcf/validator_detail_v42.hpp"
+#line 2383 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr65;
 		case 62: goto tr69;
@@ -2399,7 +2398,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2403 "inc/vcf/validator_detail_v42.hpp"
+#line 2402 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -2419,7 +2418,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2423 "inc/vcf/validator_detail_v42.hpp"
+#line 2422 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2454,7 +2453,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2458 "inc/vcf/validator_detail_v42.hpp"
+#line 2457 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr72;
 		case 95: goto tr71;
@@ -2481,7 +2480,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2485 "inc/vcf/validator_detail_v42.hpp"
+#line 2484 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2513,7 +2512,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2517 "inc/vcf/validator_detail_v42.hpp"
+#line 2516 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr76;
 		case 62: goto tr53;
@@ -2534,7 +2533,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2538 "inc/vcf/validator_detail_v42.hpp"
+#line 2537 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr77;
 	if ( (*p) < 48 ) {
@@ -2559,7 +2558,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2563 "inc/vcf/validator_detail_v42.hpp"
+#line 2562 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2594,7 +2593,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2598 "inc/vcf/validator_detail_v42.hpp"
+#line 2597 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr81;
 		case 95: goto tr80;
@@ -2621,7 +2620,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2625 "inc/vcf/validator_detail_v42.hpp"
+#line 2624 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2664,7 +2663,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2668 "inc/vcf/validator_detail_v42.hpp"
+#line 2667 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr88;
@@ -2692,7 +2691,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2696 "inc/vcf/validator_detail_v42.hpp"
+#line 2695 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2718,7 +2717,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2722 "inc/vcf/validator_detail_v42.hpp"
+#line 2721 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 92: goto tr88;
@@ -2740,7 +2739,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2744 "inc/vcf/validator_detail_v42.hpp"
+#line 2743 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr91;
@@ -2780,7 +2779,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2784 "inc/vcf/validator_detail_v42.hpp"
+#line 2783 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2831,7 +2830,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2835 "inc/vcf/validator_detail_v42.hpp"
+#line 2834 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2882,7 +2881,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2886 "inc/vcf/validator_detail_v42.hpp"
+#line 2885 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr86;
@@ -2925,7 +2924,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 2929 "inc/vcf/validator_detail_v42.hpp"
+#line 2928 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr86;
@@ -2955,7 +2954,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 2959 "inc/vcf/validator_detail_v42.hpp"
+#line 2958 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr102;
@@ -2995,7 +2994,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 2999 "inc/vcf/validator_detail_v42.hpp"
+#line 2998 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3025,7 +3024,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3029 "inc/vcf/validator_detail_v42.hpp"
+#line 3028 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr90;
 		case 44: goto tr102;
@@ -3045,7 +3044,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3049 "inc/vcf/validator_detail_v42.hpp"
+#line 3048 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr84;
 		case 44: goto tr105;
@@ -3086,7 +3085,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3090 "inc/vcf/validator_detail_v42.hpp"
+#line 3089 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 92: goto tr110;
@@ -3114,7 +3113,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3118 "inc/vcf/validator_detail_v42.hpp"
+#line 3117 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 92: goto tr110;
@@ -3136,7 +3135,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3140 "inc/vcf/validator_detail_v42.hpp"
+#line 3139 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr112;
@@ -3166,7 +3165,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3170 "inc/vcf/validator_detail_v42.hpp"
+#line 3169 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3217,7 +3216,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3221 "inc/vcf/validator_detail_v42.hpp"
+#line 3220 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3268,7 +3267,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3272 "inc/vcf/validator_detail_v42.hpp"
+#line 3271 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 47: goto tr109;
@@ -3311,7 +3310,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3315 "inc/vcf/validator_detail_v42.hpp"
+#line 3314 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr99;
 		case 44: goto tr109;
@@ -3341,7 +3340,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3345 "inc/vcf/validator_detail_v42.hpp"
+#line 3344 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr87;
 		case 44: goto tr122;
@@ -3371,7 +3370,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3375 "inc/vcf/validator_detail_v42.hpp"
+#line 3374 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -3401,7 +3400,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3405 "inc/vcf/validator_detail_v42.hpp"
+#line 3404 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr111;
 		case 44: goto tr122;
@@ -3425,7 +3424,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3429 "inc/vcf/validator_detail_v42.hpp"
+#line 3428 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr126;
@@ -3443,7 +3442,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3447 "inc/vcf/validator_detail_v42.hpp"
+#line 3446 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st76;
@@ -3470,7 +3469,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3474 "inc/vcf/validator_detail_v42.hpp"
+#line 3473 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr125;
@@ -3542,7 +3541,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3546 "inc/vcf/validator_detail_v42.hpp"
+#line 3545 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3596,7 +3595,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3600 "inc/vcf/validator_detail_v42.hpp"
+#line 3599 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr138;
 		case 61: goto tr137;
@@ -3617,7 +3616,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3621 "inc/vcf/validator_detail_v42.hpp"
+#line 3620 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr125;
@@ -3715,7 +3714,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3719 "inc/vcf/validator_detail_v42.hpp"
+#line 3718 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 92: goto tr155;
@@ -3743,7 +3742,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3747 "inc/vcf/validator_detail_v42.hpp"
+#line 3746 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr158;
@@ -3771,7 +3770,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3775 "inc/vcf/validator_detail_v42.hpp"
+#line 3774 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3805,7 +3804,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3809 "inc/vcf/validator_detail_v42.hpp"
+#line 3808 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3840,7 +3839,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3844 "inc/vcf/validator_detail_v42.hpp"
+#line 3843 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr166;
 		case 95: goto tr165;
@@ -3867,7 +3866,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3871 "inc/vcf/validator_detail_v42.hpp"
+#line 3870 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr125;
@@ -3902,7 +3901,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3906 "inc/vcf/validator_detail_v42.hpp"
+#line 3905 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 92: goto tr171;
@@ -3930,7 +3929,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 3934 "inc/vcf/validator_detail_v42.hpp"
+#line 3933 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr172;
 		case 92: goto tr171;
@@ -3952,7 +3951,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 3956 "inc/vcf/validator_detail_v42.hpp"
+#line 3955 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr173;
@@ -3982,7 +3981,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 3986 "inc/vcf/validator_detail_v42.hpp"
+#line 3985 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4033,7 +4032,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4037 "inc/vcf/validator_detail_v42.hpp"
+#line 4036 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4084,7 +4083,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4088 "inc/vcf/validator_detail_v42.hpp"
+#line 4087 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr170;
@@ -4127,7 +4126,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4131 "inc/vcf/validator_detail_v42.hpp"
+#line 4130 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr171;
@@ -4145,7 +4144,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4149 "inc/vcf/validator_detail_v42.hpp"
+#line 4148 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr154;
 		case 44: goto tr182;
@@ -4175,7 +4174,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4179 "inc/vcf/validator_detail_v42.hpp"
+#line 4178 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4214,7 +4213,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4218 "inc/vcf/validator_detail_v42.hpp"
+#line 4217 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr184;
 		case 92: goto tr158;
@@ -4236,7 +4235,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4240 "inc/vcf/validator_detail_v42.hpp"
+#line 4239 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 44: goto tr185;
@@ -4256,7 +4255,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4260 "inc/vcf/validator_detail_v42.hpp"
+#line 4259 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4307,7 +4306,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4311 "inc/vcf/validator_detail_v42.hpp"
+#line 4310 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4358,7 +4357,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4362 "inc/vcf/validator_detail_v42.hpp"
+#line 4361 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr157;
 		case 47: goto tr156;
@@ -4401,7 +4400,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4405 "inc/vcf/validator_detail_v42.hpp"
+#line 4404 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr181;
 		case 92: goto tr158;
@@ -4419,7 +4418,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4423 "inc/vcf/validator_detail_v42.hpp"
+#line 4422 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -4443,7 +4442,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4447 "inc/vcf/validator_detail_v42.hpp"
+#line 4446 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr194;
@@ -4462,7 +4461,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4466 "inc/vcf/validator_detail_v42.hpp"
+#line 4465 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr197;
@@ -4480,7 +4479,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4484 "inc/vcf/validator_detail_v42.hpp"
+#line 4483 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto tr198;
@@ -4498,7 +4497,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4502 "inc/vcf/validator_detail_v42.hpp"
+#line 4501 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr199;
@@ -4516,7 +4515,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4520 "inc/vcf/validator_detail_v42.hpp"
+#line 4519 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto st127;
@@ -4543,7 +4542,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4547 "inc/vcf/validator_detail_v42.hpp"
+#line 4546 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr196;
@@ -4600,7 +4599,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4604 "inc/vcf/validator_detail_v42.hpp"
+#line 4603 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4639,7 +4638,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4643 "inc/vcf/validator_detail_v42.hpp"
+#line 4642 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr211;
 		case 95: goto tr210;
@@ -4666,7 +4665,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4670 "inc/vcf/validator_detail_v42.hpp"
+#line 4669 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr196;
@@ -4764,7 +4763,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4768 "inc/vcf/validator_detail_v42.hpp"
+#line 4767 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 92: goto tr228;
@@ -4792,7 +4791,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4796 "inc/vcf/validator_detail_v42.hpp"
+#line 4795 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr231;
@@ -4820,7 +4819,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4824 "inc/vcf/validator_detail_v42.hpp"
+#line 4823 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4854,7 +4853,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4858 "inc/vcf/validator_detail_v42.hpp"
+#line 4857 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4889,7 +4888,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4893 "inc/vcf/validator_detail_v42.hpp"
+#line 4892 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr238;
 		case 95: goto tr237;
@@ -4916,7 +4915,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 4920 "inc/vcf/validator_detail_v42.hpp"
+#line 4919 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr196;
@@ -4951,7 +4950,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 4955 "inc/vcf/validator_detail_v42.hpp"
+#line 4954 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 92: goto tr243;
@@ -4979,7 +4978,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 4983 "inc/vcf/validator_detail_v42.hpp"
+#line 4982 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr244;
 		case 92: goto tr243;
@@ -5001,7 +5000,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5005 "inc/vcf/validator_detail_v42.hpp"
+#line 5004 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr245;
@@ -5031,7 +5030,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5035 "inc/vcf/validator_detail_v42.hpp"
+#line 5034 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5082,7 +5081,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5086 "inc/vcf/validator_detail_v42.hpp"
+#line 5085 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5133,7 +5132,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5137 "inc/vcf/validator_detail_v42.hpp"
+#line 5136 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr242;
@@ -5176,7 +5175,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5180 "inc/vcf/validator_detail_v42.hpp"
+#line 5179 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr243;
@@ -5194,7 +5193,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5198 "inc/vcf/validator_detail_v42.hpp"
+#line 5197 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr227;
 		case 44: goto tr254;
@@ -5224,7 +5223,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5228 "inc/vcf/validator_detail_v42.hpp"
+#line 5227 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5263,7 +5262,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5267 "inc/vcf/validator_detail_v42.hpp"
+#line 5266 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr256;
 		case 92: goto tr231;
@@ -5285,7 +5284,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5289 "inc/vcf/validator_detail_v42.hpp"
+#line 5288 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 44: goto tr257;
@@ -5305,7 +5304,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5309 "inc/vcf/validator_detail_v42.hpp"
+#line 5308 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5356,7 +5355,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5360 "inc/vcf/validator_detail_v42.hpp"
+#line 5359 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5407,7 +5406,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5411 "inc/vcf/validator_detail_v42.hpp"
+#line 5410 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr230;
 		case 47: goto tr229;
@@ -5450,7 +5449,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5454 "inc/vcf/validator_detail_v42.hpp"
+#line 5453 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr253;
 		case 92: goto tr231;
@@ -5468,7 +5467,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5472 "inc/vcf/validator_detail_v42.hpp"
+#line 5471 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -5488,7 +5487,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5492 "inc/vcf/validator_detail_v42.hpp"
+#line 5491 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr266;
@@ -5506,7 +5505,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5510 "inc/vcf/validator_detail_v42.hpp"
+#line 5509 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr267;
@@ -5524,7 +5523,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5528 "inc/vcf/validator_detail_v42.hpp"
+#line 5527 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr268;
@@ -5542,7 +5541,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5546 "inc/vcf/validator_detail_v42.hpp"
+#line 5545 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 84: goto st177;
@@ -5569,7 +5568,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5573 "inc/vcf/validator_detail_v42.hpp"
+#line 5572 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr265;
@@ -5626,7 +5625,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5630 "inc/vcf/validator_detail_v42.hpp"
+#line 5629 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5665,7 +5664,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5669 "inc/vcf/validator_detail_v42.hpp"
+#line 5668 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr280;
 		case 95: goto tr279;
@@ -5692,7 +5691,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5696 "inc/vcf/validator_detail_v42.hpp"
+#line 5695 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr265;
@@ -5769,7 +5768,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5773 "inc/vcf/validator_detail_v42.hpp"
+#line 5772 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	goto tr288;
@@ -5783,7 +5782,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5787 "inc/vcf/validator_detail_v42.hpp"
+#line 5786 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr265;
@@ -5849,7 +5848,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5853 "inc/vcf/validator_detail_v42.hpp"
+#line 5852 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr299;
 	if ( (*p) > 90 ) {
@@ -5868,7 +5867,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5872 "inc/vcf/validator_detail_v42.hpp"
+#line 5871 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr265;
@@ -5966,7 +5965,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 5970 "inc/vcf/validator_detail_v42.hpp"
+#line 5969 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 92: goto tr317;
@@ -5994,7 +5993,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 5998 "inc/vcf/validator_detail_v42.hpp"
+#line 5997 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr320;
@@ -6022,7 +6021,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6026 "inc/vcf/validator_detail_v42.hpp"
+#line 6025 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6056,7 +6055,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6060 "inc/vcf/validator_detail_v42.hpp"
+#line 6059 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6091,7 +6090,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6095 "inc/vcf/validator_detail_v42.hpp"
+#line 6094 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr327;
 		case 95: goto tr326;
@@ -6118,7 +6117,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6122 "inc/vcf/validator_detail_v42.hpp"
+#line 6121 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr265;
@@ -6153,7 +6152,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6157 "inc/vcf/validator_detail_v42.hpp"
+#line 6156 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 92: goto tr332;
@@ -6181,7 +6180,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6185 "inc/vcf/validator_detail_v42.hpp"
+#line 6184 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr333;
 		case 92: goto tr332;
@@ -6203,7 +6202,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6207 "inc/vcf/validator_detail_v42.hpp"
+#line 6206 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr334;
@@ -6233,7 +6232,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6237 "inc/vcf/validator_detail_v42.hpp"
+#line 6236 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6284,7 +6283,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6288 "inc/vcf/validator_detail_v42.hpp"
+#line 6287 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6335,7 +6334,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6339 "inc/vcf/validator_detail_v42.hpp"
+#line 6338 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr331;
@@ -6378,7 +6377,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6382 "inc/vcf/validator_detail_v42.hpp"
+#line 6381 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr332;
@@ -6396,7 +6395,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6400 "inc/vcf/validator_detail_v42.hpp"
+#line 6399 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr316;
 		case 44: goto tr343;
@@ -6426,7 +6425,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6430 "inc/vcf/validator_detail_v42.hpp"
+#line 6429 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6465,7 +6464,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6469 "inc/vcf/validator_detail_v42.hpp"
+#line 6468 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr345;
 		case 92: goto tr320;
@@ -6487,7 +6486,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6491 "inc/vcf/validator_detail_v42.hpp"
+#line 6490 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 44: goto tr346;
@@ -6507,7 +6506,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6511 "inc/vcf/validator_detail_v42.hpp"
+#line 6510 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6558,7 +6557,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6562 "inc/vcf/validator_detail_v42.hpp"
+#line 6561 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6609,7 +6608,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6613 "inc/vcf/validator_detail_v42.hpp"
+#line 6612 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr319;
 		case 47: goto tr318;
@@ -6652,7 +6651,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6656 "inc/vcf/validator_detail_v42.hpp"
+#line 6655 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr342;
 		case 92: goto tr320;
@@ -6670,7 +6669,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6674 "inc/vcf/validator_detail_v42.hpp"
+#line 6673 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -6704,7 +6703,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6708 "inc/vcf/validator_detail_v42.hpp"
+#line 6707 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr291;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6724,7 +6723,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6728 "inc/vcf/validator_detail_v42.hpp"
+#line 6727 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 78: goto tr356;
@@ -6742,7 +6741,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6746 "inc/vcf/validator_detail_v42.hpp"
+#line 6745 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 70: goto tr357;
@@ -6760,7 +6759,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6764 "inc/vcf/validator_detail_v42.hpp"
+#line 6763 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 79: goto st243;
@@ -6787,7 +6786,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6791 "inc/vcf/validator_detail_v42.hpp"
+#line 6790 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr355;
@@ -6844,7 +6843,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6848 "inc/vcf/validator_detail_v42.hpp"
+#line 6847 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6883,7 +6882,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6887 "inc/vcf/validator_detail_v42.hpp"
+#line 6886 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr369;
 		case 95: goto tr368;
@@ -6910,7 +6909,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 6914 "inc/vcf/validator_detail_v42.hpp"
+#line 6913 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr355;
@@ -6987,7 +6986,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 6991 "inc/vcf/validator_detail_v42.hpp"
+#line 6990 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	goto tr377;
@@ -7001,7 +7000,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7005 "inc/vcf/validator_detail_v42.hpp"
+#line 7004 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr355;
@@ -7067,7 +7066,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7071 "inc/vcf/validator_detail_v42.hpp"
+#line 7070 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr388;
 	if ( (*p) > 90 ) {
@@ -7086,7 +7085,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7090 "inc/vcf/validator_detail_v42.hpp"
+#line 7089 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr355;
@@ -7184,7 +7183,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7188 "inc/vcf/validator_detail_v42.hpp"
+#line 7187 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 92: goto tr406;
@@ -7212,7 +7211,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7216 "inc/vcf/validator_detail_v42.hpp"
+#line 7215 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr409;
@@ -7240,7 +7239,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7244 "inc/vcf/validator_detail_v42.hpp"
+#line 7243 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7274,7 +7273,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7278 "inc/vcf/validator_detail_v42.hpp"
+#line 7277 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7309,7 +7308,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7313 "inc/vcf/validator_detail_v42.hpp"
+#line 7312 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr416;
 		case 95: goto tr415;
@@ -7336,7 +7335,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7340 "inc/vcf/validator_detail_v42.hpp"
+#line 7339 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr355;
@@ -7371,7 +7370,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7375 "inc/vcf/validator_detail_v42.hpp"
+#line 7374 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 92: goto tr421;
@@ -7399,7 +7398,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7403 "inc/vcf/validator_detail_v42.hpp"
+#line 7402 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr422;
 		case 92: goto tr421;
@@ -7421,7 +7420,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7425 "inc/vcf/validator_detail_v42.hpp"
+#line 7424 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr423;
@@ -7451,7 +7450,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7455 "inc/vcf/validator_detail_v42.hpp"
+#line 7454 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7502,7 +7501,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7506 "inc/vcf/validator_detail_v42.hpp"
+#line 7505 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7553,7 +7552,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7557 "inc/vcf/validator_detail_v42.hpp"
+#line 7556 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr420;
@@ -7596,7 +7595,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7600 "inc/vcf/validator_detail_v42.hpp"
+#line 7599 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr421;
@@ -7614,7 +7613,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7618 "inc/vcf/validator_detail_v42.hpp"
+#line 7617 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr405;
 		case 44: goto tr432;
@@ -7644,7 +7643,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7648 "inc/vcf/validator_detail_v42.hpp"
+#line 7647 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7683,7 +7682,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7687 "inc/vcf/validator_detail_v42.hpp"
+#line 7686 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr434;
 		case 92: goto tr409;
@@ -7705,7 +7704,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7709 "inc/vcf/validator_detail_v42.hpp"
+#line 7708 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 44: goto tr435;
@@ -7725,7 +7724,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7729 "inc/vcf/validator_detail_v42.hpp"
+#line 7728 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7776,7 +7775,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7780 "inc/vcf/validator_detail_v42.hpp"
+#line 7779 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7827,7 +7826,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7831 "inc/vcf/validator_detail_v42.hpp"
+#line 7830 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr408;
 		case 47: goto tr407;
@@ -7870,7 +7869,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7874 "inc/vcf/validator_detail_v42.hpp"
+#line 7873 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr431;
 		case 92: goto tr409;
@@ -7888,7 +7887,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7892 "inc/vcf/validator_detail_v42.hpp"
+#line 7891 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -7922,7 +7921,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 7926 "inc/vcf/validator_detail_v42.hpp"
+#line 7925 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr380;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -7942,7 +7941,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 7946 "inc/vcf/validator_detail_v42.hpp"
+#line 7945 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr445;
@@ -7960,7 +7959,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 7964 "inc/vcf/validator_detail_v42.hpp"
+#line 7963 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr446;
@@ -7978,7 +7977,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 7982 "inc/vcf/validator_detail_v42.hpp"
+#line 7981 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 73: goto tr447;
@@ -7996,7 +7995,7 @@ st309:
 	if ( ++p == pe )
 		goto _test_eof309;
 case 309:
-#line 8000 "inc/vcf/validator_detail_v42.hpp"
+#line 7999 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 71: goto tr448;
@@ -8014,7 +8013,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8018 "inc/vcf/validator_detail_v42.hpp"
+#line 8017 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 82: goto tr449;
@@ -8032,7 +8031,7 @@ st311:
 	if ( ++p == pe )
 		goto _test_eof311;
 case 311:
-#line 8036 "inc/vcf/validator_detail_v42.hpp"
+#line 8035 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto tr450;
@@ -8050,7 +8049,7 @@ st312:
 	if ( ++p == pe )
 		goto _test_eof312;
 case 312:
-#line 8054 "inc/vcf/validator_detail_v42.hpp"
+#line 8053 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st313;
@@ -8077,7 +8076,7 @@ st314:
 	if ( ++p == pe )
 		goto _test_eof314;
 case 314:
-#line 8081 "inc/vcf/validator_detail_v42.hpp"
+#line 8080 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st315;
 	goto tr444;
@@ -8091,7 +8090,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8095 "inc/vcf/validator_detail_v42.hpp"
+#line 8094 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr455;
 	if ( (*p) < 48 ) {
@@ -8116,7 +8115,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8120 "inc/vcf/validator_detail_v42.hpp"
+#line 8119 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st316;
 	if ( (*p) < 48 ) {
@@ -8151,7 +8150,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8155 "inc/vcf/validator_detail_v42.hpp"
+#line 8154 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr459;
 		case 95: goto tr458;
@@ -8178,7 +8177,7 @@ st318:
 	if ( ++p == pe )
 		goto _test_eof318;
 case 318:
-#line 8182 "inc/vcf/validator_detail_v42.hpp"
+#line 8181 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr460;
 	if ( (*p) < 48 ) {
@@ -8203,7 +8202,7 @@ st319:
 	if ( ++p == pe )
 		goto _test_eof319;
 case 319:
-#line 8207 "inc/vcf/validator_detail_v42.hpp"
+#line 8206 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st319;
 	if ( (*p) < 48 ) {
@@ -8238,7 +8237,7 @@ st320:
 	if ( ++p == pe )
 		goto _test_eof320;
 case 320:
-#line 8242 "inc/vcf/validator_detail_v42.hpp"
+#line 8241 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr464;
 		case 62: goto tr465;
@@ -8266,7 +8265,7 @@ st321:
 	if ( ++p == pe )
 		goto _test_eof321;
 case 321:
-#line 8270 "inc/vcf/validator_detail_v42.hpp"
+#line 8269 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8286,7 +8285,7 @@ st322:
 	if ( ++p == pe )
 		goto _test_eof322;
 case 322:
-#line 8290 "inc/vcf/validator_detail_v42.hpp"
+#line 8289 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 65: goto tr467;
@@ -8304,7 +8303,7 @@ st323:
 	if ( ++p == pe )
 		goto _test_eof323;
 case 323:
-#line 8308 "inc/vcf/validator_detail_v42.hpp"
+#line 8307 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 77: goto tr468;
@@ -8322,7 +8321,7 @@ st324:
 	if ( ++p == pe )
 		goto _test_eof324;
 case 324:
-#line 8326 "inc/vcf/validator_detail_v42.hpp"
+#line 8325 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 80: goto tr469;
@@ -8340,7 +8339,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8344 "inc/vcf/validator_detail_v42.hpp"
+#line 8343 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 76: goto tr470;
@@ -8358,7 +8357,7 @@ st326:
 	if ( ++p == pe )
 		goto _test_eof326;
 case 326:
-#line 8362 "inc/vcf/validator_detail_v42.hpp"
+#line 8361 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 69: goto st327;
@@ -8385,7 +8384,7 @@ st328:
 	if ( ++p == pe )
 		goto _test_eof328;
 case 328:
-#line 8389 "inc/vcf/validator_detail_v42.hpp"
+#line 8388 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st329;
 	goto tr466;
@@ -8442,7 +8441,7 @@ st333:
 	if ( ++p == pe )
 		goto _test_eof333;
 case 333:
-#line 8446 "inc/vcf/validator_detail_v42.hpp"
+#line 8445 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st333;
 	if ( (*p) < 48 ) {
@@ -8481,7 +8480,7 @@ st334:
 	if ( ++p == pe )
 		goto _test_eof334;
 case 334:
-#line 8485 "inc/vcf/validator_detail_v42.hpp"
+#line 8484 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr483;
 		case 95: goto tr481;
@@ -8508,7 +8507,7 @@ st335:
 	if ( ++p == pe )
 		goto _test_eof335;
 case 335:
-#line 8512 "inc/vcf/validator_detail_v42.hpp"
+#line 8511 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 71 )
 		goto st336;
 	goto tr484;
@@ -8601,7 +8600,7 @@ st344:
 	if ( ++p == pe )
 		goto _test_eof344;
 case 344:
-#line 8605 "inc/vcf/validator_detail_v42.hpp"
+#line 8604 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr496;
 	if ( (*p) < 35 ) {
@@ -8623,7 +8622,7 @@ st345:
 	if ( ++p == pe )
 		goto _test_eof345;
 case 345:
-#line 8627 "inc/vcf/validator_detail_v42.hpp"
+#line 8626 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 77 )
 		goto st346;
 	goto tr497;
@@ -8716,7 +8715,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8720 "inc/vcf/validator_detail_v42.hpp"
+#line 8719 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 44 )
 		goto tr509;
 	if ( (*p) < 35 ) {
@@ -8738,7 +8737,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8742 "inc/vcf/validator_detail_v42.hpp"
+#line 8741 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 68 )
 		goto st356;
 	goto tr510;
@@ -8836,7 +8835,7 @@ st368:
 	if ( ++p == pe )
 		goto _test_eof368;
 case 368:
-#line 8840 "inc/vcf/validator_detail_v42.hpp"
+#line 8839 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr525;
 		case 92: goto tr526;
@@ -8864,7 +8863,7 @@ st369:
 	if ( ++p == pe )
 		goto _test_eof369;
 case 369:
-#line 8868 "inc/vcf/validator_detail_v42.hpp"
+#line 8867 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 92: goto tr529;
@@ -8892,7 +8891,7 @@ st370:
 	if ( ++p == pe )
 		goto _test_eof370;
 case 370:
-#line 8896 "inc/vcf/validator_detail_v42.hpp"
+#line 8895 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto st371;
 	goto tr510;
@@ -8925,7 +8924,7 @@ st372:
 	if ( ++p == pe )
 		goto _test_eof372;
 case 372:
-#line 8929 "inc/vcf/validator_detail_v42.hpp"
+#line 8928 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr531;
 		case 92: goto tr529;
@@ -8947,7 +8946,7 @@ st373:
 	if ( ++p == pe )
 		goto _test_eof373;
 case 373:
-#line 8951 "inc/vcf/validator_detail_v42.hpp"
+#line 8950 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr528;
 		case 62: goto tr532;
@@ -8966,7 +8965,7 @@ st374:
 	if ( ++p == pe )
 		goto _test_eof374;
 case 374:
-#line 8970 "inc/vcf/validator_detail_v42.hpp"
+#line 8969 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -8990,7 +8989,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8994 "inc/vcf/validator_detail_v42.hpp"
+#line 8993 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr534;
@@ -9008,7 +9007,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 9012 "inc/vcf/validator_detail_v42.hpp"
+#line 9011 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 115: goto tr535;
@@ -9026,7 +9025,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 9030 "inc/vcf/validator_detail_v42.hpp"
+#line 9029 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr536;
@@ -9044,7 +9043,7 @@ st378:
 	if ( ++p == pe )
 		goto _test_eof378;
 case 378:
-#line 9048 "inc/vcf/validator_detail_v42.hpp"
+#line 9047 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 109: goto tr537;
@@ -9062,7 +9061,7 @@ st379:
 	if ( ++p == pe )
 		goto _test_eof379;
 case 379:
-#line 9066 "inc/vcf/validator_detail_v42.hpp"
+#line 9065 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 98: goto tr538;
@@ -9080,7 +9079,7 @@ st380:
 	if ( ++p == pe )
 		goto _test_eof380;
 case 380:
-#line 9084 "inc/vcf/validator_detail_v42.hpp"
+#line 9083 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 108: goto tr539;
@@ -9098,7 +9097,7 @@ st381:
 	if ( ++p == pe )
 		goto _test_eof381;
 case 381:
-#line 9102 "inc/vcf/validator_detail_v42.hpp"
+#line 9101 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 121: goto st382;
@@ -9125,7 +9124,7 @@ st383:
 	if ( ++p == pe )
 		goto _test_eof383;
 case 383:
-#line 9129 "inc/vcf/validator_detail_v42.hpp"
+#line 9128 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr543;
@@ -9142,7 +9141,7 @@ st384:
 	if ( ++p == pe )
 		goto _test_eof384;
 case 384:
-#line 9146 "inc/vcf/validator_detail_v42.hpp"
+#line 9145 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9168,7 +9167,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9172 "inc/vcf/validator_detail_v42.hpp"
+#line 9171 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr542;
 		case 13: goto tr545;
@@ -9291,7 +9290,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9295 "inc/vcf/validator_detail_v42.hpp"
+#line 9294 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr45;
 		case 13: goto tr559;
@@ -9359,7 +9358,7 @@ st402:
 	if ( ++p == pe )
 		goto _test_eof402;
 case 402:
-#line 9363 "inc/vcf/validator_detail_v42.hpp"
+#line 9362 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 111: goto tr564;
@@ -9377,7 +9376,7 @@ st403:
 	if ( ++p == pe )
 		goto _test_eof403;
 case 403:
-#line 9381 "inc/vcf/validator_detail_v42.hpp"
+#line 9380 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 110: goto tr565;
@@ -9395,7 +9394,7 @@ st404:
 	if ( ++p == pe )
 		goto _test_eof404;
 case 404:
-#line 9399 "inc/vcf/validator_detail_v42.hpp"
+#line 9398 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 116: goto tr566;
@@ -9413,7 +9412,7 @@ st405:
 	if ( ++p == pe )
 		goto _test_eof405;
 case 405:
-#line 9417 "inc/vcf/validator_detail_v42.hpp"
+#line 9416 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr567;
@@ -9431,7 +9430,7 @@ st406:
 	if ( ++p == pe )
 		goto _test_eof406;
 case 406:
-#line 9435 "inc/vcf/validator_detail_v42.hpp"
+#line 9434 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto st407;
@@ -9458,7 +9457,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9462 "inc/vcf/validator_detail_v42.hpp"
+#line 9461 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st409;
 	goto tr563;
@@ -9520,7 +9519,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9524 "inc/vcf/validator_detail_v42.hpp"
+#line 9523 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 59: goto tr576;
@@ -9542,7 +9541,7 @@ st414:
 	if ( ++p == pe )
 		goto _test_eof414;
 case 414:
-#line 9546 "inc/vcf/validator_detail_v42.hpp"
+#line 9545 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto tr579;
 	if ( (*p) < 48 ) {
@@ -9567,7 +9566,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9571 "inc/vcf/validator_detail_v42.hpp"
+#line 9570 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 95 )
 		goto st415;
 	if ( (*p) < 48 ) {
@@ -9602,7 +9601,7 @@ st416:
 	if ( ++p == pe )
 		goto _test_eof416;
 case 416:
-#line 9606 "inc/vcf/validator_detail_v42.hpp"
+#line 9605 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr583;
 		case 95: goto tr582;
@@ -9629,7 +9628,7 @@ st417:
 	if ( ++p == pe )
 		goto _test_eof417;
 case 417:
-#line 9633 "inc/vcf/validator_detail_v42.hpp"
+#line 9632 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 34 )
 		goto st420;
 	if ( (*p) < 45 ) {
@@ -9661,7 +9660,7 @@ st418:
 	if ( ++p == pe )
 		goto _test_eof418;
 case 418:
-#line 9665 "inc/vcf/validator_detail_v42.hpp"
+#line 9664 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto tr577;
 		case 62: goto tr578;
@@ -9682,7 +9681,7 @@ st419:
 	if ( ++p == pe )
 		goto _test_eof419;
 case 419:
-#line 9686 "inc/vcf/validator_detail_v42.hpp"
+#line 9685 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -9719,7 +9718,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9723 "inc/vcf/validator_detail_v42.hpp"
+#line 9722 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 92: goto tr592;
@@ -9747,7 +9746,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9751 "inc/vcf/validator_detail_v42.hpp"
+#line 9750 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 44: goto st414;
 		case 62: goto st419;
@@ -9773,7 +9772,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9777 "inc/vcf/validator_detail_v42.hpp"
+#line 9776 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 92: goto tr592;
@@ -9795,7 +9794,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9799 "inc/vcf/validator_detail_v42.hpp"
+#line 9798 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr596;
@@ -9835,7 +9834,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9839 "inc/vcf/validator_detail_v42.hpp"
+#line 9838 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9886,7 +9885,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9890 "inc/vcf/validator_detail_v42.hpp"
+#line 9889 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9937,7 +9936,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9941 "inc/vcf/validator_detail_v42.hpp"
+#line 9940 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 47: goto tr590;
@@ -9980,7 +9979,7 @@ st428:
 	if ( ++p == pe )
 		goto _test_eof428;
 case 428:
-#line 9984 "inc/vcf/validator_detail_v42.hpp"
+#line 9983 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr604;
 		case 44: goto tr590;
@@ -10010,7 +10009,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 10014 "inc/vcf/validator_detail_v42.hpp"
+#line 10013 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr591;
 		case 44: goto tr607;
@@ -10050,7 +10049,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 10054 "inc/vcf/validator_detail_v42.hpp"
+#line 10053 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr56;
@@ -10080,7 +10079,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 10084 "inc/vcf/validator_detail_v42.hpp"
+#line 10083 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr595;
 		case 44: goto tr607;
@@ -10100,7 +10099,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 10104 "inc/vcf/validator_detail_v42.hpp"
+#line 10103 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 34: goto tr588;
 		case 44: goto tr610;
@@ -10124,7 +10123,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10128 "inc/vcf/validator_detail_v42.hpp"
+#line 10127 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr613;
@@ -10142,7 +10141,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10146 "inc/vcf/validator_detail_v42.hpp"
+#line 10145 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 100: goto tr614;
@@ -10160,7 +10159,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10164 "inc/vcf/validator_detail_v42.hpp"
+#line 10163 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 105: goto tr615;
@@ -10178,7 +10177,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10182 "inc/vcf/validator_detail_v42.hpp"
+#line 10181 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 103: goto tr616;
@@ -10196,7 +10195,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10200 "inc/vcf/validator_detail_v42.hpp"
+#line 10199 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 114: goto tr617;
@@ -10214,7 +10213,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10218 "inc/vcf/validator_detail_v42.hpp"
+#line 10217 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr618;
@@ -10232,7 +10231,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10236 "inc/vcf/validator_detail_v42.hpp"
+#line 10235 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 101: goto tr619;
@@ -10250,7 +10249,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10254 "inc/vcf/validator_detail_v42.hpp"
+#line 10253 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 68: goto tr620;
@@ -10268,7 +10267,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10272 "inc/vcf/validator_detail_v42.hpp"
+#line 10271 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 61: goto tr41;
 		case 66: goto st442;
@@ -10295,7 +10294,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10299 "inc/vcf/validator_detail_v42.hpp"
+#line 10298 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto st444;
 	goto tr612;
@@ -10319,7 +10318,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10323 "inc/vcf/validator_detail_v42.hpp"
+#line 10322 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10345,7 +10344,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10349 "inc/vcf/validator_detail_v42.hpp"
+#line 10348 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr627;
@@ -10456,7 +10455,7 @@ st456:
 	if ( ++p == pe )
 		goto _test_eof456;
 case 456:
-#line 10460 "inc/vcf/validator_detail_v42.hpp"
+#line 10459 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr624;
 		case 13: goto tr641;
@@ -10477,7 +10476,7 @@ st457:
 	if ( ++p == pe )
 		goto _test_eof457;
 case 457:
-#line 10481 "inc/vcf/validator_detail_v42.hpp"
+#line 10480 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr55;
 		case 13: goto tr643;
@@ -10512,7 +10511,7 @@ st458:
 	if ( ++p == pe )
 		goto _test_eof458;
 case 458:
-#line 10516 "inc/vcf/validator_detail_v42.hpp"
+#line 10515 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr641;
@@ -10612,7 +10611,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10616 "inc/vcf/validator_detail_v42.hpp"
+#line 10615 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 80 )
 		goto st471;
 	goto tr647;
@@ -10647,7 +10646,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10651 "inc/vcf/validator_detail_v42.hpp"
+#line 10650 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st475;
 	goto tr647;
@@ -10675,7 +10674,7 @@ st477:
 	if ( ++p == pe )
 		goto _test_eof477;
 case 477:
-#line 10679 "inc/vcf/validator_detail_v42.hpp"
+#line 10678 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 82 )
 		goto st478;
 	goto tr647;
@@ -10710,7 +10709,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10714 "inc/vcf/validator_detail_v42.hpp"
+#line 10713 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 65 )
 		goto st482;
 	goto tr647;
@@ -10745,7 +10744,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 10749 "inc/vcf/validator_detail_v42.hpp"
+#line 10748 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 81 )
 		goto st486;
 	goto tr647;
@@ -10787,7 +10786,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 10791 "inc/vcf/validator_detail_v42.hpp"
+#line 10790 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st491;
 	goto tr647;
@@ -10843,7 +10842,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 10847 "inc/vcf/validator_detail_v42.hpp"
+#line 10846 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto st498;
 	goto tr647;
@@ -10888,7 +10887,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 10892 "inc/vcf/validator_detail_v42.hpp"
+#line 10891 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 70 )
 		goto st503;
 	goto tr687;
@@ -10954,7 +10953,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 10958 "inc/vcf/validator_detail_v42.hpp"
+#line 10957 "inc/vcf/validator_detail_v42.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr695;
 	goto tr687;
@@ -10978,7 +10977,7 @@ st510:
 	if ( ++p == pe )
 		goto _test_eof510;
 case 510:
-#line 10982 "inc/vcf/validator_detail_v42.hpp"
+#line 10981 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr696;
 		case 10: goto tr697;
@@ -11027,7 +11026,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 11031 "inc/vcf/validator_detail_v42.hpp"
+#line 11030 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr916;
 		case 13: goto tr917;
@@ -11078,7 +11077,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 11082 "inc/vcf/validator_detail_v42.hpp"
+#line 11081 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr920;
 		case 13: goto tr921;
@@ -11120,7 +11119,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11124 "inc/vcf/validator_detail_v42.hpp"
+#line 11123 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st654;
 	goto st0;
@@ -11162,7 +11161,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11166 "inc/vcf/validator_detail_v42.hpp"
+#line 11165 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr703;
 		case 59: goto tr704;
@@ -11205,7 +11204,7 @@ st513:
 	if ( ++p == pe )
 		goto _test_eof513;
 case 513:
-#line 11209 "inc/vcf/validator_detail_v42.hpp"
+#line 11208 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr706;
 	goto tr705;
@@ -11229,7 +11228,7 @@ st514:
 	if ( ++p == pe )
 		goto _test_eof514;
 case 514:
-#line 11233 "inc/vcf/validator_detail_v42.hpp"
+#line 11232 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr707;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11259,7 +11258,7 @@ st515:
 	if ( ++p == pe )
 		goto _test_eof515;
 case 515:
-#line 11263 "inc/vcf/validator_detail_v42.hpp"
+#line 11262 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr710;
@@ -11286,7 +11285,7 @@ st516:
 	if ( ++p == pe )
 		goto _test_eof516;
 case 516:
-#line 11290 "inc/vcf/validator_detail_v42.hpp"
+#line 11289 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr711;
 		case 59: goto tr713;
@@ -11312,7 +11311,7 @@ st517:
 	if ( ++p == pe )
 		goto _test_eof517;
 case 517:
-#line 11316 "inc/vcf/validator_detail_v42.hpp"
+#line 11315 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr715;
 		case 67: goto tr715;
@@ -11346,7 +11345,7 @@ st518:
 	if ( ++p == pe )
 		goto _test_eof518;
 case 518:
-#line 11350 "inc/vcf/validator_detail_v42.hpp"
+#line 11349 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr716;
 		case 65: goto tr717;
@@ -11379,7 +11378,7 @@ st519:
 	if ( ++p == pe )
 		goto _test_eof519;
 case 519:
-#line 11383 "inc/vcf/validator_detail_v42.hpp"
+#line 11382 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr720;
@@ -11418,7 +11417,7 @@ st520:
 	if ( ++p == pe )
 		goto _test_eof520;
 case 520:
-#line 11422 "inc/vcf/validator_detail_v42.hpp"
+#line 11421 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -11442,7 +11441,7 @@ st521:
 	if ( ++p == pe )
 		goto _test_eof521;
 case 521:
-#line 11446 "inc/vcf/validator_detail_v42.hpp"
+#line 11445 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr728;
 		case 45: goto tr728;
@@ -11467,7 +11466,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11471 "inc/vcf/validator_detail_v42.hpp"
+#line 11470 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr734;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -11493,7 +11492,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11497 "inc/vcf/validator_detail_v42.hpp"
+#line 11496 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 46: goto tr736;
@@ -11521,7 +11520,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11525 "inc/vcf/validator_detail_v42.hpp"
+#line 11524 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr740;
 		case 58: goto tr739;
@@ -11557,7 +11556,7 @@ st525:
 	if ( ++p == pe )
 		goto _test_eof525;
 case 525:
-#line 11561 "inc/vcf/validator_detail_v42.hpp"
+#line 11560 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto st525;
 	if ( (*p) < 65 ) {
@@ -11601,7 +11600,7 @@ st526:
 	if ( ++p == pe )
 		goto _test_eof526;
 case 526:
-#line 11605 "inc/vcf/validator_detail_v42.hpp"
+#line 11604 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 59: goto tr745;
@@ -11627,7 +11626,7 @@ st527:
 	if ( ++p == pe )
 		goto _test_eof527;
 case 527:
-#line 11631 "inc/vcf/validator_detail_v42.hpp"
+#line 11630 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 46: goto tr748;
 		case 49: goto tr750;
@@ -11685,7 +11684,7 @@ st528:
 	if ( ++p == pe )
 		goto _test_eof528;
 case 528:
-#line 11689 "inc/vcf/validator_detail_v42.hpp"
+#line 11688 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr761;
 		case 60: goto tr761;
@@ -11731,7 +11730,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 11735 "inc/vcf/validator_detail_v42.hpp"
+#line 11734 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -11766,7 +11765,7 @@ st529:
 	if ( ++p == pe )
 		goto _test_eof529;
 case 529:
-#line 11770 "inc/vcf/validator_detail_v42.hpp"
+#line 11769 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr764;
@@ -11796,7 +11795,7 @@ st530:
 	if ( ++p == pe )
 		goto _test_eof530;
 case 530:
-#line 11800 "inc/vcf/validator_detail_v42.hpp"
+#line 11799 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 58: goto tr767;
@@ -11828,7 +11827,7 @@ st531:
 	if ( ++p == pe )
 		goto _test_eof531;
 case 531:
-#line 11832 "inc/vcf/validator_detail_v42.hpp"
+#line 11831 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 46 )
 		goto tr770;
 	if ( (*p) < 48 ) {
@@ -11860,7 +11859,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 11864 "inc/vcf/validator_detail_v42.hpp"
+#line 11863 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -11919,7 +11918,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 11923 "inc/vcf/validator_detail_v42.hpp"
+#line 11922 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr920;
 		case 13: goto tr921;
@@ -11948,7 +11947,7 @@ st532:
 	if ( ++p == pe )
 		goto _test_eof532;
 case 532:
-#line 11952 "inc/vcf/validator_detail_v42.hpp"
+#line 11951 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr772;
@@ -11978,7 +11977,7 @@ st533:
 	if ( ++p == pe )
 		goto _test_eof533;
 case 533:
-#line 11982 "inc/vcf/validator_detail_v42.hpp"
+#line 11981 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr773;
 		case 62: goto tr774;
@@ -12002,7 +12001,7 @@ st534:
 	if ( ++p == pe )
 		goto _test_eof534;
 case 534:
-#line 12006 "inc/vcf/validator_detail_v42.hpp"
+#line 12005 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr775;
 	goto tr702;
@@ -12055,7 +12054,7 @@ st535:
 	if ( ++p == pe )
 		goto _test_eof535;
 case 535:
-#line 12059 "inc/vcf/validator_detail_v42.hpp"
+#line 12058 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st657;
 	goto tr776;
@@ -12069,7 +12068,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 12073 "inc/vcf/validator_detail_v42.hpp"
+#line 12072 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr779;
@@ -12096,7 +12095,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 12100 "inc/vcf/validator_detail_v42.hpp"
+#line 12099 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -12118,7 +12117,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 12122 "inc/vcf/validator_detail_v42.hpp"
+#line 12121 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -12155,7 +12154,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 12159 "inc/vcf/validator_detail_v42.hpp"
+#line 12158 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr765;
 		case 10: goto tr923;
@@ -12183,7 +12182,7 @@ st537:
 	if ( ++p == pe )
 		goto _test_eof537;
 case 537:
-#line 12187 "inc/vcf/validator_detail_v42.hpp"
+#line 12186 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 49: goto tr750;
 		case 58: goto tr747;
@@ -12234,7 +12233,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 12238 "inc/vcf/validator_detail_v42.hpp"
+#line 12237 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12256,7 +12255,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 12260 "inc/vcf/validator_detail_v42.hpp"
+#line 12259 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12278,7 +12277,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 12282 "inc/vcf/validator_detail_v42.hpp"
+#line 12281 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12300,7 +12299,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 12304 "inc/vcf/validator_detail_v42.hpp"
+#line 12303 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12322,7 +12321,7 @@ st538:
 	if ( ++p == pe )
 		goto _test_eof538;
 case 538:
-#line 12326 "inc/vcf/validator_detail_v42.hpp"
+#line 12325 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr781;
@@ -12339,7 +12338,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 12343 "inc/vcf/validator_detail_v42.hpp"
+#line 12342 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12359,7 +12358,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 12363 "inc/vcf/validator_detail_v42.hpp"
+#line 12362 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12380,7 +12379,7 @@ st539:
 	if ( ++p == pe )
 		goto _test_eof539;
 case 539:
-#line 12384 "inc/vcf/validator_detail_v42.hpp"
+#line 12383 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr783;
 	goto tr782;
@@ -12394,7 +12393,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 12398 "inc/vcf/validator_detail_v42.hpp"
+#line 12397 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12416,7 +12415,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 12420 "inc/vcf/validator_detail_v42.hpp"
+#line 12419 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12441,7 +12440,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 12445 "inc/vcf/validator_detail_v42.hpp"
+#line 12444 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr784;
 	if ( (*p) > 58 ) {
@@ -12460,7 +12459,7 @@ st541:
 	if ( ++p == pe )
 		goto _test_eof541;
 case 541:
-#line 12464 "inc/vcf/validator_detail_v42.hpp"
+#line 12463 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr786;
 	if ( (*p) < 45 ) {
@@ -12482,7 +12481,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 12486 "inc/vcf/validator_detail_v42.hpp"
+#line 12485 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12508,7 +12507,7 @@ st542:
 	if ( ++p == pe )
 		goto _test_eof542;
 case 542:
-#line 12512 "inc/vcf/validator_detail_v42.hpp"
+#line 12511 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr787;
 	if ( (*p) > 58 ) {
@@ -12527,7 +12526,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12531 "inc/vcf/validator_detail_v42.hpp"
+#line 12530 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr789;
 	goto tr788;
@@ -12541,7 +12540,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 12545 "inc/vcf/validator_detail_v42.hpp"
+#line 12544 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12562,7 +12561,7 @@ st544:
 	if ( ++p == pe )
 		goto _test_eof544;
 case 544:
-#line 12566 "inc/vcf/validator_detail_v42.hpp"
+#line 12565 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr790;
 	if ( (*p) > 58 ) {
@@ -12581,7 +12580,7 @@ st545:
 	if ( ++p == pe )
 		goto _test_eof545;
 case 545:
-#line 12585 "inc/vcf/validator_detail_v42.hpp"
+#line 12584 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr792;
 		case 45: goto tr792;
@@ -12601,7 +12600,7 @@ st546:
 	if ( ++p == pe )
 		goto _test_eof546;
 case 546:
-#line 12605 "inc/vcf/validator_detail_v42.hpp"
+#line 12604 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr794;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12617,7 +12616,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 12621 "inc/vcf/validator_detail_v42.hpp"
+#line 12620 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12641,7 +12640,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12645 "inc/vcf/validator_detail_v42.hpp"
+#line 12644 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr796;
 	goto tr791;
@@ -12655,7 +12654,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 12659 "inc/vcf/validator_detail_v42.hpp"
+#line 12658 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12678,7 +12677,7 @@ st548:
 	if ( ++p == pe )
 		goto _test_eof548;
 case 548:
-#line 12682 "inc/vcf/validator_detail_v42.hpp"
+#line 12681 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr797;
 		case 45: goto tr797;
@@ -12696,7 +12695,7 @@ st549:
 	if ( ++p == pe )
 		goto _test_eof549;
 case 549:
-#line 12700 "inc/vcf/validator_detail_v42.hpp"
+#line 12699 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr798;
 	goto tr791;
@@ -12710,7 +12709,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 12714 "inc/vcf/validator_detail_v42.hpp"
+#line 12713 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12731,7 +12730,7 @@ st550:
 	if ( ++p == pe )
 		goto _test_eof550;
 case 550:
-#line 12735 "inc/vcf/validator_detail_v42.hpp"
+#line 12734 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr799;
 	goto tr791;
@@ -12745,7 +12744,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12749 "inc/vcf/validator_detail_v42.hpp"
+#line 12748 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr800;
 	goto tr791;
@@ -12759,7 +12758,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 12763 "inc/vcf/validator_detail_v42.hpp"
+#line 12762 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12778,7 +12777,7 @@ st552:
 	if ( ++p == pe )
 		goto _test_eof552;
 case 552:
-#line 12782 "inc/vcf/validator_detail_v42.hpp"
+#line 12781 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr801;
 	goto tr791;
@@ -12792,7 +12791,7 @@ st553:
 	if ( ++p == pe )
 		goto _test_eof553;
 case 553:
-#line 12796 "inc/vcf/validator_detail_v42.hpp"
+#line 12795 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr800;
 	goto tr791;
@@ -12806,7 +12805,7 @@ st554:
 	if ( ++p == pe )
 		goto _test_eof554;
 case 554:
-#line 12810 "inc/vcf/validator_detail_v42.hpp"
+#line 12809 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr802;
 	if ( (*p) > 58 ) {
@@ -12825,7 +12824,7 @@ st555:
 	if ( ++p == pe )
 		goto _test_eof555;
 case 555:
-#line 12829 "inc/vcf/validator_detail_v42.hpp"
+#line 12828 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr804;
 	goto tr803;
@@ -12839,7 +12838,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 12843 "inc/vcf/validator_detail_v42.hpp"
+#line 12842 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12863,7 +12862,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 12867 "inc/vcf/validator_detail_v42.hpp"
+#line 12866 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12885,7 +12884,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12889 "inc/vcf/validator_detail_v42.hpp"
+#line 12888 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr805;
 	if ( (*p) > 58 ) {
@@ -12904,7 +12903,7 @@ st557:
 	if ( ++p == pe )
 		goto _test_eof557;
 case 557:
-#line 12908 "inc/vcf/validator_detail_v42.hpp"
+#line 12907 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr807;
 		case 45: goto tr807;
@@ -12924,7 +12923,7 @@ st558:
 	if ( ++p == pe )
 		goto _test_eof558;
 case 558:
-#line 12928 "inc/vcf/validator_detail_v42.hpp"
+#line 12927 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr809;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12940,7 +12939,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 12944 "inc/vcf/validator_detail_v42.hpp"
+#line 12943 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12963,7 +12962,7 @@ st559:
 	if ( ++p == pe )
 		goto _test_eof559;
 case 559:
-#line 12967 "inc/vcf/validator_detail_v42.hpp"
+#line 12966 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr811;
 	goto tr806;
@@ -12977,7 +12976,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 12981 "inc/vcf/validator_detail_v42.hpp"
+#line 12980 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -12999,7 +12998,7 @@ st560:
 	if ( ++p == pe )
 		goto _test_eof560;
 case 560:
-#line 13003 "inc/vcf/validator_detail_v42.hpp"
+#line 13002 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr812;
 		case 45: goto tr812;
@@ -13017,7 +13016,7 @@ st561:
 	if ( ++p == pe )
 		goto _test_eof561;
 case 561:
-#line 13021 "inc/vcf/validator_detail_v42.hpp"
+#line 13020 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr813;
 	goto tr806;
@@ -13031,7 +13030,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 13035 "inc/vcf/validator_detail_v42.hpp"
+#line 13034 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13051,7 +13050,7 @@ st562:
 	if ( ++p == pe )
 		goto _test_eof562;
 case 562:
-#line 13055 "inc/vcf/validator_detail_v42.hpp"
+#line 13054 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr814;
 	goto tr806;
@@ -13065,7 +13064,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 13069 "inc/vcf/validator_detail_v42.hpp"
+#line 13068 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr815;
 	goto tr806;
@@ -13079,7 +13078,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 13083 "inc/vcf/validator_detail_v42.hpp"
+#line 13082 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13097,7 +13096,7 @@ st564:
 	if ( ++p == pe )
 		goto _test_eof564;
 case 564:
-#line 13101 "inc/vcf/validator_detail_v42.hpp"
+#line 13100 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr816;
 	goto tr806;
@@ -13111,7 +13110,7 @@ st565:
 	if ( ++p == pe )
 		goto _test_eof565;
 case 565:
-#line 13115 "inc/vcf/validator_detail_v42.hpp"
+#line 13114 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr815;
 	goto tr806;
@@ -13129,7 +13128,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 13133 "inc/vcf/validator_detail_v42.hpp"
+#line 13132 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13151,7 +13150,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 13155 "inc/vcf/validator_detail_v42.hpp"
+#line 13154 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13173,7 +13172,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 13177 "inc/vcf/validator_detail_v42.hpp"
+#line 13176 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13195,7 +13194,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 13199 "inc/vcf/validator_detail_v42.hpp"
+#line 13198 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13217,7 +13216,7 @@ st566:
 	if ( ++p == pe )
 		goto _test_eof566;
 case 566:
-#line 13221 "inc/vcf/validator_detail_v42.hpp"
+#line 13220 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr817;
 	if ( (*p) > 58 ) {
@@ -13236,7 +13235,7 @@ st567:
 	if ( ++p == pe )
 		goto _test_eof567;
 case 567:
-#line 13240 "inc/vcf/validator_detail_v42.hpp"
+#line 13239 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr819;
 	goto tr818;
@@ -13250,7 +13249,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 13254 "inc/vcf/validator_detail_v42.hpp"
+#line 13253 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 68: goto tr820;
 		case 80: goto tr820;
@@ -13276,7 +13275,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 13280 "inc/vcf/validator_detail_v42.hpp"
+#line 13279 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13301,7 +13300,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 13305 "inc/vcf/validator_detail_v42.hpp"
+#line 13304 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13324,7 +13323,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 13328 "inc/vcf/validator_detail_v42.hpp"
+#line 13327 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13345,7 +13344,7 @@ st569:
 	if ( ++p == pe )
 		goto _test_eof569;
 case 569:
-#line 13349 "inc/vcf/validator_detail_v42.hpp"
+#line 13348 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr822;
 	goto tr821;
@@ -13359,7 +13358,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 13363 "inc/vcf/validator_detail_v42.hpp"
+#line 13362 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13377,7 +13376,7 @@ st570:
 	if ( ++p == pe )
 		goto _test_eof570;
 case 570:
-#line 13381 "inc/vcf/validator_detail_v42.hpp"
+#line 13380 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr823;
 	if ( (*p) > 58 ) {
@@ -13396,7 +13395,7 @@ st571:
 	if ( ++p == pe )
 		goto _test_eof571;
 case 571:
-#line 13400 "inc/vcf/validator_detail_v42.hpp"
+#line 13399 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr825;
 	goto tr824;
@@ -13410,7 +13409,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 13414 "inc/vcf/validator_detail_v42.hpp"
+#line 13413 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13434,7 +13433,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 13438 "inc/vcf/validator_detail_v42.hpp"
+#line 13437 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13456,7 +13455,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 13460 "inc/vcf/validator_detail_v42.hpp"
+#line 13459 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13478,7 +13477,7 @@ st572:
 	if ( ++p == pe )
 		goto _test_eof572;
 case 572:
-#line 13482 "inc/vcf/validator_detail_v42.hpp"
+#line 13481 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr826;
 	if ( (*p) > 58 ) {
@@ -13497,7 +13496,7 @@ st573:
 	if ( ++p == pe )
 		goto _test_eof573;
 case 573:
-#line 13501 "inc/vcf/validator_detail_v42.hpp"
+#line 13500 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr828;
 	goto tr827;
@@ -13511,7 +13510,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 13515 "inc/vcf/validator_detail_v42.hpp"
+#line 13514 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13535,7 +13534,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 13539 "inc/vcf/validator_detail_v42.hpp"
+#line 13538 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13558,7 +13557,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 13562 "inc/vcf/validator_detail_v42.hpp"
+#line 13561 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13579,7 +13578,7 @@ st574:
 	if ( ++p == pe )
 		goto _test_eof574;
 case 574:
-#line 13583 "inc/vcf/validator_detail_v42.hpp"
+#line 13582 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr830;
 	goto tr829;
@@ -13593,7 +13592,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 13597 "inc/vcf/validator_detail_v42.hpp"
+#line 13596 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13611,7 +13610,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 13615 "inc/vcf/validator_detail_v42.hpp"
+#line 13614 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13632,7 +13631,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 13636 "inc/vcf/validator_detail_v42.hpp"
+#line 13635 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr832;
 	goto tr831;
@@ -13646,7 +13645,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 13650 "inc/vcf/validator_detail_v42.hpp"
+#line 13649 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13668,7 +13667,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 13672 "inc/vcf/validator_detail_v42.hpp"
+#line 13671 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13690,7 +13689,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 13694 "inc/vcf/validator_detail_v42.hpp"
+#line 13693 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 48: goto tr833;
 		case 61: goto tr834;
@@ -13711,7 +13710,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 13715 "inc/vcf/validator_detail_v42.hpp"
+#line 13714 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr835;
 	if ( (*p) > 58 ) {
@@ -13730,7 +13729,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 13734 "inc/vcf/validator_detail_v42.hpp"
+#line 13733 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr837;
 	goto tr836;
@@ -13744,7 +13743,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 13748 "inc/vcf/validator_detail_v42.hpp"
+#line 13747 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13764,7 +13763,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 13768 "inc/vcf/validator_detail_v42.hpp"
+#line 13767 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr839;
 		case 45: goto tr839;
@@ -13784,7 +13783,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 13788 "inc/vcf/validator_detail_v42.hpp"
+#line 13787 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr841;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -13800,7 +13799,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 13804 "inc/vcf/validator_detail_v42.hpp"
+#line 13803 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13823,7 +13822,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 13827 "inc/vcf/validator_detail_v42.hpp"
+#line 13826 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr843;
 	goto tr838;
@@ -13837,7 +13836,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 13841 "inc/vcf/validator_detail_v42.hpp"
+#line 13840 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13859,7 +13858,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 13863 "inc/vcf/validator_detail_v42.hpp"
+#line 13862 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr844;
 		case 45: goto tr844;
@@ -13877,7 +13876,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 13881 "inc/vcf/validator_detail_v42.hpp"
+#line 13880 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr845;
 	goto tr838;
@@ -13891,7 +13890,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 13895 "inc/vcf/validator_detail_v42.hpp"
+#line 13894 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13911,7 +13910,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 13915 "inc/vcf/validator_detail_v42.hpp"
+#line 13914 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr846;
 	goto tr838;
@@ -13925,7 +13924,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 13929 "inc/vcf/validator_detail_v42.hpp"
+#line 13928 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr847;
 	goto tr838;
@@ -13939,7 +13938,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 13943 "inc/vcf/validator_detail_v42.hpp"
+#line 13942 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -13957,7 +13956,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 13961 "inc/vcf/validator_detail_v42.hpp"
+#line 13960 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr848;
 	goto tr838;
@@ -13971,7 +13970,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 13975 "inc/vcf/validator_detail_v42.hpp"
+#line 13974 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr847;
 	goto tr838;
@@ -13989,7 +13988,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 13993 "inc/vcf/validator_detail_v42.hpp"
+#line 13992 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14011,7 +14010,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 14015 "inc/vcf/validator_detail_v42.hpp"
+#line 14014 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr849;
 	if ( (*p) > 58 ) {
@@ -14030,7 +14029,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 14034 "inc/vcf/validator_detail_v42.hpp"
+#line 14033 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr851;
 	goto tr850;
@@ -14044,7 +14043,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 14048 "inc/vcf/validator_detail_v42.hpp"
+#line 14047 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14068,7 +14067,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 14072 "inc/vcf/validator_detail_v42.hpp"
+#line 14071 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14091,7 +14090,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 14095 "inc/vcf/validator_detail_v42.hpp"
+#line 14094 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr852;
 	if ( (*p) > 58 ) {
@@ -14110,7 +14109,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 14114 "inc/vcf/validator_detail_v42.hpp"
+#line 14113 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr854;
 		case 45: goto tr854;
@@ -14130,7 +14129,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 14134 "inc/vcf/validator_detail_v42.hpp"
+#line 14133 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 73 )
 		goto tr856;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14146,7 +14145,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 14150 "inc/vcf/validator_detail_v42.hpp"
+#line 14149 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14169,7 +14168,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 14173 "inc/vcf/validator_detail_v42.hpp"
+#line 14172 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr858;
 	goto tr853;
@@ -14183,7 +14182,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 14187 "inc/vcf/validator_detail_v42.hpp"
+#line 14186 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14205,7 +14204,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 14209 "inc/vcf/validator_detail_v42.hpp"
+#line 14208 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr859;
 		case 45: goto tr859;
@@ -14223,7 +14222,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 14227 "inc/vcf/validator_detail_v42.hpp"
+#line 14226 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr860;
 	goto tr853;
@@ -14237,7 +14236,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 14241 "inc/vcf/validator_detail_v42.hpp"
+#line 14240 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14257,7 +14256,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 14261 "inc/vcf/validator_detail_v42.hpp"
+#line 14260 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr861;
 	goto tr853;
@@ -14271,7 +14270,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 14275 "inc/vcf/validator_detail_v42.hpp"
+#line 14274 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr862;
 	goto tr853;
@@ -14285,7 +14284,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 14289 "inc/vcf/validator_detail_v42.hpp"
+#line 14288 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14303,7 +14302,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 14307 "inc/vcf/validator_detail_v42.hpp"
+#line 14306 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr863;
 	goto tr853;
@@ -14317,7 +14316,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 14321 "inc/vcf/validator_detail_v42.hpp"
+#line 14320 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr862;
 	goto tr853;
@@ -14331,7 +14330,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 14335 "inc/vcf/validator_detail_v42.hpp"
+#line 14334 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14353,7 +14352,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 14357 "inc/vcf/validator_detail_v42.hpp"
+#line 14356 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14375,7 +14374,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 14379 "inc/vcf/validator_detail_v42.hpp"
+#line 14378 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14397,7 +14396,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 14401 "inc/vcf/validator_detail_v42.hpp"
+#line 14400 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14419,7 +14418,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 14423 "inc/vcf/validator_detail_v42.hpp"
+#line 14422 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14441,7 +14440,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 14445 "inc/vcf/validator_detail_v42.hpp"
+#line 14444 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14462,7 +14461,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 14466 "inc/vcf/validator_detail_v42.hpp"
+#line 14465 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr865;
 	goto tr864;
@@ -14476,7 +14475,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 14480 "inc/vcf/validator_detail_v42.hpp"
+#line 14479 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14498,7 +14497,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 14502 "inc/vcf/validator_detail_v42.hpp"
+#line 14501 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14520,7 +14519,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 14524 "inc/vcf/validator_detail_v42.hpp"
+#line 14523 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14542,7 +14541,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 14546 "inc/vcf/validator_detail_v42.hpp"
+#line 14545 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14564,7 +14563,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 14568 "inc/vcf/validator_detail_v42.hpp"
+#line 14567 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14586,7 +14585,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 14590 "inc/vcf/validator_detail_v42.hpp"
+#line 14589 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14608,7 +14607,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 14612 "inc/vcf/validator_detail_v42.hpp"
+#line 14611 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14630,7 +14629,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 14634 "inc/vcf/validator_detail_v42.hpp"
+#line 14633 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14652,7 +14651,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 14656 "inc/vcf/validator_detail_v42.hpp"
+#line 14655 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14674,7 +14673,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 14678 "inc/vcf/validator_detail_v42.hpp"
+#line 14677 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14695,7 +14694,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 14699 "inc/vcf/validator_detail_v42.hpp"
+#line 14698 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr867;
 	goto tr866;
@@ -14709,7 +14708,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 14713 "inc/vcf/validator_detail_v42.hpp"
+#line 14712 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14731,7 +14730,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 14735 "inc/vcf/validator_detail_v42.hpp"
+#line 14734 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr922;
 		case 10: goto tr923;
@@ -14770,7 +14769,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 14774 "inc/vcf/validator_detail_v42.hpp"
+#line 14773 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr739;
 	if ( (*p) < 65 ) {
@@ -14808,7 +14807,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 14812 "inc/vcf/validator_detail_v42.hpp"
+#line 14811 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr744;
 		case 58: goto st525;
@@ -14844,7 +14843,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 14848 "inc/vcf/validator_detail_v42.hpp"
+#line 14847 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr868;
 	goto tr727;
@@ -14858,7 +14857,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 14862 "inc/vcf/validator_detail_v42.hpp"
+#line 14861 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr735;
 		case 69: goto tr737;
@@ -14877,7 +14876,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 14881 "inc/vcf/validator_detail_v42.hpp"
+#line 14880 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 43: goto tr869;
 		case 45: goto tr869;
@@ -14895,7 +14894,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 14899 "inc/vcf/validator_detail_v42.hpp"
+#line 14898 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr870;
 	goto tr727;
@@ -14909,7 +14908,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 14913 "inc/vcf/validator_detail_v42.hpp"
+#line 14912 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14935,7 +14934,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 14939 "inc/vcf/validator_detail_v42.hpp"
+#line 14938 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 110 )
 		goto tr871;
 	goto tr727;
@@ -14949,7 +14948,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 14953 "inc/vcf/validator_detail_v42.hpp"
+#line 14952 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 102 )
 		goto tr872;
 	goto tr727;
@@ -14973,7 +14972,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 14977 "inc/vcf/validator_detail_v42.hpp"
+#line 14976 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 9 )
 		goto tr735;
 	goto tr727;
@@ -14991,7 +14990,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 14995 "inc/vcf/validator_detail_v42.hpp"
+#line 14994 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 97 )
 		goto tr873;
 	goto tr727;
@@ -15005,7 +15004,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 15009 "inc/vcf/validator_detail_v42.hpp"
+#line 15008 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 78 )
 		goto tr872;
 	goto tr727;
@@ -15019,7 +15018,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 15023 "inc/vcf/validator_detail_v42.hpp"
+#line 15022 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 42: goto tr719;
 		case 46: goto tr874;
@@ -15058,7 +15057,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 15062 "inc/vcf/validator_detail_v42.hpp"
+#line 15061 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 65: goto tr875;
 		case 67: goto tr875;
@@ -15082,7 +15081,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 15086 "inc/vcf/validator_detail_v42.hpp"
+#line 15085 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15118,7 +15117,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 15122 "inc/vcf/validator_detail_v42.hpp"
+#line 15121 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 61 )
 		goto tr876;
 	if ( (*p) < 63 ) {
@@ -15158,7 +15157,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 15162 "inc/vcf/validator_detail_v42.hpp"
+#line 15161 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 62 )
 		goto tr878;
 	if ( (*p) < 45 ) {
@@ -15190,7 +15189,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 15194 "inc/vcf/validator_detail_v42.hpp"
+#line 15193 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 44: goto tr726;
@@ -15219,7 +15218,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 15223 "inc/vcf/validator_detail_v42.hpp"
+#line 15222 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr883;
 	if ( (*p) < 65 ) {
@@ -15241,7 +15240,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 15245 "inc/vcf/validator_detail_v42.hpp"
+#line 15244 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr884;
 		case 61: goto tr882;
@@ -15265,7 +15264,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 15269 "inc/vcf/validator_detail_v42.hpp"
+#line 15268 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr885;
 	goto tr718;
@@ -15279,7 +15278,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 15283 "inc/vcf/validator_detail_v42.hpp"
+#line 15282 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr878;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15295,7 +15294,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 15299 "inc/vcf/validator_detail_v42.hpp"
+#line 15298 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr886;
@@ -15315,7 +15314,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 15319 "inc/vcf/validator_detail_v42.hpp"
+#line 15318 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr886;
 		case 62: goto tr887;
@@ -15339,7 +15338,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 15343 "inc/vcf/validator_detail_v42.hpp"
+#line 15342 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr884;
 	goto tr718;
@@ -15353,7 +15352,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 15357 "inc/vcf/validator_detail_v42.hpp"
+#line 15356 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr889;
 	if ( (*p) < 65 ) {
@@ -15375,7 +15374,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 15379 "inc/vcf/validator_detail_v42.hpp"
+#line 15378 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr890;
 		case 61: goto tr888;
@@ -15399,7 +15398,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 15403 "inc/vcf/validator_detail_v42.hpp"
+#line 15402 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr891;
 	goto tr718;
@@ -15413,7 +15412,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 15417 "inc/vcf/validator_detail_v42.hpp"
+#line 15416 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr878;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15429,7 +15428,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 15433 "inc/vcf/validator_detail_v42.hpp"
+#line 15432 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr892;
@@ -15449,7 +15448,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 15453 "inc/vcf/validator_detail_v42.hpp"
+#line 15452 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr892;
 		case 62: goto tr893;
@@ -15473,7 +15472,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 15477 "inc/vcf/validator_detail_v42.hpp"
+#line 15476 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr890;
 	goto tr718;
@@ -15491,7 +15490,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 15495 "inc/vcf/validator_detail_v42.hpp"
+#line 15494 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr895;
 	if ( (*p) < 65 ) {
@@ -15513,7 +15512,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 15517 "inc/vcf/validator_detail_v42.hpp"
+#line 15516 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr896;
 		case 61: goto tr894;
@@ -15537,7 +15536,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 15541 "inc/vcf/validator_detail_v42.hpp"
+#line 15540 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr897;
 	goto tr718;
@@ -15551,7 +15550,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 15555 "inc/vcf/validator_detail_v42.hpp"
+#line 15554 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 91 )
 		goto tr898;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15567,7 +15566,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 15571 "inc/vcf/validator_detail_v42.hpp"
+#line 15570 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr899;
@@ -15587,7 +15586,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 15591 "inc/vcf/validator_detail_v42.hpp"
+#line 15590 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr899;
 		case 62: goto tr900;
@@ -15611,7 +15610,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 15615 "inc/vcf/validator_detail_v42.hpp"
+#line 15614 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr896;
 	goto tr718;
@@ -15629,7 +15628,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 15633 "inc/vcf/validator_detail_v42.hpp"
+#line 15632 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 60 )
 		goto tr902;
 	if ( (*p) < 65 ) {
@@ -15651,7 +15650,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 15655 "inc/vcf/validator_detail_v42.hpp"
+#line 15654 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 58: goto tr903;
 		case 61: goto tr901;
@@ -15675,7 +15674,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 15679 "inc/vcf/validator_detail_v42.hpp"
+#line 15678 "inc/vcf/validator_detail_v42.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr904;
 	goto tr718;
@@ -15689,7 +15688,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 15693 "inc/vcf/validator_detail_v42.hpp"
+#line 15692 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 93 )
 		goto tr898;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15705,7 +15704,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 15709 "inc/vcf/validator_detail_v42.hpp"
+#line 15708 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) < 65 ) {
 		if ( 48 <= (*p) && (*p) <= 57 )
 			goto tr905;
@@ -15725,7 +15724,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 15729 "inc/vcf/validator_detail_v42.hpp"
+#line 15728 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 59: goto tr905;
 		case 62: goto tr906;
@@ -15749,7 +15748,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 15753 "inc/vcf/validator_detail_v42.hpp"
+#line 15752 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 58 )
 		goto tr903;
 	goto tr718;
@@ -15767,7 +15766,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 15771 "inc/vcf/validator_detail_v42.hpp"
+#line 15770 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 9: goto tr725;
 		case 65: goto tr875;
@@ -15822,7 +15821,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 15826 "inc/vcf/validator_detail_v42.hpp"
+#line 15825 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st653;
 	goto tr687;
@@ -15851,7 +15850,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 15855 "inc/vcf/validator_detail_v42.hpp"
+#line 15854 "inc/vcf/validator_detail_v42.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -15871,7 +15870,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 15875 "inc/vcf/validator_detail_v42.hpp"
+#line 15874 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr910;
 		case 13: goto tr911;
@@ -15888,14 +15887,14 @@ tr910:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 826 "src/vcf/vcf_v42.ragel"
+#line 825 "src/vcf/vcf_v42.ragel"
 	{ {goto st28;} }
 	goto st729;
 st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 15899 "inc/vcf/validator_detail_v42.hpp"
+#line 15898 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 tr914:
 #line 43 "src/vcf/vcf_v42.ragel"
@@ -15913,7 +15912,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 15917 "inc/vcf/validator_detail_v42.hpp"
+#line 15916 "inc/vcf/validator_detail_v42.hpp"
 	switch( (*p) ) {
 		case 10: goto tr913;
 		case 13: goto tr914;
@@ -15930,14 +15929,14 @@ tr913:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 827 "src/vcf/vcf_v42.ragel"
+#line 826 "src/vcf/vcf_v42.ragel"
 	{ {goto st657;} }
 	goto st730;
 st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 15941 "inc/vcf/validator_detail_v42.hpp"
+#line 15940 "inc/vcf/validator_detail_v42.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -16800,8 +16799,7 @@ case 730:
 #line 227 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         p--; {goto st651;}
     }
 #line 60 "src/vcf/vcf_v42.ragel"
@@ -16832,7 +16830,7 @@ case 730:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -16851,7 +16849,7 @@ case 730:
 	case 380: 
 	case 381: 
 	case 382: 
-#line 247 "src/vcf/vcf_v42.ragel"
+#line 246 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -16891,7 +16889,7 @@ case 730:
 	case 430: 
 	case 431: 
 	case 432: 
-#line 253 "src/vcf/vcf_v42.ragel"
+#line 252 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -16926,7 +16924,7 @@ case 730:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -16973,7 +16971,7 @@ case 730:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17019,7 +17017,7 @@ case 730:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17040,7 +17038,7 @@ case 730:
 	case 313: 
 	case 314: 
 	case 321: 
-#line 297 "src/vcf/vcf_v42.ragel"
+#line 296 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -17062,7 +17060,7 @@ case 730:
 	case 441: 
 	case 442: 
 	case 443: 
-#line 303 "src/vcf/vcf_v42.ragel"
+#line 302 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -17084,7 +17082,7 @@ case 730:
 	case 330: 
 	case 331: 
 	case 371: 
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17132,7 +17130,7 @@ case 730:
 	case 499: 
 	case 500: 
 	case 501: 
-#line 341 "src/vcf/vcf_v42.ragel"
+#line 340 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17164,7 +17162,7 @@ case 730:
 	case 532: 
 	case 533: 
 	case 534: 
-#line 358 "src/vcf/vcf_v42.ragel"
+#line 357 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st652;}
@@ -17177,7 +17175,7 @@ case 730:
 	break;
 	case 513: 
 	case 514: 
-#line 364 "src/vcf/vcf_v42.ragel"
+#line 363 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st652;}
@@ -17190,7 +17188,7 @@ case 730:
 	break;
 	case 515: 
 	case 516: 
-#line 370 "src/vcf/vcf_v42.ragel"
+#line 369 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st652;}
@@ -17203,7 +17201,7 @@ case 730:
 	break;
 	case 517: 
 	case 518: 
-#line 376 "src/vcf/vcf_v42.ragel"
+#line 375 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st652;}
@@ -17251,7 +17249,7 @@ case 730:
 	case 646: 
 	case 647: 
 	case 648: 
-#line 382 "src/vcf/vcf_v42.ragel"
+#line 381 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st652;}
@@ -17275,7 +17273,7 @@ case 730:
 	case 611: 
 	case 612: 
 	case 613: 
-#line 388 "src/vcf/vcf_v42.ragel"
+#line 387 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st652;}
@@ -17291,7 +17289,7 @@ case 730:
 	case 526: 
 	case 602: 
 	case 603: 
-#line 394 "src/vcf/vcf_v42.ragel"
+#line 393 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st652;}
@@ -17304,7 +17302,7 @@ case 730:
 	break;
 	case 529: 
 	case 530: 
-#line 560 "src/vcf/vcf_v42.ragel"
+#line 559 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines});
         p--; {goto st652;}
@@ -17316,7 +17314,7 @@ case 730:
     }
 	break;
 	case 536: 
-#line 566 "src/vcf/vcf_v42.ragel"
+#line 565 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -17443,7 +17441,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 341 "src/vcf/vcf_v42.ragel"
+#line 340 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -17474,13 +17472,13 @@ case 730:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 240 "src/vcf/vcf_v42.ragel"
+#line 239 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -17492,12 +17490,12 @@ case 730:
     }
 	break;
 	case 122: 
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17511,12 +17509,12 @@ case 730:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 270 "src/vcf/vcf_v42.ragel"
+#line 269 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17530,12 +17528,12 @@ case 730:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 286 "src/vcf/vcf_v42.ragel"
+#line 285 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17548,12 +17546,12 @@ case 730:
 	break;
 	case 199: 
 	case 200: 
-#line 291 "src/vcf/vcf_v42.ragel"
+#line 290 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17566,12 +17564,12 @@ case 730:
 	break;
 	case 265: 
 	case 266: 
-#line 291 "src/vcf/vcf_v42.ragel"
+#line 290 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not a Integer, Float, Flag, Character or String"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17591,12 +17589,12 @@ case 730:
 	case 341: 
 	case 342: 
 	case 343: 
-#line 314 "src/vcf/vcf_v42.ragel"
+#line 313 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17616,12 +17614,12 @@ case 730:
 	case 351: 
 	case 352: 
 	case 353: 
-#line 319 "src/vcf/vcf_v42.ragel"
+#line 318 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17635,12 +17633,12 @@ case 730:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -17653,12 +17651,12 @@ case 730:
 	break;
 	case 412: 
 	case 413: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 253 "src/vcf/vcf_v42.ragel"
+#line 252 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
@@ -17675,12 +17673,12 @@ case 730:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -17697,12 +17695,12 @@ case 730:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17719,12 +17717,12 @@ case 730:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17741,12 +17739,12 @@ case 730:
 	case 318: 
 	case 319: 
 	case 320: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 297 "src/vcf/vcf_v42.ragel"
+#line 296 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
@@ -17759,12 +17757,12 @@ case 730:
 	break;
 	case 332: 
 	case 333: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17789,12 +17787,12 @@ case 730:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -17819,12 +17817,12 @@ case 730:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -17849,12 +17847,12 @@ case 730:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -17879,12 +17877,12 @@ case 730:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -17914,12 +17912,12 @@ case 730:
 	case 372: 
 	case 373: 
 	case 374: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -17949,12 +17947,12 @@ case 730:
 	case 399: 
 	case 400: 
 	case 401: 
-#line 335 "src/vcf/vcf_v42.ragel"
+#line 334 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 247 "src/vcf/vcf_v42.ragel"
+#line 246 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
@@ -17986,12 +17984,12 @@ case 730:
 	case 462: 
 	case 463: 
 	case 464: 
-#line 335 "src/vcf/vcf_v42.ragel"
+#line 334 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st651;}
     }
-#line 303 "src/vcf/vcf_v42.ragel"
+#line 302 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -18017,12 +18015,12 @@ case 730:
 	case 577: 
 	case 588: 
 	case 590: 
-#line 405 "src/vcf/vcf_v42.ragel"
+#line 404 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18034,12 +18032,12 @@ case 730:
     }
 	break;
 	case 538: 
-#line 410 "src/vcf/vcf_v42.ragel"
+#line 409 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18051,7 +18049,7 @@ case 730:
     }
 	break;
 	case 541: 
-#line 415 "src/vcf/vcf_v42.ragel"
+#line 414 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18059,7 +18057,7 @@ case 730:
                 "AA"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18071,7 +18069,7 @@ case 730:
     }
 	break;
 	case 543: 
-#line 423 "src/vcf/vcf_v42.ragel"
+#line 422 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18079,7 +18077,7 @@ case 730:
                 "AC"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18099,7 +18097,7 @@ case 730:
 	case 551: 
 	case 552: 
 	case 553: 
-#line 431 "src/vcf/vcf_v42.ragel"
+#line 430 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18107,7 +18105,7 @@ case 730:
                 "AF"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18119,7 +18117,7 @@ case 730:
     }
 	break;
 	case 555: 
-#line 439 "src/vcf/vcf_v42.ragel"
+#line 438 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18127,7 +18125,7 @@ case 730:
                 "AN"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18147,7 +18145,7 @@ case 730:
 	case 563: 
 	case 564: 
 	case 565: 
-#line 447 "src/vcf/vcf_v42.ragel"
+#line 446 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18155,7 +18153,7 @@ case 730:
                 "BQ"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18168,7 +18166,7 @@ case 730:
 	break;
 	case 567: 
 	case 568: 
-#line 455 "src/vcf/vcf_v42.ragel"
+#line 454 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18176,7 +18174,7 @@ case 730:
                 "CIGAR"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18188,7 +18186,7 @@ case 730:
     }
 	break;
 	case 569: 
-#line 463 "src/vcf/vcf_v42.ragel"
+#line 462 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18196,7 +18194,7 @@ case 730:
                 "DB"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18208,7 +18206,7 @@ case 730:
     }
 	break;
 	case 571: 
-#line 471 "src/vcf/vcf_v42.ragel"
+#line 470 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18216,7 +18214,7 @@ case 730:
                 "DP"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18228,7 +18226,7 @@ case 730:
     }
 	break;
 	case 573: 
-#line 479 "src/vcf/vcf_v42.ragel"
+#line 478 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18236,7 +18234,7 @@ case 730:
                 "END"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18248,7 +18246,7 @@ case 730:
     }
 	break;
 	case 574: 
-#line 487 "src/vcf/vcf_v42.ragel"
+#line 486 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18256,7 +18254,7 @@ case 730:
                 "H2"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18268,7 +18266,7 @@ case 730:
     }
 	break;
 	case 575: 
-#line 495 "src/vcf/vcf_v42.ragel"
+#line 494 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18276,7 +18274,7 @@ case 730:
                 "H3"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18296,7 +18294,7 @@ case 730:
 	case 585: 
 	case 586: 
 	case 587: 
-#line 503 "src/vcf/vcf_v42.ragel"
+#line 502 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18304,7 +18302,7 @@ case 730:
                 "MQ"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18316,7 +18314,7 @@ case 730:
     }
 	break;
 	case 578: 
-#line 511 "src/vcf/vcf_v42.ragel"
+#line 510 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18324,7 +18322,7 @@ case 730:
                 "MQ0"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18336,7 +18334,7 @@ case 730:
     }
 	break;
 	case 589: 
-#line 519 "src/vcf/vcf_v42.ragel"
+#line 518 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18344,7 +18342,7 @@ case 730:
                 "NS"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18364,7 +18362,7 @@ case 730:
 	case 597: 
 	case 598: 
 	case 599: 
-#line 527 "src/vcf/vcf_v42.ragel"
+#line 526 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18372,7 +18370,7 @@ case 730:
                 "SB"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18384,7 +18382,7 @@ case 730:
     }
 	break;
 	case 600: 
-#line 535 "src/vcf/vcf_v42.ragel"
+#line 534 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18392,7 +18390,7 @@ case 730:
                 "SOMATIC"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18404,7 +18402,7 @@ case 730:
     }
 	break;
 	case 601: 
-#line 543 "src/vcf/vcf_v42.ragel"
+#line 542 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18412,7 +18410,7 @@ case 730:
                 "VALIDATED"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18424,7 +18422,7 @@ case 730:
     }
 	break;
 	case 539: 
-#line 551 "src/vcf/vcf_v42.ragel"
+#line 550 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -18432,7 +18430,7 @@ case 730:
                 "1000G"});
         p--; {goto st652;}
     }
-#line 400 "src/vcf/vcf_v42.ragel"
+#line 399 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st652;}
@@ -18444,14 +18442,14 @@ case 730:
     }
 	break;
 	case 531: 
-#line 573 "src/vcf/vcf_v42.ragel"
+#line 572 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st652;}
     }
-#line 566 "src/vcf/vcf_v42.ragel"
+#line 565 "src/vcf/vcf_v42.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -18475,7 +18473,7 @@ case 730:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st651;}
     }
-#line 341 "src/vcf/vcf_v42.ragel"
+#line 340 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -18504,17 +18502,17 @@ case 730:
     }
 	break;
 	case 344: 
-#line 314 "src/vcf/vcf_v42.ragel"
+#line 313 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 319 "src/vcf/vcf_v42.ragel"
+#line 318 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -18526,17 +18524,17 @@ case 730:
     }
 	break;
 	case 354: 
-#line 319 "src/vcf/vcf_v42.ragel"
+#line 318 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Mixture is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -18548,17 +18546,17 @@ case 730:
     }
 	break;
 	case 334: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 314 "src/vcf/vcf_v42.ragel"
+#line 313 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "SAMPLE metadata Genomes is not a valid string (maybe it contains quotes?)"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
@@ -18572,17 +18570,17 @@ case 730:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -18596,17 +18594,17 @@ case 730:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -18620,17 +18618,17 @@ case 730:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -18644,17 +18642,17 @@ case 730:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -18668,17 +18666,17 @@ case 730:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
@@ -18692,17 +18690,17 @@ case 730:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
@@ -18716,17 +18714,17 @@ case 730:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
@@ -18740,17 +18738,17 @@ case 730:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 330 "src/vcf/vcf_v42.ragel"
+#line 329 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st651;}
     }
-#line 325 "src/vcf/vcf_v42.ragel"
+#line 324 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
@@ -18762,47 +18760,47 @@ case 730:
     }
 	break;
 	case 24: 
-#line 235 "src/vcf/vcf_v42.ragel"
+#line 234 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st651;}
     }
-#line 259 "src/vcf/vcf_v42.ragel"
+#line 258 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st651;}
     }
-#line 265 "src/vcf/vcf_v42.ragel"
+#line 264 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st651;}
     }
-#line 281 "src/vcf/vcf_v42.ragel"
+#line 280 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st651;}
     }
-#line 247 "src/vcf/vcf_v42.ragel"
+#line 246 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st651;}
     }
-#line 253 "src/vcf/vcf_v42.ragel"
+#line 252 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st651;}
     }
-#line 309 "src/vcf/vcf_v42.ragel"
+#line 308 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st651;}
     }
-#line 297 "src/vcf/vcf_v42.ragel"
+#line 296 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st651;}
     }
-#line 303 "src/vcf/vcf_v42.ragel"
+#line 302 "src/vcf/vcf_v42.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st651;}
@@ -18813,14 +18811,14 @@ case 730:
         p--; {goto st651;}
     }
 	break;
-#line 18817 "inc/vcf/validator_detail_v42.hpp"
+#line 18815 "inc/vcf/validator_detail_v42.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 856 "src/vcf/vcf_v42.ragel"
+#line 855 "src/vcf/vcf_v42.ragel"
 
     }
    

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 918 "src/vcf/vcf_v43.ragel"
+#line 919 "src/vcf/vcf_v43.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v43_en_meta_section_skip = 722;
 static const int vcf_v43_en_body_section_skip = 723;
 
 
-#line 924 "src/vcf/vcf_v43.ragel"
+#line 925 "src/vcf/vcf_v43.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v43_start;
 	}
 
-#line 938 "src/vcf/vcf_v43.ragel"
+#line 939 "src/vcf/vcf_v43.ragel"
 
     }
 
@@ -87,7 +87,8 @@ tr14:
 #line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         p--; {goto st722;}
     }
 #line 60 "src/vcf/vcf_v43.ragel"
@@ -107,7 +108,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 377 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -141,7 +142,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 377 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -170,52 +171,52 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
     }
-#line 257 "src/vcf/vcf_v43.ragel"
+#line 258 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
     }
-#line 263 "src/vcf/vcf_v43.ragel"
+#line 264 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
     }
-#line 355 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
     }
-#line 328 "src/vcf/vcf_v43.ragel"
+#line 329 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -234,7 +235,7 @@ tr40:
     }
 	goto st0;
 tr126:
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -246,13 +247,13 @@ tr126:
     }
 	goto st0;
 tr134:
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -264,12 +265,12 @@ tr134:
     }
 	goto st0;
 tr153:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -281,12 +282,12 @@ tr153:
     }
 	goto st0;
 tr162:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -298,17 +299,17 @@ tr162:
     }
 	goto st0;
 tr176:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -320,17 +321,17 @@ tr176:
     }
 	goto st0;
 tr188:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -342,12 +343,12 @@ tr188:
     }
 	goto st0;
 tr194:
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -359,7 +360,7 @@ tr194:
     }
 	goto st0;
 tr197:
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -371,12 +372,12 @@ tr197:
     }
 	goto st0;
 tr207:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -388,12 +389,12 @@ tr207:
     }
 	goto st0;
 tr226:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -405,17 +406,17 @@ tr226:
     }
 	goto st0;
 tr248:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -427,17 +428,17 @@ tr248:
     }
 	goto st0;
 tr260:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -449,7 +450,7 @@ tr260:
     }
 	goto st0;
 tr266:
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -461,12 +462,12 @@ tr266:
     }
 	goto st0;
 tr276:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -478,12 +479,12 @@ tr276:
     }
 	goto st0;
 tr289:
-#line 280 "src/vcf/vcf_v43.ragel"
+#line 281 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -495,12 +496,12 @@ tr289:
     }
 	goto st0;
 tr298:
-#line 301 "src/vcf/vcf_v43.ragel"
+#line 302 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -512,12 +513,12 @@ tr298:
     }
 	goto st0;
 tr315:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -529,17 +530,17 @@ tr315:
     }
 	goto st0;
 tr337:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -551,17 +552,17 @@ tr337:
     }
 	goto st0;
 tr349:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -573,7 +574,7 @@ tr349:
     }
 	goto st0;
 tr356:
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -585,12 +586,12 @@ tr356:
     }
 	goto st0;
 tr365:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -602,12 +603,12 @@ tr365:
     }
 	goto st0;
 tr378:
-#line 296 "src/vcf/vcf_v43.ragel"
+#line 297 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -619,12 +620,12 @@ tr378:
     }
 	goto st0;
 tr387:
-#line 301 "src/vcf/vcf_v43.ragel"
+#line 302 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -636,12 +637,12 @@ tr387:
     }
 	goto st0;
 tr404:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -653,17 +654,17 @@ tr404:
     }
 	goto st0;
 tr426:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -675,17 +676,17 @@ tr426:
     }
 	goto st0;
 tr438:
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -697,7 +698,7 @@ tr438:
     }
 	goto st0;
 tr445:
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -709,12 +710,12 @@ tr445:
     }
 	goto st0;
 tr454:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -726,12 +727,12 @@ tr454:
     }
 	goto st0;
 tr467:
-#line 339 "src/vcf/vcf_v43.ragel"
+#line 340 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -743,12 +744,12 @@ tr467:
     }
 	goto st0;
 tr475:
-#line 344 "src/vcf/vcf_v43.ragel"
+#line 345 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -760,12 +761,12 @@ tr475:
     }
 	goto st0;
 tr492:
-#line 349 "src/vcf/vcf_v43.ragel"
+#line 350 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -777,7 +778,7 @@ tr492:
     }
 	goto st0;
 tr498:
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -789,12 +790,12 @@ tr498:
     }
 	goto st0;
 tr511:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -806,12 +807,12 @@ tr511:
     }
 	goto st0;
 tr517:
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 323 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -823,12 +824,12 @@ tr517:
     }
 	goto st0;
 tr527:
-#line 317 "src/vcf/vcf_v43.ragel"
+#line 318 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -840,12 +841,12 @@ tr527:
     }
 	goto st0;
 tr564:
-#line 312 "src/vcf/vcf_v43.ragel"
+#line 313 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -857,7 +858,7 @@ tr564:
     }
 	goto st0;
 tr569:
-#line 355 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -869,12 +870,12 @@ tr569:
     }
 	goto st0;
 tr580:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 355 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -886,7 +887,7 @@ tr580:
     }
 	goto st0;
 tr620:
-#line 257 "src/vcf/vcf_v43.ragel"
+#line 258 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -898,12 +899,12 @@ tr620:
     }
 	goto st0;
 tr629:
-#line 371 "src/vcf/vcf_v43.ragel"
+#line 372 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 257 "src/vcf/vcf_v43.ragel"
+#line 258 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -915,7 +916,7 @@ tr629:
     }
 	goto st0;
 tr650:
-#line 263 "src/vcf/vcf_v43.ragel"
+#line 264 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -927,12 +928,12 @@ tr650:
     }
 	goto st0;
 tr661:
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 263 "src/vcf/vcf_v43.ragel"
+#line 264 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -944,7 +945,7 @@ tr661:
     }
 	goto st0;
 tr699:
-#line 328 "src/vcf/vcf_v43.ragel"
+#line 329 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -956,12 +957,12 @@ tr699:
     }
 	goto st0;
 tr711:
-#line 371 "src/vcf/vcf_v43.ragel"
+#line 372 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 328 "src/vcf/vcf_v43.ragel"
+#line 329 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -973,7 +974,7 @@ tr711:
     }
 	goto st0;
 tr734:
-#line 377 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -1017,7 +1018,7 @@ tr774:
     }
 	goto st0;
 tr789:
-#line 394 "src/vcf/vcf_v43.ragel"
+#line 395 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st723;}
@@ -1029,7 +1030,7 @@ tr789:
     }
 	goto st0;
 tr792:
-#line 400 "src/vcf/vcf_v43.ragel"
+#line 401 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st723;}
@@ -1041,7 +1042,7 @@ tr792:
     }
 	goto st0;
 tr796:
-#line 406 "src/vcf/vcf_v43.ragel"
+#line 407 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st723;}
@@ -1053,7 +1054,7 @@ tr796:
     }
 	goto st0;
 tr801:
-#line 412 "src/vcf/vcf_v43.ragel"
+#line 413 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st723;}
@@ -1065,7 +1066,7 @@ tr801:
     }
 	goto st0;
 tr805:
-#line 418 "src/vcf/vcf_v43.ragel"
+#line 419 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st723;}
@@ -1077,7 +1078,7 @@ tr805:
     }
 	goto st0;
 tr814:
-#line 424 "src/vcf/vcf_v43.ragel"
+#line 425 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st723;}
@@ -1089,7 +1090,7 @@ tr814:
     }
 	goto st0;
 tr825:
-#line 430 "src/vcf/vcf_v43.ragel"
+#line 431 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st723;}
@@ -1101,12 +1102,12 @@ tr825:
     }
 	goto st0;
 tr833:
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1118,7 +1119,7 @@ tr833:
     }
 	goto st0;
 tr847:
-#line 620 "src/vcf/vcf_v43.ragel"
+#line 621 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st723;}
@@ -1130,14 +1131,14 @@ tr847:
     }
 	goto st0;
 tr852:
-#line 633 "src/vcf/vcf_v43.ragel"
+#line 634 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st723;}
     }
-#line 626 "src/vcf/vcf_v43.ragel"
+#line 627 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1158,7 +1159,7 @@ tr860:
     }
 	goto st0;
 tr862:
-#line 626 "src/vcf/vcf_v43.ragel"
+#line 627 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1172,12 +1173,12 @@ tr862:
     }
 	goto st0;
 tr864:
-#line 446 "src/vcf/vcf_v43.ragel"
+#line 447 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1189,7 +1190,7 @@ tr864:
     }
 	goto st0;
 tr866:
-#line 611 "src/vcf/vcf_v43.ragel"
+#line 612 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1197,7 +1198,7 @@ tr866:
                 "1000G"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1209,7 +1210,7 @@ tr866:
     }
 	goto st0;
 tr870:
-#line 451 "src/vcf/vcf_v43.ragel"
+#line 452 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1217,7 +1218,7 @@ tr870:
                 "AA"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1229,7 +1230,7 @@ tr870:
     }
 	goto st0;
 tr873:
-#line 459 "src/vcf/vcf_v43.ragel"
+#line 460 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1237,7 +1238,7 @@ tr873:
                 "AC"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1249,7 +1250,7 @@ tr873:
     }
 	goto st0;
 tr878:
-#line 467 "src/vcf/vcf_v43.ragel"
+#line 468 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1257,7 +1258,7 @@ tr878:
                 "AD"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1269,7 +1270,7 @@ tr878:
     }
 	goto st0;
 tr881:
-#line 475 "src/vcf/vcf_v43.ragel"
+#line 476 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1277,7 +1278,7 @@ tr881:
                 "ADF"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1289,7 +1290,7 @@ tr881:
     }
 	goto st0;
 tr884:
-#line 483 "src/vcf/vcf_v43.ragel"
+#line 484 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1297,7 +1298,7 @@ tr884:
                 "ADR"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1309,7 +1310,7 @@ tr884:
     }
 	goto st0;
 tr887:
-#line 491 "src/vcf/vcf_v43.ragel"
+#line 492 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1317,7 +1318,7 @@ tr887:
                 "AF"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1329,7 +1330,7 @@ tr887:
     }
 	goto st0;
 tr899:
-#line 499 "src/vcf/vcf_v43.ragel"
+#line 500 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1337,7 +1338,7 @@ tr899:
                 "AN"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1349,7 +1350,7 @@ tr899:
     }
 	goto st0;
 tr902:
-#line 507 "src/vcf/vcf_v43.ragel"
+#line 508 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1357,7 +1358,7 @@ tr902:
                 "BQ"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1369,7 +1370,7 @@ tr902:
     }
 	goto st0;
 tr914:
-#line 515 "src/vcf/vcf_v43.ragel"
+#line 516 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1377,7 +1378,7 @@ tr914:
                 "CIGAR"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1389,7 +1390,7 @@ tr914:
     }
 	goto st0;
 tr917:
-#line 523 "src/vcf/vcf_v43.ragel"
+#line 524 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1397,7 +1398,7 @@ tr917:
                 "DB"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1409,7 +1410,7 @@ tr917:
     }
 	goto st0;
 tr920:
-#line 531 "src/vcf/vcf_v43.ragel"
+#line 532 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1417,7 +1418,7 @@ tr920:
                 "DP"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1429,7 +1430,7 @@ tr920:
     }
 	goto st0;
 tr923:
-#line 539 "src/vcf/vcf_v43.ragel"
+#line 540 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1437,7 +1438,7 @@ tr923:
                 "END"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1449,7 +1450,7 @@ tr923:
     }
 	goto st0;
 tr925:
-#line 547 "src/vcf/vcf_v43.ragel"
+#line 548 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1457,7 +1458,7 @@ tr925:
                 "H2"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1469,7 +1470,7 @@ tr925:
     }
 	goto st0;
 tr927:
-#line 555 "src/vcf/vcf_v43.ragel"
+#line 556 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1477,7 +1478,7 @@ tr927:
                 "H3"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1489,7 +1490,7 @@ tr927:
     }
 	goto st0;
 tr932:
-#line 571 "src/vcf/vcf_v43.ragel"
+#line 572 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1497,7 +1498,7 @@ tr932:
                 "MQ0"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1509,7 +1510,7 @@ tr932:
     }
 	goto st0;
 tr934:
-#line 563 "src/vcf/vcf_v43.ragel"
+#line 564 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1517,7 +1518,7 @@ tr934:
                 "MQ"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1529,7 +1530,7 @@ tr934:
     }
 	goto st0;
 tr946:
-#line 579 "src/vcf/vcf_v43.ragel"
+#line 580 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1537,7 +1538,7 @@ tr946:
                 "NS"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1549,7 +1550,7 @@ tr946:
     }
 	goto st0;
 tr949:
-#line 587 "src/vcf/vcf_v43.ragel"
+#line 588 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1557,7 +1558,7 @@ tr949:
                 "SB"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1569,7 +1570,7 @@ tr949:
     }
 	goto st0;
 tr960:
-#line 595 "src/vcf/vcf_v43.ragel"
+#line 596 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1577,7 +1578,7 @@ tr960:
                 "SOMATIC"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1589,7 +1590,7 @@ tr960:
     }
 	goto st0;
 tr962:
-#line 603 "src/vcf/vcf_v43.ragel"
+#line 604 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1597,7 +1598,7 @@ tr962:
                 "VALIDATED"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1622,7 +1623,7 @@ tr1011:
         
         p--; {goto st723;}
     }
-#line 394 "src/vcf/vcf_v43.ragel"
+#line 395 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st723;}
@@ -1634,7 +1635,7 @@ tr1011:
     }
 	goto st0;
 tr1018:
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1646,7 +1647,7 @@ tr1018:
     }
 	goto st0;
 tr1034:
-#line 611 "src/vcf/vcf_v43.ragel"
+#line 612 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1654,12 +1655,12 @@ tr1034:
                 "1000G"});
         p--; {goto st723;}
     }
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1671,7 +1672,7 @@ tr1034:
     }
 	goto st0;
 tr1052:
-#line 523 "src/vcf/vcf_v43.ragel"
+#line 524 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1679,12 +1680,12 @@ tr1052:
                 "DB"});
         p--; {goto st723;}
     }
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1696,7 +1697,7 @@ tr1052:
     }
 	goto st0;
 tr1058:
-#line 547 "src/vcf/vcf_v43.ragel"
+#line 548 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1704,12 +1705,12 @@ tr1058:
                 "H2"});
         p--; {goto st723;}
     }
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1721,7 +1722,7 @@ tr1058:
     }
 	goto st0;
 tr1060:
-#line 555 "src/vcf/vcf_v43.ragel"
+#line 556 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1729,12 +1730,12 @@ tr1060:
                 "H3"});
         p--; {goto st723;}
     }
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1746,7 +1747,7 @@ tr1060:
     }
 	goto st0;
 tr1075:
-#line 595 "src/vcf/vcf_v43.ragel"
+#line 596 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1754,12 +1755,12 @@ tr1075:
                 "SOMATIC"});
         p--; {goto st723;}
     }
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1771,7 +1772,7 @@ tr1075:
     }
 	goto st0;
 tr1085:
-#line 603 "src/vcf/vcf_v43.ragel"
+#line 604 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1779,12 +1780,12 @@ tr1085:
                 "VALIDATED"});
         p--; {goto st723;}
     }
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1795,7 +1796,7 @@ tr1085:
         p--; {goto st723;}
     }
 	goto st0;
-#line 1799 "inc/vcf/validator_detail_v43.hpp"
+#line 1800 "inc/vcf/validator_detail_v43.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1904,7 +1905,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1908 "inc/vcf/validator_detail_v43.hpp"
+#line 1909 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1918,7 +1919,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1922 "inc/vcf/validator_detail_v43.hpp"
+#line 1923 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1932,7 +1933,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1936 "inc/vcf/validator_detail_v43.hpp"
+#line 1937 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1946,7 +1947,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1950 "inc/vcf/validator_detail_v43.hpp"
+#line 1951 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1960,7 +1961,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1964 "inc/vcf/validator_detail_v43.hpp"
+#line 1965 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1974,7 +1975,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1978 "inc/vcf/validator_detail_v43.hpp"
+#line 1979 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 51 )
 		goto tr21;
 	goto tr14;
@@ -1988,7 +1989,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1992 "inc/vcf/validator_detail_v43.hpp"
+#line 1993 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -2019,7 +2020,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 2023 "inc/vcf/validator_detail_v43.hpp"
+#line 2024 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -2073,7 +2074,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 2077 "inc/vcf/validator_detail_v43.hpp"
+#line 2078 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr42;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -2089,7 +2090,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2093 "inc/vcf/validator_detail_v43.hpp"
+#line 2094 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2117,7 +2118,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2121 "inc/vcf/validator_detail_v43.hpp"
+#line 2122 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr47;
@@ -2173,7 +2174,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2177 "inc/vcf/validator_detail_v43.hpp"
+#line 2178 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -2225,7 +2226,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2229 "inc/vcf/validator_detail_v43.hpp"
+#line 2230 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr40;
@@ -2260,7 +2261,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2264 "inc/vcf/validator_detail_v43.hpp"
+#line 2265 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr54;
 		case 92: goto tr55;
@@ -2288,7 +2289,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2292 "inc/vcf/validator_detail_v43.hpp"
+#line 2293 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2314,7 +2315,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2318 "inc/vcf/validator_detail_v43.hpp"
+#line 2319 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr58;
 		case 92: goto tr55;
@@ -2336,7 +2337,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2340 "inc/vcf/validator_detail_v43.hpp"
+#line 2341 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2397,7 +2398,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2401 "inc/vcf/validator_detail_v43.hpp"
+#line 2402 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 92: goto tr67;
@@ -2425,7 +2426,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2429 "inc/vcf/validator_detail_v43.hpp"
+#line 2430 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr40;
@@ -2449,7 +2450,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2453 "inc/vcf/validator_detail_v43.hpp"
+#line 2454 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr69;
 		case 92: goto tr67;
@@ -2471,7 +2472,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2475 "inc/vcf/validator_detail_v43.hpp"
+#line 2476 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 62: goto tr70;
@@ -2490,7 +2491,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2494 "inc/vcf/validator_detail_v43.hpp"
+#line 2495 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2510,7 +2511,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2514 "inc/vcf/validator_detail_v43.hpp"
+#line 2515 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2545,7 +2546,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2549 "inc/vcf/validator_detail_v43.hpp"
+#line 2550 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr73;
 		case 95: goto tr72;
@@ -2572,7 +2573,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2576 "inc/vcf/validator_detail_v43.hpp"
+#line 2577 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2604,7 +2605,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2608 "inc/vcf/validator_detail_v43.hpp"
+#line 2609 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr77;
 		case 62: goto tr54;
@@ -2625,7 +2626,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2629 "inc/vcf/validator_detail_v43.hpp"
+#line 2630 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr78;
 	if ( (*p) < 48 ) {
@@ -2650,7 +2651,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2654 "inc/vcf/validator_detail_v43.hpp"
+#line 2655 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2685,7 +2686,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2689 "inc/vcf/validator_detail_v43.hpp"
+#line 2690 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr82;
 		case 95: goto tr81;
@@ -2712,7 +2713,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2716 "inc/vcf/validator_detail_v43.hpp"
+#line 2717 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2755,7 +2756,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2759 "inc/vcf/validator_detail_v43.hpp"
+#line 2760 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr89;
@@ -2783,7 +2784,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2787 "inc/vcf/validator_detail_v43.hpp"
+#line 2788 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2809,7 +2810,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2813 "inc/vcf/validator_detail_v43.hpp"
+#line 2814 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 92: goto tr89;
@@ -2831,7 +2832,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2835 "inc/vcf/validator_detail_v43.hpp"
+#line 2836 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr92;
@@ -2871,7 +2872,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2875 "inc/vcf/validator_detail_v43.hpp"
+#line 2876 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2922,7 +2923,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2926 "inc/vcf/validator_detail_v43.hpp"
+#line 2927 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2973,7 +2974,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2977 "inc/vcf/validator_detail_v43.hpp"
+#line 2978 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -3016,7 +3017,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 3020 "inc/vcf/validator_detail_v43.hpp"
+#line 3021 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr87;
@@ -3046,7 +3047,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 3050 "inc/vcf/validator_detail_v43.hpp"
+#line 3051 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr103;
@@ -3086,7 +3087,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 3090 "inc/vcf/validator_detail_v43.hpp"
+#line 3091 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3116,7 +3117,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3120 "inc/vcf/validator_detail_v43.hpp"
+#line 3121 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 44: goto tr103;
@@ -3136,7 +3137,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3140 "inc/vcf/validator_detail_v43.hpp"
+#line 3141 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr85;
 		case 44: goto tr106;
@@ -3177,7 +3178,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3181 "inc/vcf/validator_detail_v43.hpp"
+#line 3182 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr111;
@@ -3205,7 +3206,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3209 "inc/vcf/validator_detail_v43.hpp"
+#line 3210 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 92: goto tr111;
@@ -3227,7 +3228,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3231 "inc/vcf/validator_detail_v43.hpp"
+#line 3232 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr113;
@@ -3257,7 +3258,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3261 "inc/vcf/validator_detail_v43.hpp"
+#line 3262 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3308,7 +3309,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3312 "inc/vcf/validator_detail_v43.hpp"
+#line 3313 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3359,7 +3360,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3363 "inc/vcf/validator_detail_v43.hpp"
+#line 3364 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3402,7 +3403,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3406 "inc/vcf/validator_detail_v43.hpp"
+#line 3407 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr110;
@@ -3432,7 +3433,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3436 "inc/vcf/validator_detail_v43.hpp"
+#line 3437 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr123;
@@ -3462,7 +3463,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3466 "inc/vcf/validator_detail_v43.hpp"
+#line 3467 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3492,7 +3493,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3496 "inc/vcf/validator_detail_v43.hpp"
+#line 3497 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 44: goto tr123;
@@ -3516,7 +3517,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3520 "inc/vcf/validator_detail_v43.hpp"
+#line 3521 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr127;
@@ -3534,7 +3535,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3538 "inc/vcf/validator_detail_v43.hpp"
+#line 3539 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st76;
@@ -3561,7 +3562,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3565 "inc/vcf/validator_detail_v43.hpp"
+#line 3566 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr126;
@@ -3633,7 +3634,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3637 "inc/vcf/validator_detail_v43.hpp"
+#line 3638 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3687,7 +3688,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3691 "inc/vcf/validator_detail_v43.hpp"
+#line 3692 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr139;
 		case 61: goto tr138;
@@ -3708,7 +3709,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3712 "inc/vcf/validator_detail_v43.hpp"
+#line 3713 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr126;
@@ -3806,7 +3807,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3810 "inc/vcf/validator_detail_v43.hpp"
+#line 3811 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 92: goto tr156;
@@ -3834,7 +3835,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3838 "inc/vcf/validator_detail_v43.hpp"
+#line 3839 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr159;
@@ -3862,7 +3863,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3866 "inc/vcf/validator_detail_v43.hpp"
+#line 3867 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3896,7 +3897,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3900 "inc/vcf/validator_detail_v43.hpp"
+#line 3901 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3931,7 +3932,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3935 "inc/vcf/validator_detail_v43.hpp"
+#line 3936 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr167;
 		case 95: goto tr166;
@@ -3958,7 +3959,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3962 "inc/vcf/validator_detail_v43.hpp"
+#line 3963 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr126;
@@ -3993,7 +3994,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3997 "inc/vcf/validator_detail_v43.hpp"
+#line 3998 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr172;
@@ -4021,7 +4022,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 4025 "inc/vcf/validator_detail_v43.hpp"
+#line 4026 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr173;
 		case 92: goto tr172;
@@ -4043,7 +4044,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 4047 "inc/vcf/validator_detail_v43.hpp"
+#line 4048 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr174;
@@ -4073,7 +4074,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 4077 "inc/vcf/validator_detail_v43.hpp"
+#line 4078 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4124,7 +4125,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4128 "inc/vcf/validator_detail_v43.hpp"
+#line 4129 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4175,7 +4176,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4179 "inc/vcf/validator_detail_v43.hpp"
+#line 4180 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4218,7 +4219,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4222 "inc/vcf/validator_detail_v43.hpp"
+#line 4223 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr172;
@@ -4236,7 +4237,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4240 "inc/vcf/validator_detail_v43.hpp"
+#line 4241 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 44: goto tr183;
@@ -4266,7 +4267,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4270 "inc/vcf/validator_detail_v43.hpp"
+#line 4271 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4305,7 +4306,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4309 "inc/vcf/validator_detail_v43.hpp"
+#line 4310 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr185;
 		case 92: goto tr159;
@@ -4327,7 +4328,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4331 "inc/vcf/validator_detail_v43.hpp"
+#line 4332 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr186;
@@ -4347,7 +4348,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4351 "inc/vcf/validator_detail_v43.hpp"
+#line 4352 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4398,7 +4399,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4402 "inc/vcf/validator_detail_v43.hpp"
+#line 4403 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4449,7 +4450,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4453 "inc/vcf/validator_detail_v43.hpp"
+#line 4454 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4492,7 +4493,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4496 "inc/vcf/validator_detail_v43.hpp"
+#line 4497 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr159;
@@ -4510,7 +4511,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4514 "inc/vcf/validator_detail_v43.hpp"
+#line 4515 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4534,7 +4535,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4538 "inc/vcf/validator_detail_v43.hpp"
+#line 4539 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr195;
@@ -4553,7 +4554,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4557 "inc/vcf/validator_detail_v43.hpp"
+#line 4558 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr198;
@@ -4571,7 +4572,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4575 "inc/vcf/validator_detail_v43.hpp"
+#line 4576 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr199;
@@ -4589,7 +4590,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4593 "inc/vcf/validator_detail_v43.hpp"
+#line 4594 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr200;
@@ -4607,7 +4608,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4611 "inc/vcf/validator_detail_v43.hpp"
+#line 4612 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto st127;
@@ -4634,7 +4635,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4638 "inc/vcf/validator_detail_v43.hpp"
+#line 4639 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr197;
@@ -4691,7 +4692,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4695 "inc/vcf/validator_detail_v43.hpp"
+#line 4696 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4730,7 +4731,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4734 "inc/vcf/validator_detail_v43.hpp"
+#line 4735 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr212;
 		case 95: goto tr211;
@@ -4757,7 +4758,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4761 "inc/vcf/validator_detail_v43.hpp"
+#line 4762 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr197;
@@ -4855,7 +4856,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4859 "inc/vcf/validator_detail_v43.hpp"
+#line 4860 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 92: goto tr229;
@@ -4883,7 +4884,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4887 "inc/vcf/validator_detail_v43.hpp"
+#line 4888 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr232;
@@ -4911,7 +4912,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4915 "inc/vcf/validator_detail_v43.hpp"
+#line 4916 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4945,7 +4946,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4949 "inc/vcf/validator_detail_v43.hpp"
+#line 4950 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4980,7 +4981,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4984 "inc/vcf/validator_detail_v43.hpp"
+#line 4985 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr239;
 		case 95: goto tr238;
@@ -5007,7 +5008,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 5011 "inc/vcf/validator_detail_v43.hpp"
+#line 5012 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr197;
@@ -5042,7 +5043,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 5046 "inc/vcf/validator_detail_v43.hpp"
+#line 5047 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr244;
@@ -5070,7 +5071,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 5074 "inc/vcf/validator_detail_v43.hpp"
+#line 5075 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr245;
 		case 92: goto tr244;
@@ -5092,7 +5093,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5096 "inc/vcf/validator_detail_v43.hpp"
+#line 5097 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr246;
@@ -5122,7 +5123,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5126 "inc/vcf/validator_detail_v43.hpp"
+#line 5127 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5173,7 +5174,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5177 "inc/vcf/validator_detail_v43.hpp"
+#line 5178 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5224,7 +5225,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5228 "inc/vcf/validator_detail_v43.hpp"
+#line 5229 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5267,7 +5268,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5271 "inc/vcf/validator_detail_v43.hpp"
+#line 5272 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr244;
@@ -5285,7 +5286,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5289 "inc/vcf/validator_detail_v43.hpp"
+#line 5290 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 44: goto tr255;
@@ -5315,7 +5316,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5319 "inc/vcf/validator_detail_v43.hpp"
+#line 5320 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5354,7 +5355,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5358 "inc/vcf/validator_detail_v43.hpp"
+#line 5359 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr257;
 		case 92: goto tr232;
@@ -5376,7 +5377,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5380 "inc/vcf/validator_detail_v43.hpp"
+#line 5381 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr258;
@@ -5396,7 +5397,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5400 "inc/vcf/validator_detail_v43.hpp"
+#line 5401 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5447,7 +5448,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5451 "inc/vcf/validator_detail_v43.hpp"
+#line 5452 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5498,7 +5499,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5502 "inc/vcf/validator_detail_v43.hpp"
+#line 5503 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5541,7 +5542,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5545 "inc/vcf/validator_detail_v43.hpp"
+#line 5546 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr232;
@@ -5559,7 +5560,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5563 "inc/vcf/validator_detail_v43.hpp"
+#line 5564 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5579,7 +5580,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5583 "inc/vcf/validator_detail_v43.hpp"
+#line 5584 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr267;
@@ -5597,7 +5598,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5601 "inc/vcf/validator_detail_v43.hpp"
+#line 5602 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr268;
@@ -5615,7 +5616,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5619 "inc/vcf/validator_detail_v43.hpp"
+#line 5620 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr269;
@@ -5633,7 +5634,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5637 "inc/vcf/validator_detail_v43.hpp"
+#line 5638 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st177;
@@ -5660,7 +5661,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5664 "inc/vcf/validator_detail_v43.hpp"
+#line 5665 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr266;
@@ -5717,7 +5718,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5721 "inc/vcf/validator_detail_v43.hpp"
+#line 5722 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5756,7 +5757,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5760 "inc/vcf/validator_detail_v43.hpp"
+#line 5761 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr281;
 		case 95: goto tr280;
@@ -5783,7 +5784,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5787 "inc/vcf/validator_detail_v43.hpp"
+#line 5788 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr266;
@@ -5860,7 +5861,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5864 "inc/vcf/validator_detail_v43.hpp"
+#line 5865 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	goto tr289;
@@ -5874,7 +5875,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5878 "inc/vcf/validator_detail_v43.hpp"
+#line 5879 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr266;
@@ -5940,7 +5941,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5944 "inc/vcf/validator_detail_v43.hpp"
+#line 5945 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr300;
 	if ( (*p) > 90 ) {
@@ -5959,7 +5960,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5963 "inc/vcf/validator_detail_v43.hpp"
+#line 5964 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr266;
@@ -6057,7 +6058,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 6061 "inc/vcf/validator_detail_v43.hpp"
+#line 6062 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -6085,7 +6086,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 6089 "inc/vcf/validator_detail_v43.hpp"
+#line 6090 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr321;
@@ -6113,7 +6114,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6117 "inc/vcf/validator_detail_v43.hpp"
+#line 6118 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6147,7 +6148,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6151 "inc/vcf/validator_detail_v43.hpp"
+#line 6152 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6182,7 +6183,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6186 "inc/vcf/validator_detail_v43.hpp"
+#line 6187 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr328;
 		case 95: goto tr327;
@@ -6209,7 +6210,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6213 "inc/vcf/validator_detail_v43.hpp"
+#line 6214 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr266;
@@ -6244,7 +6245,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6248 "inc/vcf/validator_detail_v43.hpp"
+#line 6249 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr333;
@@ -6272,7 +6273,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6276 "inc/vcf/validator_detail_v43.hpp"
+#line 6277 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr334;
 		case 92: goto tr333;
@@ -6294,7 +6295,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6298 "inc/vcf/validator_detail_v43.hpp"
+#line 6299 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr335;
@@ -6324,7 +6325,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6328 "inc/vcf/validator_detail_v43.hpp"
+#line 6329 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6375,7 +6376,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6379 "inc/vcf/validator_detail_v43.hpp"
+#line 6380 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6426,7 +6427,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6430 "inc/vcf/validator_detail_v43.hpp"
+#line 6431 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6469,7 +6470,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6473 "inc/vcf/validator_detail_v43.hpp"
+#line 6474 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr333;
@@ -6487,7 +6488,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6491 "inc/vcf/validator_detail_v43.hpp"
+#line 6492 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 44: goto tr344;
@@ -6517,7 +6518,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6521 "inc/vcf/validator_detail_v43.hpp"
+#line 6522 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6556,7 +6557,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6560 "inc/vcf/validator_detail_v43.hpp"
+#line 6561 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr346;
 		case 92: goto tr321;
@@ -6578,7 +6579,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6582 "inc/vcf/validator_detail_v43.hpp"
+#line 6583 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr347;
@@ -6598,7 +6599,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6602 "inc/vcf/validator_detail_v43.hpp"
+#line 6603 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6649,7 +6650,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6653 "inc/vcf/validator_detail_v43.hpp"
+#line 6654 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6700,7 +6701,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6704 "inc/vcf/validator_detail_v43.hpp"
+#line 6705 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6743,7 +6744,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6747 "inc/vcf/validator_detail_v43.hpp"
+#line 6748 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr321;
@@ -6761,7 +6762,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6765 "inc/vcf/validator_detail_v43.hpp"
+#line 6766 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6795,7 +6796,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6799 "inc/vcf/validator_detail_v43.hpp"
+#line 6800 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6815,7 +6816,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6819 "inc/vcf/validator_detail_v43.hpp"
+#line 6820 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 78: goto tr357;
@@ -6833,7 +6834,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6837 "inc/vcf/validator_detail_v43.hpp"
+#line 6838 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 70: goto tr358;
@@ -6851,7 +6852,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6855 "inc/vcf/validator_detail_v43.hpp"
+#line 6856 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 79: goto st243;
@@ -6878,7 +6879,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6882 "inc/vcf/validator_detail_v43.hpp"
+#line 6883 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr356;
@@ -6935,7 +6936,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6939 "inc/vcf/validator_detail_v43.hpp"
+#line 6940 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6974,7 +6975,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6978 "inc/vcf/validator_detail_v43.hpp"
+#line 6979 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr370;
 		case 95: goto tr369;
@@ -7001,7 +7002,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 7005 "inc/vcf/validator_detail_v43.hpp"
+#line 7006 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr356;
@@ -7078,7 +7079,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 7082 "inc/vcf/validator_detail_v43.hpp"
+#line 7083 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	goto tr378;
@@ -7092,7 +7093,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7096 "inc/vcf/validator_detail_v43.hpp"
+#line 7097 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr356;
@@ -7158,7 +7159,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7162 "inc/vcf/validator_detail_v43.hpp"
+#line 7163 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr389;
 	if ( (*p) > 90 ) {
@@ -7177,7 +7178,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7181 "inc/vcf/validator_detail_v43.hpp"
+#line 7182 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr356;
@@ -7275,7 +7276,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7279 "inc/vcf/validator_detail_v43.hpp"
+#line 7280 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 92: goto tr407;
@@ -7303,7 +7304,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7307 "inc/vcf/validator_detail_v43.hpp"
+#line 7308 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr410;
@@ -7331,7 +7332,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7335 "inc/vcf/validator_detail_v43.hpp"
+#line 7336 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7365,7 +7366,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7369 "inc/vcf/validator_detail_v43.hpp"
+#line 7370 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7400,7 +7401,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7404 "inc/vcf/validator_detail_v43.hpp"
+#line 7405 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr417;
 		case 95: goto tr416;
@@ -7427,7 +7428,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7431 "inc/vcf/validator_detail_v43.hpp"
+#line 7432 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr356;
@@ -7462,7 +7463,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7466 "inc/vcf/validator_detail_v43.hpp"
+#line 7467 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr422;
@@ -7490,7 +7491,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7494 "inc/vcf/validator_detail_v43.hpp"
+#line 7495 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr423;
 		case 92: goto tr422;
@@ -7512,7 +7513,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7516 "inc/vcf/validator_detail_v43.hpp"
+#line 7517 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr424;
@@ -7542,7 +7543,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7546 "inc/vcf/validator_detail_v43.hpp"
+#line 7547 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7593,7 +7594,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7597 "inc/vcf/validator_detail_v43.hpp"
+#line 7598 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7644,7 +7645,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7648 "inc/vcf/validator_detail_v43.hpp"
+#line 7649 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7687,7 +7688,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7691 "inc/vcf/validator_detail_v43.hpp"
+#line 7692 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr422;
@@ -7705,7 +7706,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7709 "inc/vcf/validator_detail_v43.hpp"
+#line 7710 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 44: goto tr433;
@@ -7735,7 +7736,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7739 "inc/vcf/validator_detail_v43.hpp"
+#line 7740 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -7774,7 +7775,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7778 "inc/vcf/validator_detail_v43.hpp"
+#line 7779 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr435;
 		case 92: goto tr410;
@@ -7796,7 +7797,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7800 "inc/vcf/validator_detail_v43.hpp"
+#line 7801 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr436;
@@ -7816,7 +7817,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7820 "inc/vcf/validator_detail_v43.hpp"
+#line 7821 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7867,7 +7868,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7871 "inc/vcf/validator_detail_v43.hpp"
+#line 7872 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7918,7 +7919,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7922 "inc/vcf/validator_detail_v43.hpp"
+#line 7923 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7961,7 +7962,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7965 "inc/vcf/validator_detail_v43.hpp"
+#line 7966 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr410;
@@ -7979,7 +7980,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7983 "inc/vcf/validator_detail_v43.hpp"
+#line 7984 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -8013,7 +8014,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 8017 "inc/vcf/validator_detail_v43.hpp"
+#line 8018 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8033,7 +8034,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 8037 "inc/vcf/validator_detail_v43.hpp"
+#line 8038 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr446;
@@ -8051,7 +8052,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 8055 "inc/vcf/validator_detail_v43.hpp"
+#line 8056 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr447;
@@ -8069,7 +8070,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 8073 "inc/vcf/validator_detail_v43.hpp"
+#line 8074 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto st309;
@@ -8096,7 +8097,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8100 "inc/vcf/validator_detail_v43.hpp"
+#line 8101 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st311;
 	goto tr445;
@@ -8153,7 +8154,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8157 "inc/vcf/validator_detail_v43.hpp"
+#line 8158 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st315;
 	if ( (*p) < 48 ) {
@@ -8192,7 +8193,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8196 "inc/vcf/validator_detail_v43.hpp"
+#line 8197 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr459;
 		case 95: goto tr458;
@@ -8219,7 +8220,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8223 "inc/vcf/validator_detail_v43.hpp"
+#line 8224 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st318;
 	goto tr445;
@@ -8282,7 +8283,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8286 "inc/vcf/validator_detail_v43.hpp"
+#line 8287 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto st326;
 	goto tr467;
@@ -8338,7 +8339,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 8342 "inc/vcf/validator_detail_v43.hpp"
+#line 8343 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 116 )
 		goto st333;
 	goto tr475;
@@ -8443,7 +8444,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 8447 "inc/vcf/validator_detail_v43.hpp"
+#line 8448 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr491;
 	if ( (*p) < 45 ) {
@@ -8475,7 +8476,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 8479 "inc/vcf/validator_detail_v43.hpp"
+#line 8480 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 61: goto tr493;
@@ -8497,7 +8498,7 @@ st348:
 	if ( ++p == pe )
 		goto _test_eof348;
 case 348:
-#line 8501 "inc/vcf/validator_detail_v43.hpp"
+#line 8502 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr496;
 		case 61: goto tr493;
@@ -8524,7 +8525,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 8528 "inc/vcf/validator_detail_v43.hpp"
+#line 8529 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr493;
 	if ( (*p) < 45 ) {
@@ -8550,7 +8551,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 8554 "inc/vcf/validator_detail_v43.hpp"
+#line 8555 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 62: goto st351;
@@ -8585,7 +8586,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 8589 "inc/vcf/validator_detail_v43.hpp"
+#line 8590 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr499;
@@ -8603,7 +8604,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 8607 "inc/vcf/validator_detail_v43.hpp"
+#line 8608 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr500;
@@ -8621,7 +8622,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8625 "inc/vcf/validator_detail_v43.hpp"
+#line 8626 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr501;
@@ -8639,7 +8640,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8643 "inc/vcf/validator_detail_v43.hpp"
+#line 8644 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 71: goto tr502;
@@ -8657,7 +8658,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 8661 "inc/vcf/validator_detail_v43.hpp"
+#line 8662 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr503;
@@ -8675,7 +8676,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 8679 "inc/vcf/validator_detail_v43.hpp"
+#line 8680 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr504;
@@ -8693,7 +8694,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 8697 "inc/vcf/validator_detail_v43.hpp"
+#line 8698 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st359;
@@ -8720,7 +8721,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 8724 "inc/vcf/validator_detail_v43.hpp"
+#line 8725 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st361;
 	goto tr498;
@@ -8777,7 +8778,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 8781 "inc/vcf/validator_detail_v43.hpp"
+#line 8782 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st365;
 	if ( (*p) < 48 ) {
@@ -8816,7 +8817,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 8820 "inc/vcf/validator_detail_v43.hpp"
+#line 8821 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr516;
 		case 95: goto tr515;
@@ -8843,7 +8844,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 8847 "inc/vcf/validator_detail_v43.hpp"
+#line 8848 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 70: goto st368;
 		case 78: goto tr519;
@@ -8924,7 +8925,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8928 "inc/vcf/validator_detail_v43.hpp"
+#line 8929 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st375;
 	if ( (*p) < 48 ) {
@@ -8963,7 +8964,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 8967 "inc/vcf/validator_detail_v43.hpp"
+#line 8968 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr532;
 		case 95: goto tr531;
@@ -8990,7 +8991,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 8994 "inc/vcf/validator_detail_v43.hpp"
+#line 8995 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 77 )
 		goto st378;
 	goto tr498;
@@ -9068,7 +9069,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9072 "inc/vcf/validator_detail_v43.hpp"
+#line 9073 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st385;
 	if ( (*p) < 48 ) {
@@ -9107,7 +9108,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 9111 "inc/vcf/validator_detail_v43.hpp"
+#line 9112 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr543;
@@ -9134,7 +9135,7 @@ st387:
 	if ( ++p == pe )
 		goto _test_eof387;
 case 387:
-#line 9138 "inc/vcf/validator_detail_v43.hpp"
+#line 9139 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -9154,7 +9155,7 @@ st388:
 	if ( ++p == pe )
 		goto _test_eof388;
 case 388:
-#line 9158 "inc/vcf/validator_detail_v43.hpp"
+#line 9159 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr545;
 	goto tr517;
@@ -9168,7 +9169,7 @@ st389:
 	if ( ++p == pe )
 		goto _test_eof389;
 case 389:
-#line 9172 "inc/vcf/validator_detail_v43.hpp"
+#line 9173 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 109 )
 		goto tr546;
 	goto tr517;
@@ -9182,7 +9183,7 @@ st390:
 	if ( ++p == pe )
 		goto _test_eof390;
 case 390:
-#line 9186 "inc/vcf/validator_detail_v43.hpp"
+#line 9187 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 101 )
 		goto tr547;
 	goto tr517;
@@ -9196,7 +9197,7 @@ st391:
 	if ( ++p == pe )
 		goto _test_eof391;
 case 391:
-#line 9200 "inc/vcf/validator_detail_v43.hpp"
+#line 9201 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr548;
 	goto tr517;
@@ -9210,7 +9211,7 @@ st392:
 	if ( ++p == pe )
 		goto _test_eof392;
 case 392:
-#line 9214 "inc/vcf/validator_detail_v43.hpp"
+#line 9215 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr549;
 	goto tr517;
@@ -9224,7 +9225,7 @@ st393:
 	if ( ++p == pe )
 		goto _test_eof393;
 case 393:
-#line 9228 "inc/vcf/validator_detail_v43.hpp"
+#line 9229 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr550;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9240,7 +9241,7 @@ st394:
 	if ( ++p == pe )
 		goto _test_eof394;
 case 394:
-#line 9244 "inc/vcf/validator_detail_v43.hpp"
+#line 9245 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr551;
 	if ( (*p) < 48 ) {
@@ -9265,7 +9266,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9269 "inc/vcf/validator_detail_v43.hpp"
+#line 9270 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st395;
 	if ( (*p) < 48 ) {
@@ -9300,7 +9301,7 @@ st396:
 	if ( ++p == pe )
 		goto _test_eof396;
 case 396:
-#line 9304 "inc/vcf/validator_detail_v43.hpp"
+#line 9305 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr555;
 		case 62: goto tr544;
@@ -9328,7 +9329,7 @@ st397:
 	if ( ++p == pe )
 		goto _test_eof397;
 case 397:
-#line 9332 "inc/vcf/validator_detail_v43.hpp"
+#line 9333 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr519;
 	goto tr517;
@@ -9420,7 +9421,7 @@ st407:
 	if ( ++p == pe )
 		goto _test_eof407;
 case 407:
-#line 9424 "inc/vcf/validator_detail_v43.hpp"
+#line 9425 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st407;
 	if ( (*p) < 48 ) {
@@ -9459,7 +9460,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9463 "inc/vcf/validator_detail_v43.hpp"
+#line 9464 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr568;
@@ -9490,7 +9491,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 9494 "inc/vcf/validator_detail_v43.hpp"
+#line 9495 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr570;
@@ -9508,7 +9509,7 @@ st410:
 	if ( ++p == pe )
 		goto _test_eof410;
 case 410:
-#line 9512 "inc/vcf/validator_detail_v43.hpp"
+#line 9513 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr571;
@@ -9526,7 +9527,7 @@ st411:
 	if ( ++p == pe )
 		goto _test_eof411;
 case 411:
-#line 9530 "inc/vcf/validator_detail_v43.hpp"
+#line 9531 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 80: goto tr572;
@@ -9544,7 +9545,7 @@ st412:
 	if ( ++p == pe )
 		goto _test_eof412;
 case 412:
-#line 9548 "inc/vcf/validator_detail_v43.hpp"
+#line 9549 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr573;
@@ -9562,7 +9563,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9566 "inc/vcf/validator_detail_v43.hpp"
+#line 9567 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st414;
@@ -9589,7 +9590,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9593 "inc/vcf/validator_detail_v43.hpp"
+#line 9594 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st416;
 	goto tr569;
@@ -9646,7 +9647,7 @@ st420:
 	if ( ++p == pe )
 		goto _test_eof420;
 case 420:
-#line 9650 "inc/vcf/validator_detail_v43.hpp"
+#line 9651 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st420;
 	if ( (*p) < 48 ) {
@@ -9685,7 +9686,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9689 "inc/vcf/validator_detail_v43.hpp"
+#line 9690 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9713,7 +9714,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9717 "inc/vcf/validator_detail_v43.hpp"
+#line 9718 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr587;
 	if ( (*p) < 48 ) {
@@ -9738,7 +9739,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9742 "inc/vcf/validator_detail_v43.hpp"
+#line 9743 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st423;
 	if ( (*p) < 48 ) {
@@ -9773,7 +9774,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9777 "inc/vcf/validator_detail_v43.hpp"
+#line 9778 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr591;
 		case 95: goto tr590;
@@ -9800,7 +9801,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9804 "inc/vcf/validator_detail_v43.hpp"
+#line 9805 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st428;
 	if ( (*p) < 45 ) {
@@ -9832,7 +9833,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9836 "inc/vcf/validator_detail_v43.hpp"
+#line 9837 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9853,7 +9854,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9857 "inc/vcf/validator_detail_v43.hpp"
+#line 9858 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -9890,7 +9891,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 9894 "inc/vcf/validator_detail_v43.hpp"
+#line 9895 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 92: goto tr600;
@@ -9918,7 +9919,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 9922 "inc/vcf/validator_detail_v43.hpp"
+#line 9923 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st422;
 		case 62: goto st427;
@@ -9944,7 +9945,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 9948 "inc/vcf/validator_detail_v43.hpp"
+#line 9949 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 92: goto tr600;
@@ -9966,7 +9967,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 9970 "inc/vcf/validator_detail_v43.hpp"
+#line 9971 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr604;
@@ -10006,7 +10007,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10010 "inc/vcf/validator_detail_v43.hpp"
+#line 10011 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10057,7 +10058,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10061 "inc/vcf/validator_detail_v43.hpp"
+#line 10062 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10108,7 +10109,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10112 "inc/vcf/validator_detail_v43.hpp"
+#line 10113 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10151,7 +10152,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10155 "inc/vcf/validator_detail_v43.hpp"
+#line 10156 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr612;
 		case 44: goto tr598;
@@ -10181,7 +10182,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10185 "inc/vcf/validator_detail_v43.hpp"
+#line 10186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr615;
@@ -10221,7 +10222,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10225 "inc/vcf/validator_detail_v43.hpp"
+#line 10226 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -10251,7 +10252,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10255 "inc/vcf/validator_detail_v43.hpp"
+#line 10256 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 44: goto tr615;
@@ -10271,7 +10272,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10275 "inc/vcf/validator_detail_v43.hpp"
+#line 10276 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr596;
 		case 44: goto tr618;
@@ -10295,7 +10296,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10299 "inc/vcf/validator_detail_v43.hpp"
+#line 10300 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr621;
@@ -10313,7 +10314,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 10317 "inc/vcf/validator_detail_v43.hpp"
+#line 10318 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr622;
@@ -10331,7 +10332,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10335 "inc/vcf/validator_detail_v43.hpp"
+#line 10336 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr623;
@@ -10349,7 +10350,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 10353 "inc/vcf/validator_detail_v43.hpp"
+#line 10354 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 109: goto tr624;
@@ -10367,7 +10368,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10371 "inc/vcf/validator_detail_v43.hpp"
+#line 10372 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 98: goto tr625;
@@ -10385,7 +10386,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10389 "inc/vcf/validator_detail_v43.hpp"
+#line 10390 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 108: goto tr626;
@@ -10403,7 +10404,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 10407 "inc/vcf/validator_detail_v43.hpp"
+#line 10408 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 121: goto st448;
@@ -10430,7 +10431,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 10434 "inc/vcf/validator_detail_v43.hpp"
+#line 10435 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr630;
@@ -10447,7 +10448,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 10451 "inc/vcf/validator_detail_v43.hpp"
+#line 10452 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10473,7 +10474,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 10477 "inc/vcf/validator_detail_v43.hpp"
+#line 10478 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10596,7 +10597,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 10600 "inc/vcf/validator_detail_v43.hpp"
+#line 10601 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr646;
@@ -10664,7 +10665,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 10668 "inc/vcf/validator_detail_v43.hpp"
+#line 10669 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 111: goto tr651;
@@ -10682,7 +10683,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 10686 "inc/vcf/validator_detail_v43.hpp"
+#line 10687 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 110: goto tr652;
@@ -10700,7 +10701,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10704 "inc/vcf/validator_detail_v43.hpp"
+#line 10705 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 116: goto tr653;
@@ -10718,7 +10719,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 10722 "inc/vcf/validator_detail_v43.hpp"
+#line 10723 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr654;
@@ -10736,7 +10737,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 10740 "inc/vcf/validator_detail_v43.hpp"
+#line 10741 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto st473;
@@ -10763,7 +10764,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10767 "inc/vcf/validator_detail_v43.hpp"
+#line 10768 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st475;
 	goto tr650;
@@ -10836,7 +10837,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 10840 "inc/vcf/validator_detail_v43.hpp"
+#line 10841 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 59: goto tr663;
@@ -10865,7 +10866,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 10869 "inc/vcf/validator_detail_v43.hpp"
+#line 10870 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr666;
 	if ( (*p) < 48 ) {
@@ -10890,7 +10891,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10894 "inc/vcf/validator_detail_v43.hpp"
+#line 10895 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st481;
 	if ( (*p) < 48 ) {
@@ -10925,7 +10926,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 10929 "inc/vcf/validator_detail_v43.hpp"
+#line 10930 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr670;
 		case 95: goto tr669;
@@ -10952,7 +10953,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 10956 "inc/vcf/validator_detail_v43.hpp"
+#line 10957 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st486;
 	if ( (*p) < 45 ) {
@@ -10984,7 +10985,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10988 "inc/vcf/validator_detail_v43.hpp"
+#line 10989 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 62: goto tr665;
@@ -11005,7 +11006,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 11009 "inc/vcf/validator_detail_v43.hpp"
+#line 11010 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11042,7 +11043,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 11046 "inc/vcf/validator_detail_v43.hpp"
+#line 11047 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 92: goto tr679;
@@ -11070,7 +11071,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 11074 "inc/vcf/validator_detail_v43.hpp"
+#line 11075 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st480;
 		case 62: goto st485;
@@ -11096,7 +11097,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 11100 "inc/vcf/validator_detail_v43.hpp"
+#line 11101 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 92: goto tr679;
@@ -11118,7 +11119,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 11122 "inc/vcf/validator_detail_v43.hpp"
+#line 11123 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr683;
@@ -11158,7 +11159,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 11162 "inc/vcf/validator_detail_v43.hpp"
+#line 11163 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11209,7 +11210,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 11213 "inc/vcf/validator_detail_v43.hpp"
+#line 11214 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11260,7 +11261,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 11264 "inc/vcf/validator_detail_v43.hpp"
+#line 11265 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11303,7 +11304,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 11307 "inc/vcf/validator_detail_v43.hpp"
+#line 11308 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr691;
 		case 44: goto tr677;
@@ -11333,7 +11334,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 11337 "inc/vcf/validator_detail_v43.hpp"
+#line 11338 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr694;
@@ -11373,7 +11374,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 11377 "inc/vcf/validator_detail_v43.hpp"
+#line 11378 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11403,7 +11404,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 11407 "inc/vcf/validator_detail_v43.hpp"
+#line 11408 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 44: goto tr694;
@@ -11423,7 +11424,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 11427 "inc/vcf/validator_detail_v43.hpp"
+#line 11428 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr675;
 		case 44: goto tr697;
@@ -11447,7 +11448,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 11451 "inc/vcf/validator_detail_v43.hpp"
+#line 11452 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr700;
@@ -11465,7 +11466,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 11469 "inc/vcf/validator_detail_v43.hpp"
+#line 11470 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 100: goto tr701;
@@ -11483,7 +11484,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 11487 "inc/vcf/validator_detail_v43.hpp"
+#line 11488 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr702;
@@ -11501,7 +11502,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 11505 "inc/vcf/validator_detail_v43.hpp"
+#line 11506 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto tr703;
@@ -11519,7 +11520,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11523 "inc/vcf/validator_detail_v43.hpp"
+#line 11524 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 114: goto tr704;
@@ -11537,7 +11538,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11541 "inc/vcf/validator_detail_v43.hpp"
+#line 11542 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr705;
@@ -11555,7 +11556,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11559 "inc/vcf/validator_detail_v43.hpp"
+#line 11560 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr706;
@@ -11573,7 +11574,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11577 "inc/vcf/validator_detail_v43.hpp"
+#line 11578 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr707;
@@ -11591,7 +11592,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11595 "inc/vcf/validator_detail_v43.hpp"
+#line 11596 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 66: goto st508;
@@ -11618,7 +11619,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11622 "inc/vcf/validator_detail_v43.hpp"
+#line 11623 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st510;
 	goto tr699;
@@ -11642,7 +11643,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11646 "inc/vcf/validator_detail_v43.hpp"
+#line 11647 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11668,7 +11669,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11672 "inc/vcf/validator_detail_v43.hpp"
+#line 11673 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11779,7 +11780,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11783 "inc/vcf/validator_detail_v43.hpp"
+#line 11784 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr728;
@@ -11800,7 +11801,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11804 "inc/vcf/validator_detail_v43.hpp"
+#line 11805 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr730;
@@ -11835,7 +11836,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11839 "inc/vcf/validator_detail_v43.hpp"
+#line 11840 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr728;
@@ -11935,7 +11936,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 11939 "inc/vcf/validator_detail_v43.hpp"
+#line 11940 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 80 )
 		goto st537;
 	goto tr734;
@@ -11970,7 +11971,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 11974 "inc/vcf/validator_detail_v43.hpp"
+#line 11975 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st541;
 	goto tr734;
@@ -11998,7 +11999,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12002 "inc/vcf/validator_detail_v43.hpp"
+#line 12003 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 82 )
 		goto st544;
 	goto tr734;
@@ -12033,7 +12034,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12037 "inc/vcf/validator_detail_v43.hpp"
+#line 12038 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 65 )
 		goto st548;
 	goto tr734;
@@ -12068,7 +12069,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12072 "inc/vcf/validator_detail_v43.hpp"
+#line 12073 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 81 )
 		goto st552;
 	goto tr734;
@@ -12110,7 +12111,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12114 "inc/vcf/validator_detail_v43.hpp"
+#line 12115 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st557;
 	goto tr734;
@@ -12166,7 +12167,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12170 "inc/vcf/validator_detail_v43.hpp"
+#line 12171 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st564;
 	goto tr734;
@@ -12211,7 +12212,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12215 "inc/vcf/validator_detail_v43.hpp"
+#line 12216 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st569;
 	goto tr774;
@@ -12277,7 +12278,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12281 "inc/vcf/validator_detail_v43.hpp"
+#line 12282 "inc/vcf/validator_detail_v43.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr782;
 	goto tr774;
@@ -12301,7 +12302,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12305 "inc/vcf/validator_detail_v43.hpp"
+#line 12306 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr783;
 		case 10: goto tr784;
@@ -12350,7 +12351,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 12354 "inc/vcf/validator_detail_v43.hpp"
+#line 12355 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1012;
 		case 13: goto tr1013;
@@ -12410,7 +12411,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 12414 "inc/vcf/validator_detail_v43.hpp"
+#line 12415 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1016;
 		case 13: goto tr1017;
@@ -12452,7 +12453,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12456 "inc/vcf/validator_detail_v43.hpp"
+#line 12457 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st725;
 	goto st0;
@@ -12494,7 +12495,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12498 "inc/vcf/validator_detail_v43.hpp"
+#line 12499 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr790;
 		case 43: goto tr791;
@@ -12541,7 +12542,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12545 "inc/vcf/validator_detail_v43.hpp"
+#line 12546 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr793;
 	goto tr792;
@@ -12565,7 +12566,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12569 "inc/vcf/validator_detail_v43.hpp"
+#line 12570 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr794;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12595,7 +12596,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12599 "inc/vcf/validator_detail_v43.hpp"
+#line 12600 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr797;
@@ -12622,7 +12623,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12626 "inc/vcf/validator_detail_v43.hpp"
+#line 12627 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr798;
 		case 59: goto tr800;
@@ -12648,7 +12649,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12652 "inc/vcf/validator_detail_v43.hpp"
+#line 12653 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr802;
 		case 67: goto tr802;
@@ -12682,7 +12683,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 12686 "inc/vcf/validator_detail_v43.hpp"
+#line 12687 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr803;
 		case 65: goto tr804;
@@ -12715,7 +12716,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 12719 "inc/vcf/validator_detail_v43.hpp"
+#line 12720 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr807;
@@ -12754,7 +12755,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 12758 "inc/vcf/validator_detail_v43.hpp"
+#line 12759 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -12778,7 +12779,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 12782 "inc/vcf/validator_detail_v43.hpp"
+#line 12783 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr815;
 		case 45: goto tr815;
@@ -12803,7 +12804,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 12807 "inc/vcf/validator_detail_v43.hpp"
+#line 12808 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr821;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12829,7 +12830,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 12833 "inc/vcf/validator_detail_v43.hpp"
+#line 12834 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 46: goto tr823;
@@ -12857,7 +12858,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 12861 "inc/vcf/validator_detail_v43.hpp"
+#line 12862 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr827;
 		case 58: goto tr826;
@@ -12893,7 +12894,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12897 "inc/vcf/validator_detail_v43.hpp"
+#line 12898 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto st591;
 	if ( (*p) < 65 ) {
@@ -12937,7 +12938,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12941 "inc/vcf/validator_detail_v43.hpp"
+#line 12942 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 59: goto tr832;
@@ -12963,7 +12964,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12967 "inc/vcf/validator_detail_v43.hpp"
+#line 12968 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr834;
 		case 49: goto tr836;
@@ -13002,7 +13003,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 13006 "inc/vcf/validator_detail_v43.hpp"
+#line 13007 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13033,7 +13034,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13037 "inc/vcf/validator_detail_v43.hpp"
+#line 13038 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr848;
 	if ( (*p) > 90 ) {
@@ -13062,7 +13063,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13066 "inc/vcf/validator_detail_v43.hpp"
+#line 13067 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 37: goto tr850;
@@ -13097,7 +13098,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13101 "inc/vcf/validator_detail_v43.hpp"
+#line 13102 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr854;
 	if ( (*p) < 48 ) {
@@ -13129,7 +13130,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 13133 "inc/vcf/validator_detail_v43.hpp"
+#line 13134 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13188,7 +13189,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 13192 "inc/vcf/validator_detail_v43.hpp"
+#line 13193 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1016;
 		case 13: goto tr1017;
@@ -13226,7 +13227,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13230 "inc/vcf/validator_detail_v43.hpp"
+#line 13231 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr856;
 		case 59: goto tr856;
@@ -13267,7 +13268,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13271 "inc/vcf/validator_detail_v43.hpp"
+#line 13272 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr857;
 		case 59: goto tr857;
@@ -13296,7 +13297,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13300 "inc/vcf/validator_detail_v43.hpp"
+#line 13301 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr859;
 	goto tr789;
@@ -13349,7 +13350,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13353 "inc/vcf/validator_detail_v43.hpp"
+#line 13354 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st728;
 	goto tr860;
@@ -13363,7 +13364,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13367 "inc/vcf/validator_detail_v43.hpp"
+#line 13368 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr863;
@@ -13390,7 +13391,7 @@ st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 13394 "inc/vcf/validator_detail_v43.hpp"
+#line 13395 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13412,7 +13413,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 13416 "inc/vcf/validator_detail_v43.hpp"
+#line 13417 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13449,7 +13450,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 13453 "inc/vcf/validator_detail_v43.hpp"
+#line 13454 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13487,7 +13488,7 @@ st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 13491 "inc/vcf/validator_detail_v43.hpp"
+#line 13492 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13516,7 +13517,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13520 "inc/vcf/validator_detail_v43.hpp"
+#line 13521 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 49: goto tr836;
 		case 65: goto tr837;
@@ -13554,7 +13555,7 @@ st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 13558 "inc/vcf/validator_detail_v43.hpp"
+#line 13559 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13584,7 +13585,7 @@ st734:
 	if ( ++p == pe )
 		goto _test_eof734;
 case 734:
-#line 13588 "inc/vcf/validator_detail_v43.hpp"
+#line 13589 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13614,7 +13615,7 @@ st735:
 	if ( ++p == pe )
 		goto _test_eof735;
 case 735:
-#line 13618 "inc/vcf/validator_detail_v43.hpp"
+#line 13619 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13644,7 +13645,7 @@ st736:
 	if ( ++p == pe )
 		goto _test_eof736;
 case 736:
-#line 13648 "inc/vcf/validator_detail_v43.hpp"
+#line 13649 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13674,7 +13675,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13678 "inc/vcf/validator_detail_v43.hpp"
+#line 13679 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr865;
@@ -13691,7 +13692,7 @@ st737:
 	if ( ++p == pe )
 		goto _test_eof737;
 case 737:
-#line 13695 "inc/vcf/validator_detail_v43.hpp"
+#line 13696 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13711,7 +13712,7 @@ st738:
 	if ( ++p == pe )
 		goto _test_eof738;
 case 738:
-#line 13715 "inc/vcf/validator_detail_v43.hpp"
+#line 13716 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13740,7 +13741,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13744 "inc/vcf/validator_detail_v43.hpp"
+#line 13745 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr867;
 	goto tr866;
@@ -13754,7 +13755,7 @@ st739:
 	if ( ++p == pe )
 		goto _test_eof739;
 case 739:
-#line 13758 "inc/vcf/validator_detail_v43.hpp"
+#line 13759 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13776,7 +13777,7 @@ st740:
 	if ( ++p == pe )
 		goto _test_eof740;
 case 740:
-#line 13780 "inc/vcf/validator_detail_v43.hpp"
+#line 13781 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13810,7 +13811,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13814 "inc/vcf/validator_detail_v43.hpp"
+#line 13815 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr869;
@@ -13835,7 +13836,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13839 "inc/vcf/validator_detail_v43.hpp"
+#line 13840 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr871;
 	if ( (*p) < 45 ) {
@@ -13857,7 +13858,7 @@ st741:
 	if ( ++p == pe )
 		goto _test_eof741;
 case 741:
-#line 13861 "inc/vcf/validator_detail_v43.hpp"
+#line 13862 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13883,7 +13884,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13887 "inc/vcf/validator_detail_v43.hpp"
+#line 13888 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr872;
@@ -13908,7 +13909,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13912 "inc/vcf/validator_detail_v43.hpp"
+#line 13913 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr874;
 	goto tr873;
@@ -13922,7 +13923,7 @@ st742:
 	if ( ++p == pe )
 		goto _test_eof742;
 case 742:
-#line 13926 "inc/vcf/validator_detail_v43.hpp"
+#line 13927 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13943,7 +13944,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13947 "inc/vcf/validator_detail_v43.hpp"
+#line 13948 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr875;
@@ -13970,7 +13971,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13974 "inc/vcf/validator_detail_v43.hpp"
+#line 13975 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr879;
 	goto tr878;
@@ -13984,7 +13985,7 @@ st743:
 	if ( ++p == pe )
 		goto _test_eof743;
 case 743:
-#line 13988 "inc/vcf/validator_detail_v43.hpp"
+#line 13989 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14005,7 +14006,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 14009 "inc/vcf/validator_detail_v43.hpp"
+#line 14010 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr880;
@@ -14030,7 +14031,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 14034 "inc/vcf/validator_detail_v43.hpp"
+#line 14035 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr882;
 	goto tr881;
@@ -14044,7 +14045,7 @@ st744:
 	if ( ++p == pe )
 		goto _test_eof744;
 case 744:
-#line 14048 "inc/vcf/validator_detail_v43.hpp"
+#line 14049 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14065,7 +14066,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 14069 "inc/vcf/validator_detail_v43.hpp"
+#line 14070 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr883;
@@ -14090,7 +14091,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 14094 "inc/vcf/validator_detail_v43.hpp"
+#line 14095 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr885;
 	goto tr884;
@@ -14104,7 +14105,7 @@ st745:
 	if ( ++p == pe )
 		goto _test_eof745;
 case 745:
-#line 14108 "inc/vcf/validator_detail_v43.hpp"
+#line 14109 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14125,7 +14126,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 14129 "inc/vcf/validator_detail_v43.hpp"
+#line 14130 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr886;
@@ -14150,7 +14151,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 14154 "inc/vcf/validator_detail_v43.hpp"
+#line 14155 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr888;
 		case 45: goto tr888;
@@ -14170,7 +14171,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 14174 "inc/vcf/validator_detail_v43.hpp"
+#line 14175 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr890;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14186,7 +14187,7 @@ st746:
 	if ( ++p == pe )
 		goto _test_eof746;
 case 746:
-#line 14190 "inc/vcf/validator_detail_v43.hpp"
+#line 14191 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14210,7 +14211,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 14214 "inc/vcf/validator_detail_v43.hpp"
+#line 14215 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr892;
 	goto tr887;
@@ -14224,7 +14225,7 @@ st747:
 	if ( ++p == pe )
 		goto _test_eof747;
 case 747:
-#line 14228 "inc/vcf/validator_detail_v43.hpp"
+#line 14229 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14247,7 +14248,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 14251 "inc/vcf/validator_detail_v43.hpp"
+#line 14252 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr893;
 		case 45: goto tr893;
@@ -14265,7 +14266,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 14269 "inc/vcf/validator_detail_v43.hpp"
+#line 14270 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr894;
 	goto tr887;
@@ -14279,7 +14280,7 @@ st748:
 	if ( ++p == pe )
 		goto _test_eof748;
 case 748:
-#line 14283 "inc/vcf/validator_detail_v43.hpp"
+#line 14284 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14300,7 +14301,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 14304 "inc/vcf/validator_detail_v43.hpp"
+#line 14305 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr895;
 	goto tr887;
@@ -14314,7 +14315,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 14318 "inc/vcf/validator_detail_v43.hpp"
+#line 14319 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr896;
 	goto tr887;
@@ -14328,7 +14329,7 @@ st749:
 	if ( ++p == pe )
 		goto _test_eof749;
 case 749:
-#line 14332 "inc/vcf/validator_detail_v43.hpp"
+#line 14333 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14347,7 +14348,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 14351 "inc/vcf/validator_detail_v43.hpp"
+#line 14352 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr897;
 	goto tr887;
@@ -14361,7 +14362,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 14365 "inc/vcf/validator_detail_v43.hpp"
+#line 14366 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr896;
 	goto tr887;
@@ -14375,7 +14376,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 14379 "inc/vcf/validator_detail_v43.hpp"
+#line 14380 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr898;
@@ -14400,7 +14401,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 14404 "inc/vcf/validator_detail_v43.hpp"
+#line 14405 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr900;
 	goto tr899;
@@ -14414,7 +14415,7 @@ st750:
 	if ( ++p == pe )
 		goto _test_eof750;
 case 750:
-#line 14418 "inc/vcf/validator_detail_v43.hpp"
+#line 14419 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14438,7 +14439,7 @@ st751:
 	if ( ++p == pe )
 		goto _test_eof751;
 case 751:
-#line 14442 "inc/vcf/validator_detail_v43.hpp"
+#line 14443 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14468,7 +14469,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 14472 "inc/vcf/validator_detail_v43.hpp"
+#line 14473 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr901;
@@ -14493,7 +14494,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 14497 "inc/vcf/validator_detail_v43.hpp"
+#line 14498 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr903;
 		case 45: goto tr903;
@@ -14513,7 +14514,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 14517 "inc/vcf/validator_detail_v43.hpp"
+#line 14518 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr905;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14529,7 +14530,7 @@ st752:
 	if ( ++p == pe )
 		goto _test_eof752;
 case 752:
-#line 14533 "inc/vcf/validator_detail_v43.hpp"
+#line 14534 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14552,7 +14553,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 14556 "inc/vcf/validator_detail_v43.hpp"
+#line 14557 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr907;
 	goto tr902;
@@ -14566,7 +14567,7 @@ st753:
 	if ( ++p == pe )
 		goto _test_eof753;
 case 753:
-#line 14570 "inc/vcf/validator_detail_v43.hpp"
+#line 14571 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14588,7 +14589,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 14592 "inc/vcf/validator_detail_v43.hpp"
+#line 14593 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr908;
 		case 45: goto tr908;
@@ -14606,7 +14607,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 14610 "inc/vcf/validator_detail_v43.hpp"
+#line 14611 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr909;
 	goto tr902;
@@ -14620,7 +14621,7 @@ st754:
 	if ( ++p == pe )
 		goto _test_eof754;
 case 754:
-#line 14624 "inc/vcf/validator_detail_v43.hpp"
+#line 14625 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14640,7 +14641,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 14644 "inc/vcf/validator_detail_v43.hpp"
+#line 14645 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr910;
 	goto tr902;
@@ -14654,7 +14655,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 14658 "inc/vcf/validator_detail_v43.hpp"
+#line 14659 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr911;
 	goto tr902;
@@ -14668,7 +14669,7 @@ st755:
 	if ( ++p == pe )
 		goto _test_eof755;
 case 755:
-#line 14672 "inc/vcf/validator_detail_v43.hpp"
+#line 14673 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14686,7 +14687,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 14690 "inc/vcf/validator_detail_v43.hpp"
+#line 14691 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr912;
 	goto tr902;
@@ -14700,7 +14701,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 14704 "inc/vcf/validator_detail_v43.hpp"
+#line 14705 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr911;
 	goto tr902;
@@ -14718,7 +14719,7 @@ st756:
 	if ( ++p == pe )
 		goto _test_eof756;
 case 756:
-#line 14722 "inc/vcf/validator_detail_v43.hpp"
+#line 14723 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14748,7 +14749,7 @@ st757:
 	if ( ++p == pe )
 		goto _test_eof757;
 case 757:
-#line 14752 "inc/vcf/validator_detail_v43.hpp"
+#line 14753 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14778,7 +14779,7 @@ st758:
 	if ( ++p == pe )
 		goto _test_eof758;
 case 758:
-#line 14782 "inc/vcf/validator_detail_v43.hpp"
+#line 14783 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14808,7 +14809,7 @@ st759:
 	if ( ++p == pe )
 		goto _test_eof759;
 case 759:
-#line 14812 "inc/vcf/validator_detail_v43.hpp"
+#line 14813 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14838,7 +14839,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14842 "inc/vcf/validator_detail_v43.hpp"
+#line 14843 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr913;
@@ -14863,7 +14864,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14867 "inc/vcf/validator_detail_v43.hpp"
+#line 14868 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr915;
 	goto tr914;
@@ -14877,7 +14878,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14881 "inc/vcf/validator_detail_v43.hpp"
+#line 14882 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 68: goto tr916;
 		case 80: goto tr916;
@@ -14903,7 +14904,7 @@ st760:
 	if ( ++p == pe )
 		goto _test_eof760;
 case 760:
-#line 14907 "inc/vcf/validator_detail_v43.hpp"
+#line 14908 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14928,7 +14929,7 @@ st761:
 	if ( ++p == pe )
 		goto _test_eof761;
 case 761:
-#line 14932 "inc/vcf/validator_detail_v43.hpp"
+#line 14933 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14959,7 +14960,7 @@ st762:
 	if ( ++p == pe )
 		goto _test_eof762;
 case 762:
-#line 14963 "inc/vcf/validator_detail_v43.hpp"
+#line 14964 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14988,7 +14989,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14992 "inc/vcf/validator_detail_v43.hpp"
+#line 14993 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr918;
 	goto tr917;
@@ -15002,7 +15003,7 @@ st763:
 	if ( ++p == pe )
 		goto _test_eof763;
 case 763:
-#line 15006 "inc/vcf/validator_detail_v43.hpp"
+#line 15007 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15020,7 +15021,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 15024 "inc/vcf/validator_detail_v43.hpp"
+#line 15025 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr919;
@@ -15045,7 +15046,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 15049 "inc/vcf/validator_detail_v43.hpp"
+#line 15050 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr921;
 	goto tr920;
@@ -15059,7 +15060,7 @@ st764:
 	if ( ++p == pe )
 		goto _test_eof764;
 case 764:
-#line 15063 "inc/vcf/validator_detail_v43.hpp"
+#line 15064 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15083,7 +15084,7 @@ st765:
 	if ( ++p == pe )
 		goto _test_eof765;
 case 765:
-#line 15087 "inc/vcf/validator_detail_v43.hpp"
+#line 15088 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15113,7 +15114,7 @@ st766:
 	if ( ++p == pe )
 		goto _test_eof766;
 case 766:
-#line 15117 "inc/vcf/validator_detail_v43.hpp"
+#line 15118 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15143,7 +15144,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 15147 "inc/vcf/validator_detail_v43.hpp"
+#line 15148 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr922;
@@ -15168,7 +15169,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 15172 "inc/vcf/validator_detail_v43.hpp"
+#line 15173 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr924;
 	goto tr923;
@@ -15182,7 +15183,7 @@ st767:
 	if ( ++p == pe )
 		goto _test_eof767;
 case 767:
-#line 15186 "inc/vcf/validator_detail_v43.hpp"
+#line 15187 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15206,7 +15207,7 @@ st768:
 	if ( ++p == pe )
 		goto _test_eof768;
 case 768:
-#line 15210 "inc/vcf/validator_detail_v43.hpp"
+#line 15211 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15237,7 +15238,7 @@ st769:
 	if ( ++p == pe )
 		goto _test_eof769;
 case 769:
-#line 15241 "inc/vcf/validator_detail_v43.hpp"
+#line 15242 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15266,7 +15267,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 15270 "inc/vcf/validator_detail_v43.hpp"
+#line 15271 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr926;
 	goto tr925;
@@ -15280,7 +15281,7 @@ st770:
 	if ( ++p == pe )
 		goto _test_eof770;
 case 770:
-#line 15284 "inc/vcf/validator_detail_v43.hpp"
+#line 15285 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15298,7 +15299,7 @@ st771:
 	if ( ++p == pe )
 		goto _test_eof771;
 case 771:
-#line 15302 "inc/vcf/validator_detail_v43.hpp"
+#line 15303 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15327,7 +15328,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 15331 "inc/vcf/validator_detail_v43.hpp"
+#line 15332 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr928;
 	goto tr927;
@@ -15341,7 +15342,7 @@ st772:
 	if ( ++p == pe )
 		goto _test_eof772;
 case 772:
-#line 15345 "inc/vcf/validator_detail_v43.hpp"
+#line 15346 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15363,7 +15364,7 @@ st773:
 	if ( ++p == pe )
 		goto _test_eof773;
 case 773:
-#line 15367 "inc/vcf/validator_detail_v43.hpp"
+#line 15368 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15393,7 +15394,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 15397 "inc/vcf/validator_detail_v43.hpp"
+#line 15398 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 48: goto tr929;
@@ -15419,7 +15420,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 15423 "inc/vcf/validator_detail_v43.hpp"
+#line 15424 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr931;
@@ -15444,7 +15445,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 15448 "inc/vcf/validator_detail_v43.hpp"
+#line 15449 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr932;
@@ -15458,7 +15459,7 @@ st774:
 	if ( ++p == pe )
 		goto _test_eof774;
 case 774:
-#line 15462 "inc/vcf/validator_detail_v43.hpp"
+#line 15463 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15478,7 +15479,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 15482 "inc/vcf/validator_detail_v43.hpp"
+#line 15483 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr935;
 		case 45: goto tr935;
@@ -15498,7 +15499,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 15502 "inc/vcf/validator_detail_v43.hpp"
+#line 15503 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr937;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15514,7 +15515,7 @@ st775:
 	if ( ++p == pe )
 		goto _test_eof775;
 case 775:
-#line 15518 "inc/vcf/validator_detail_v43.hpp"
+#line 15519 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15537,7 +15538,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 15541 "inc/vcf/validator_detail_v43.hpp"
+#line 15542 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr939;
 	goto tr934;
@@ -15551,7 +15552,7 @@ st776:
 	if ( ++p == pe )
 		goto _test_eof776;
 case 776:
-#line 15555 "inc/vcf/validator_detail_v43.hpp"
+#line 15556 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15573,7 +15574,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 15577 "inc/vcf/validator_detail_v43.hpp"
+#line 15578 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr940;
 		case 45: goto tr940;
@@ -15591,7 +15592,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 15595 "inc/vcf/validator_detail_v43.hpp"
+#line 15596 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr941;
 	goto tr934;
@@ -15605,7 +15606,7 @@ st777:
 	if ( ++p == pe )
 		goto _test_eof777;
 case 777:
-#line 15609 "inc/vcf/validator_detail_v43.hpp"
+#line 15610 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15625,7 +15626,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 15629 "inc/vcf/validator_detail_v43.hpp"
+#line 15630 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr942;
 	goto tr934;
@@ -15639,7 +15640,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 15643 "inc/vcf/validator_detail_v43.hpp"
+#line 15644 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr943;
 	goto tr934;
@@ -15653,7 +15654,7 @@ st778:
 	if ( ++p == pe )
 		goto _test_eof778;
 case 778:
-#line 15657 "inc/vcf/validator_detail_v43.hpp"
+#line 15658 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15671,7 +15672,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 15675 "inc/vcf/validator_detail_v43.hpp"
+#line 15676 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr944;
 	goto tr934;
@@ -15685,7 +15686,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 15689 "inc/vcf/validator_detail_v43.hpp"
+#line 15690 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr943;
 	goto tr934;
@@ -15703,7 +15704,7 @@ st779:
 	if ( ++p == pe )
 		goto _test_eof779;
 case 779:
-#line 15707 "inc/vcf/validator_detail_v43.hpp"
+#line 15708 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15733,7 +15734,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 15737 "inc/vcf/validator_detail_v43.hpp"
+#line 15738 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr945;
@@ -15758,7 +15759,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 15762 "inc/vcf/validator_detail_v43.hpp"
+#line 15763 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr947;
 	goto tr946;
@@ -15772,7 +15773,7 @@ st780:
 	if ( ++p == pe )
 		goto _test_eof780;
 case 780:
-#line 15776 "inc/vcf/validator_detail_v43.hpp"
+#line 15777 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15796,7 +15797,7 @@ st781:
 	if ( ++p == pe )
 		goto _test_eof781;
 case 781:
-#line 15800 "inc/vcf/validator_detail_v43.hpp"
+#line 15801 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15827,7 +15828,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 15831 "inc/vcf/validator_detail_v43.hpp"
+#line 15832 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr948;
@@ -15852,7 +15853,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 15856 "inc/vcf/validator_detail_v43.hpp"
+#line 15857 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr950;
 		case 45: goto tr950;
@@ -15872,7 +15873,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 15876 "inc/vcf/validator_detail_v43.hpp"
+#line 15877 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr952;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15888,7 +15889,7 @@ st782:
 	if ( ++p == pe )
 		goto _test_eof782;
 case 782:
-#line 15892 "inc/vcf/validator_detail_v43.hpp"
+#line 15893 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15911,7 +15912,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 15915 "inc/vcf/validator_detail_v43.hpp"
+#line 15916 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr954;
 	goto tr949;
@@ -15925,7 +15926,7 @@ st783:
 	if ( ++p == pe )
 		goto _test_eof783;
 case 783:
-#line 15929 "inc/vcf/validator_detail_v43.hpp"
+#line 15930 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15947,7 +15948,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 15951 "inc/vcf/validator_detail_v43.hpp"
+#line 15952 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr955;
 		case 45: goto tr955;
@@ -15965,7 +15966,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 15969 "inc/vcf/validator_detail_v43.hpp"
+#line 15970 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr949;
@@ -15979,7 +15980,7 @@ st784:
 	if ( ++p == pe )
 		goto _test_eof784;
 case 784:
-#line 15983 "inc/vcf/validator_detail_v43.hpp"
+#line 15984 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15999,7 +16000,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 16003 "inc/vcf/validator_detail_v43.hpp"
+#line 16004 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr957;
 	goto tr949;
@@ -16013,7 +16014,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 16017 "inc/vcf/validator_detail_v43.hpp"
+#line 16018 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr958;
 	goto tr949;
@@ -16027,7 +16028,7 @@ st785:
 	if ( ++p == pe )
 		goto _test_eof785;
 case 785:
-#line 16031 "inc/vcf/validator_detail_v43.hpp"
+#line 16032 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16045,7 +16046,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 16049 "inc/vcf/validator_detail_v43.hpp"
+#line 16050 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr959;
 	goto tr949;
@@ -16059,7 +16060,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 16063 "inc/vcf/validator_detail_v43.hpp"
+#line 16064 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr958;
 	goto tr949;
@@ -16073,7 +16074,7 @@ st786:
 	if ( ++p == pe )
 		goto _test_eof786;
 case 786:
-#line 16077 "inc/vcf/validator_detail_v43.hpp"
+#line 16078 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16103,7 +16104,7 @@ st787:
 	if ( ++p == pe )
 		goto _test_eof787;
 case 787:
-#line 16107 "inc/vcf/validator_detail_v43.hpp"
+#line 16108 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16133,7 +16134,7 @@ st788:
 	if ( ++p == pe )
 		goto _test_eof788;
 case 788:
-#line 16137 "inc/vcf/validator_detail_v43.hpp"
+#line 16138 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16163,7 +16164,7 @@ st789:
 	if ( ++p == pe )
 		goto _test_eof789;
 case 789:
-#line 16167 "inc/vcf/validator_detail_v43.hpp"
+#line 16168 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16193,7 +16194,7 @@ st790:
 	if ( ++p == pe )
 		goto _test_eof790;
 case 790:
-#line 16197 "inc/vcf/validator_detail_v43.hpp"
+#line 16198 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16223,7 +16224,7 @@ st791:
 	if ( ++p == pe )
 		goto _test_eof791;
 case 791:
-#line 16227 "inc/vcf/validator_detail_v43.hpp"
+#line 16228 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16252,7 +16253,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 16256 "inc/vcf/validator_detail_v43.hpp"
+#line 16257 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr961;
 	goto tr960;
@@ -16266,7 +16267,7 @@ st792:
 	if ( ++p == pe )
 		goto _test_eof792;
 case 792:
-#line 16270 "inc/vcf/validator_detail_v43.hpp"
+#line 16271 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16288,7 +16289,7 @@ st793:
 	if ( ++p == pe )
 		goto _test_eof793;
 case 793:
-#line 16292 "inc/vcf/validator_detail_v43.hpp"
+#line 16293 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16318,7 +16319,7 @@ st794:
 	if ( ++p == pe )
 		goto _test_eof794;
 case 794:
-#line 16322 "inc/vcf/validator_detail_v43.hpp"
+#line 16323 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16348,7 +16349,7 @@ st795:
 	if ( ++p == pe )
 		goto _test_eof795;
 case 795:
-#line 16352 "inc/vcf/validator_detail_v43.hpp"
+#line 16353 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16378,7 +16379,7 @@ st796:
 	if ( ++p == pe )
 		goto _test_eof796;
 case 796:
-#line 16382 "inc/vcf/validator_detail_v43.hpp"
+#line 16383 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16408,7 +16409,7 @@ st797:
 	if ( ++p == pe )
 		goto _test_eof797;
 case 797:
-#line 16412 "inc/vcf/validator_detail_v43.hpp"
+#line 16413 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16438,7 +16439,7 @@ st798:
 	if ( ++p == pe )
 		goto _test_eof798;
 case 798:
-#line 16442 "inc/vcf/validator_detail_v43.hpp"
+#line 16443 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16468,7 +16469,7 @@ st799:
 	if ( ++p == pe )
 		goto _test_eof799;
 case 799:
-#line 16472 "inc/vcf/validator_detail_v43.hpp"
+#line 16473 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16498,7 +16499,7 @@ st800:
 	if ( ++p == pe )
 		goto _test_eof800;
 case 800:
-#line 16502 "inc/vcf/validator_detail_v43.hpp"
+#line 16503 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16528,7 +16529,7 @@ st801:
 	if ( ++p == pe )
 		goto _test_eof801;
 case 801:
-#line 16532 "inc/vcf/validator_detail_v43.hpp"
+#line 16533 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16557,7 +16558,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 16561 "inc/vcf/validator_detail_v43.hpp"
+#line 16562 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr963;
 	goto tr962;
@@ -16571,7 +16572,7 @@ st802:
 	if ( ++p == pe )
 		goto _test_eof802;
 case 802:
-#line 16575 "inc/vcf/validator_detail_v43.hpp"
+#line 16576 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16589,7 +16590,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 16593 "inc/vcf/validator_detail_v43.hpp"
+#line 16594 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr826;
 	if ( (*p) < 65 ) {
@@ -16627,7 +16628,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 16631 "inc/vcf/validator_detail_v43.hpp"
+#line 16632 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 58: goto st591;
@@ -16663,7 +16664,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 16667 "inc/vcf/validator_detail_v43.hpp"
+#line 16668 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr964;
 	goto tr814;
@@ -16677,7 +16678,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 16681 "inc/vcf/validator_detail_v43.hpp"
+#line 16682 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 69: goto tr824;
@@ -16696,7 +16697,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 16700 "inc/vcf/validator_detail_v43.hpp"
+#line 16701 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr965;
 		case 45: goto tr965;
@@ -16714,7 +16715,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 16718 "inc/vcf/validator_detail_v43.hpp"
+#line 16719 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr966;
 	goto tr814;
@@ -16728,7 +16729,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 16732 "inc/vcf/validator_detail_v43.hpp"
+#line 16733 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16754,7 +16755,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 16758 "inc/vcf/validator_detail_v43.hpp"
+#line 16759 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr967;
 	goto tr814;
@@ -16768,7 +16769,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 16772 "inc/vcf/validator_detail_v43.hpp"
+#line 16773 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr968;
 	goto tr814;
@@ -16792,7 +16793,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 16796 "inc/vcf/validator_detail_v43.hpp"
+#line 16797 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	goto tr814;
@@ -16810,7 +16811,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 16814 "inc/vcf/validator_detail_v43.hpp"
+#line 16815 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr969;
 	goto tr814;
@@ -16824,7 +16825,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 16828 "inc/vcf/validator_detail_v43.hpp"
+#line 16829 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr968;
 	goto tr814;
@@ -16838,7 +16839,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 16842 "inc/vcf/validator_detail_v43.hpp"
+#line 16843 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr970;
@@ -16877,7 +16878,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 16881 "inc/vcf/validator_detail_v43.hpp"
+#line 16882 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr971;
 		case 67: goto tr971;
@@ -16901,7 +16902,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 16905 "inc/vcf/validator_detail_v43.hpp"
+#line 16906 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -16937,7 +16938,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 16941 "inc/vcf/validator_detail_v43.hpp"
+#line 16942 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr972;
 	if ( (*p) < 63 ) {
@@ -16977,7 +16978,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 16981 "inc/vcf/validator_detail_v43.hpp"
+#line 16982 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto tr974;
 	if ( (*p) < 45 ) {
@@ -17009,7 +17010,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 17013 "inc/vcf/validator_detail_v43.hpp"
+#line 17014 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -17038,7 +17039,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 17042 "inc/vcf/validator_detail_v43.hpp"
+#line 17043 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr978;
 		case 59: goto tr978;
@@ -17070,7 +17071,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 17074 "inc/vcf/validator_detail_v43.hpp"
+#line 17075 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr978;
 		case 58: goto tr980;
@@ -17098,7 +17099,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 17102 "inc/vcf/validator_detail_v43.hpp"
+#line 17103 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr981;
 	goto tr805;
@@ -17112,7 +17113,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 17116 "inc/vcf/validator_detail_v43.hpp"
+#line 17117 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr974;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17128,7 +17129,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 17132 "inc/vcf/validator_detail_v43.hpp"
+#line 17133 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr982;
 		case 59: goto tr982;
@@ -17159,7 +17160,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 17163 "inc/vcf/validator_detail_v43.hpp"
+#line 17164 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr982;
 		case 59: goto tr982;
@@ -17188,7 +17189,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 17192 "inc/vcf/validator_detail_v43.hpp"
+#line 17193 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr980;
 	goto tr805;
@@ -17202,7 +17203,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 17206 "inc/vcf/validator_detail_v43.hpp"
+#line 17207 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr984;
 		case 59: goto tr984;
@@ -17234,7 +17235,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 17238 "inc/vcf/validator_detail_v43.hpp"
+#line 17239 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr984;
 		case 58: goto tr986;
@@ -17262,7 +17263,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 17266 "inc/vcf/validator_detail_v43.hpp"
+#line 17267 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr987;
 	goto tr805;
@@ -17276,7 +17277,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 17280 "inc/vcf/validator_detail_v43.hpp"
+#line 17281 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr974;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17292,7 +17293,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 17296 "inc/vcf/validator_detail_v43.hpp"
+#line 17297 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr988;
 		case 59: goto tr988;
@@ -17323,7 +17324,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 17327 "inc/vcf/validator_detail_v43.hpp"
+#line 17328 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr988;
 		case 59: goto tr988;
@@ -17352,7 +17353,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 17356 "inc/vcf/validator_detail_v43.hpp"
+#line 17357 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr986;
 	goto tr805;
@@ -17370,7 +17371,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 17374 "inc/vcf/validator_detail_v43.hpp"
+#line 17375 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr990;
 		case 59: goto tr990;
@@ -17402,7 +17403,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 17406 "inc/vcf/validator_detail_v43.hpp"
+#line 17407 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr990;
 		case 58: goto tr992;
@@ -17430,7 +17431,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 17434 "inc/vcf/validator_detail_v43.hpp"
+#line 17435 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr993;
 	goto tr805;
@@ -17444,7 +17445,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 17448 "inc/vcf/validator_detail_v43.hpp"
+#line 17449 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr994;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17460,7 +17461,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 17464 "inc/vcf/validator_detail_v43.hpp"
+#line 17465 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr995;
 		case 59: goto tr995;
@@ -17491,7 +17492,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 17495 "inc/vcf/validator_detail_v43.hpp"
+#line 17496 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr995;
 		case 59: goto tr995;
@@ -17520,7 +17521,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 17524 "inc/vcf/validator_detail_v43.hpp"
+#line 17525 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr992;
 	goto tr805;
@@ -17538,7 +17539,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 17542 "inc/vcf/validator_detail_v43.hpp"
+#line 17543 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr997;
 		case 59: goto tr997;
@@ -17570,7 +17571,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 17574 "inc/vcf/validator_detail_v43.hpp"
+#line 17575 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr997;
 		case 58: goto tr999;
@@ -17598,7 +17599,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 17602 "inc/vcf/validator_detail_v43.hpp"
+#line 17603 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1000;
 	goto tr805;
@@ -17612,7 +17613,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 17616 "inc/vcf/validator_detail_v43.hpp"
+#line 17617 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr994;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17628,7 +17629,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 17632 "inc/vcf/validator_detail_v43.hpp"
+#line 17633 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1001;
 		case 59: goto tr1001;
@@ -17659,7 +17660,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 17663 "inc/vcf/validator_detail_v43.hpp"
+#line 17664 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1001;
 		case 59: goto tr1001;
@@ -17688,7 +17689,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 17692 "inc/vcf/validator_detail_v43.hpp"
+#line 17693 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr999;
 	goto tr805;
@@ -17706,7 +17707,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 17710 "inc/vcf/validator_detail_v43.hpp"
+#line 17711 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 65: goto tr971;
@@ -17761,7 +17762,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 17765 "inc/vcf/validator_detail_v43.hpp"
+#line 17766 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st724;
 	goto tr774;
@@ -17790,7 +17791,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 17794 "inc/vcf/validator_detail_v43.hpp"
+#line 17795 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -17810,7 +17811,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 17814 "inc/vcf/validator_detail_v43.hpp"
+#line 17815 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1006;
 		case 13: goto tr1007;
@@ -17827,14 +17828,14 @@ tr1006:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 916 "src/vcf/vcf_v43.ragel"
+#line 917 "src/vcf/vcf_v43.ragel"
 	{ {goto st28;} }
 	goto st803;
 st803:
 	if ( ++p == pe )
 		goto _test_eof803;
 case 803:
-#line 17838 "inc/vcf/validator_detail_v43.hpp"
+#line 17839 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 tr1010:
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -17852,7 +17853,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 17856 "inc/vcf/validator_detail_v43.hpp"
+#line 17857 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1009;
 		case 13: goto tr1010;
@@ -17869,14 +17870,14 @@ tr1009:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 917 "src/vcf/vcf_v43.ragel"
+#line 918 "src/vcf/vcf_v43.ragel"
 	{ {goto st728;} }
 	goto st804;
 st804:
 	if ( ++p == pe )
 		goto _test_eof804;
 case 804:
-#line 17880 "inc/vcf/validator_detail_v43.hpp"
+#line 17881 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -18804,7 +18805,8 @@ case 804:
 #line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         p--; {goto st722;}
     }
 #line 60 "src/vcf/vcf_v43.ragel"
@@ -18835,7 +18837,7 @@ case 804:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -18854,7 +18856,7 @@ case 804:
 	case 446: 
 	case 447: 
 	case 448: 
-#line 257 "src/vcf/vcf_v43.ragel"
+#line 258 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -18894,7 +18896,7 @@ case 804:
 	case 496: 
 	case 497: 
 	case 498: 
-#line 263 "src/vcf/vcf_v43.ragel"
+#line 264 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -18929,7 +18931,7 @@ case 804:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -18976,7 +18978,7 @@ case 804:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19022,7 +19024,7 @@ case 804:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19067,7 +19069,7 @@ case 804:
 	case 403: 
 	case 404: 
 	case 405: 
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19089,7 +19091,7 @@ case 804:
 	case 507: 
 	case 508: 
 	case 509: 
-#line 328 "src/vcf/vcf_v43.ragel"
+#line 329 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -19132,7 +19134,7 @@ case 804:
 	case 348: 
 	case 349: 
 	case 351: 
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19172,7 +19174,7 @@ case 804:
 	case 438: 
 	case 439: 
 	case 440: 
-#line 355 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -19187,7 +19189,7 @@ case 804:
 	case 597: 
 	case 598: 
 	case 599: 
-#line 394 "src/vcf/vcf_v43.ragel"
+#line 395 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st723;}
@@ -19200,7 +19202,7 @@ case 804:
 	break;
 	case 579: 
 	case 580: 
-#line 400 "src/vcf/vcf_v43.ragel"
+#line 401 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st723;}
@@ -19213,7 +19215,7 @@ case 804:
 	break;
 	case 581: 
 	case 582: 
-#line 406 "src/vcf/vcf_v43.ragel"
+#line 407 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st723;}
@@ -19226,7 +19228,7 @@ case 804:
 	break;
 	case 583: 
 	case 584: 
-#line 412 "src/vcf/vcf_v43.ragel"
+#line 413 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st723;}
@@ -19274,7 +19276,7 @@ case 804:
 	case 717: 
 	case 718: 
 	case 719: 
-#line 418 "src/vcf/vcf_v43.ragel"
+#line 419 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st723;}
@@ -19298,7 +19300,7 @@ case 804:
 	case 682: 
 	case 683: 
 	case 684: 
-#line 424 "src/vcf/vcf_v43.ragel"
+#line 425 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st723;}
@@ -19314,7 +19316,7 @@ case 804:
 	case 592: 
 	case 673: 
 	case 674: 
-#line 430 "src/vcf/vcf_v43.ragel"
+#line 431 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st723;}
@@ -19327,7 +19329,7 @@ case 804:
 	break;
 	case 594: 
 	case 595: 
-#line 620 "src/vcf/vcf_v43.ragel"
+#line 621 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st723;}
@@ -19347,7 +19349,7 @@ case 804:
 	case 574: 
 	case 575: 
 	case 576: 
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
@@ -19369,13 +19371,13 @@ case 804:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 250 "src/vcf/vcf_v43.ragel"
+#line 251 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -19387,12 +19389,12 @@ case 804:
     }
 	break;
 	case 122: 
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19406,12 +19408,12 @@ case 804:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 280 "src/vcf/vcf_v43.ragel"
+#line 281 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19425,12 +19427,12 @@ case 804:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 296 "src/vcf/vcf_v43.ragel"
+#line 297 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19443,12 +19445,12 @@ case 804:
 	break;
 	case 199: 
 	case 200: 
-#line 301 "src/vcf/vcf_v43.ragel"
+#line 302 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19461,12 +19463,12 @@ case 804:
 	break;
 	case 265: 
 	case 266: 
-#line 301 "src/vcf/vcf_v43.ragel"
+#line 302 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19480,12 +19482,12 @@ case 804:
 	case 406: 
 	case 407: 
 	case 408: 
-#line 312 "src/vcf/vcf_v43.ragel"
+#line 313 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19502,12 +19504,12 @@ case 804:
 	case 384: 
 	case 385: 
 	case 386: 
-#line 317 "src/vcf/vcf_v43.ragel"
+#line 318 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19529,12 +19531,12 @@ case 804:
 	case 395: 
 	case 396: 
 	case 397: 
-#line 322 "src/vcf/vcf_v43.ragel"
+#line 323 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19547,12 +19549,12 @@ case 804:
 	break;
 	case 324: 
 	case 325: 
-#line 339 "src/vcf/vcf_v43.ragel"
+#line 340 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19570,12 +19572,12 @@ case 804:
 	case 335: 
 	case 336: 
 	case 337: 
-#line 344 "src/vcf/vcf_v43.ragel"
+#line 345 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19588,12 +19590,12 @@ case 804:
 	break;
 	case 347: 
 	case 350: 
-#line 349 "src/vcf/vcf_v43.ragel"
+#line 350 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19607,12 +19609,12 @@ case 804:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -19625,12 +19627,12 @@ case 804:
 	break;
 	case 478: 
 	case 479: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 263 "src/vcf/vcf_v43.ragel"
+#line 264 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -19647,12 +19649,12 @@ case 804:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -19669,12 +19671,12 @@ case 804:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19691,12 +19693,12 @@ case 804:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19710,12 +19712,12 @@ case 804:
 	case 364: 
 	case 365: 
 	case 366: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19729,12 +19731,12 @@ case 804:
 	case 314: 
 	case 315: 
 	case 316: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19748,12 +19750,12 @@ case 804:
 	case 419: 
 	case 420: 
 	case 421: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 355 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -19778,12 +19780,12 @@ case 804:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -19808,12 +19810,12 @@ case 804:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -19838,12 +19840,12 @@ case 804:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19868,12 +19870,12 @@ case 804:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19903,12 +19905,12 @@ case 804:
 	case 465: 
 	case 466: 
 	case 467: 
-#line 371 "src/vcf/vcf_v43.ragel"
+#line 372 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 257 "src/vcf/vcf_v43.ragel"
+#line 258 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -19940,12 +19942,12 @@ case 804:
 	case 528: 
 	case 529: 
 	case 530: 
-#line 371 "src/vcf/vcf_v43.ragel"
+#line 372 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 328 "src/vcf/vcf_v43.ragel"
+#line 329 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -19993,12 +19995,12 @@ case 804:
 	case 565: 
 	case 566: 
 	case 567: 
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 377 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -20027,12 +20029,12 @@ case 804:
     }
 	break;
 	case 601: 
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 626 "src/vcf/vcf_v43.ragel"
+#line 627 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -20126,7 +20128,7 @@ case 804:
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
@@ -20164,12 +20166,12 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 377 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -20200,17 +20202,17 @@ case 804:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -20224,17 +20226,17 @@ case 804:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -20248,17 +20250,17 @@ case 804:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -20272,17 +20274,17 @@ case 804:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -20296,17 +20298,17 @@ case 804:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -20320,17 +20322,17 @@ case 804:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -20344,17 +20346,17 @@ case 804:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -20368,17 +20370,17 @@ case 804:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 366 "src/vcf/vcf_v43.ragel"
+#line 367 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 361 "src/vcf/vcf_v43.ragel"
+#line 362 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -20406,17 +20408,17 @@ case 804:
 	case 648: 
 	case 659: 
 	case 661: 
-#line 441 "src/vcf/vcf_v43.ragel"
+#line 442 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20428,17 +20430,17 @@ case 804:
     }
 	break;
 	case 603: 
-#line 446 "src/vcf/vcf_v43.ragel"
+#line 447 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20450,7 +20452,7 @@ case 804:
     }
 	break;
 	case 606: 
-#line 451 "src/vcf/vcf_v43.ragel"
+#line 452 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20458,12 +20460,12 @@ case 804:
                 "AA"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20475,7 +20477,7 @@ case 804:
     }
 	break;
 	case 608: 
-#line 459 "src/vcf/vcf_v43.ragel"
+#line 460 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20483,12 +20485,12 @@ case 804:
                 "AC"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20500,7 +20502,7 @@ case 804:
     }
 	break;
 	case 610: 
-#line 467 "src/vcf/vcf_v43.ragel"
+#line 468 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20508,12 +20510,12 @@ case 804:
                 "AD"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20525,7 +20527,7 @@ case 804:
     }
 	break;
 	case 612: 
-#line 475 "src/vcf/vcf_v43.ragel"
+#line 476 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20533,12 +20535,12 @@ case 804:
                 "ADF"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20550,7 +20552,7 @@ case 804:
     }
 	break;
 	case 614: 
-#line 483 "src/vcf/vcf_v43.ragel"
+#line 484 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20558,12 +20560,12 @@ case 804:
                 "ADR"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20583,7 +20585,7 @@ case 804:
 	case 622: 
 	case 623: 
 	case 624: 
-#line 491 "src/vcf/vcf_v43.ragel"
+#line 492 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20591,12 +20593,12 @@ case 804:
                 "AF"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20608,7 +20610,7 @@ case 804:
     }
 	break;
 	case 626: 
-#line 499 "src/vcf/vcf_v43.ragel"
+#line 500 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20616,12 +20618,12 @@ case 804:
                 "AN"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20641,7 +20643,7 @@ case 804:
 	case 634: 
 	case 635: 
 	case 636: 
-#line 507 "src/vcf/vcf_v43.ragel"
+#line 508 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20649,12 +20651,12 @@ case 804:
                 "BQ"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20667,7 +20669,7 @@ case 804:
 	break;
 	case 638: 
 	case 639: 
-#line 515 "src/vcf/vcf_v43.ragel"
+#line 516 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20675,12 +20677,12 @@ case 804:
                 "CIGAR"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20692,7 +20694,7 @@ case 804:
     }
 	break;
 	case 640: 
-#line 523 "src/vcf/vcf_v43.ragel"
+#line 524 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20700,12 +20702,12 @@ case 804:
                 "DB"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20717,7 +20719,7 @@ case 804:
     }
 	break;
 	case 642: 
-#line 531 "src/vcf/vcf_v43.ragel"
+#line 532 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20725,12 +20727,12 @@ case 804:
                 "DP"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20742,7 +20744,7 @@ case 804:
     }
 	break;
 	case 644: 
-#line 539 "src/vcf/vcf_v43.ragel"
+#line 540 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20750,12 +20752,12 @@ case 804:
                 "END"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20767,7 +20769,7 @@ case 804:
     }
 	break;
 	case 645: 
-#line 547 "src/vcf/vcf_v43.ragel"
+#line 548 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20775,12 +20777,12 @@ case 804:
                 "H2"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20792,7 +20794,7 @@ case 804:
     }
 	break;
 	case 646: 
-#line 555 "src/vcf/vcf_v43.ragel"
+#line 556 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20800,12 +20802,12 @@ case 804:
                 "H3"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20825,7 +20827,7 @@ case 804:
 	case 656: 
 	case 657: 
 	case 658: 
-#line 563 "src/vcf/vcf_v43.ragel"
+#line 564 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20833,12 +20835,12 @@ case 804:
                 "MQ"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20850,7 +20852,7 @@ case 804:
     }
 	break;
 	case 649: 
-#line 571 "src/vcf/vcf_v43.ragel"
+#line 572 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20858,12 +20860,12 @@ case 804:
                 "MQ0"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20875,7 +20877,7 @@ case 804:
     }
 	break;
 	case 660: 
-#line 579 "src/vcf/vcf_v43.ragel"
+#line 580 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20883,12 +20885,12 @@ case 804:
                 "NS"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20908,7 +20910,7 @@ case 804:
 	case 668: 
 	case 669: 
 	case 670: 
-#line 587 "src/vcf/vcf_v43.ragel"
+#line 588 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20916,12 +20918,12 @@ case 804:
                 "SB"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20933,7 +20935,7 @@ case 804:
     }
 	break;
 	case 671: 
-#line 595 "src/vcf/vcf_v43.ragel"
+#line 596 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20941,12 +20943,12 @@ case 804:
                 "SOMATIC"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20958,7 +20960,7 @@ case 804:
     }
 	break;
 	case 672: 
-#line 603 "src/vcf/vcf_v43.ragel"
+#line 604 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20966,12 +20968,12 @@ case 804:
                 "VALIDATED"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20983,7 +20985,7 @@ case 804:
     }
 	break;
 	case 604: 
-#line 611 "src/vcf/vcf_v43.ragel"
+#line 612 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20991,12 +20993,12 @@ case 804:
                 "1000G"});
         p--; {goto st723;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 436 "src/vcf/vcf_v43.ragel"
+#line 437 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -21010,7 +21012,7 @@ case 804:
 	case 729: 
 	case 730: 
 	case 731: 
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
@@ -21050,19 +21052,19 @@ case 804:
     }
 	break;
 	case 596: 
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 633 "src/vcf/vcf_v43.ragel"
+#line 634 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st723;}
     }
-#line 626 "src/vcf/vcf_v43.ragel"
+#line 627 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -21086,12 +21088,12 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 640 "src/vcf/vcf_v43.ragel"
+#line 641 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 377 "src/vcf/vcf_v43.ragel"
+#line 378 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -21120,52 +21122,52 @@ case 804:
     }
 	break;
 	case 24: 
-#line 245 "src/vcf/vcf_v43.ragel"
+#line 246 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
     }
-#line 269 "src/vcf/vcf_v43.ragel"
+#line 270 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 275 "src/vcf/vcf_v43.ragel"
+#line 276 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
     }
-#line 291 "src/vcf/vcf_v43.ragel"
+#line 292 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
     }
-#line 257 "src/vcf/vcf_v43.ragel"
+#line 258 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
     }
-#line 263 "src/vcf/vcf_v43.ragel"
+#line 264 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
     }
-#line 334 "src/vcf/vcf_v43.ragel"
+#line 335 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
     }
-#line 355 "src/vcf/vcf_v43.ragel"
+#line 356 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
     }
-#line 307 "src/vcf/vcf_v43.ragel"
+#line 308 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
     }
-#line 328 "src/vcf/vcf_v43.ragel"
+#line 329 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -21176,14 +21178,14 @@ case 804:
         p--; {goto st722;}
     }
 	break;
-#line 21180 "inc/vcf/validator_detail_v43.hpp"
+#line 21182 "inc/vcf/validator_detail_v43.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 946 "src/vcf/vcf_v43.ragel"
+#line 947 "src/vcf/vcf_v43.ragel"
 
     }
     

--- a/inc/vcf/validator_detail_v43.hpp
+++ b/inc/vcf/validator_detail_v43.hpp
@@ -21,7 +21,7 @@
 #include "vcf/validator.hpp"
 
 
-#line 919 "src/vcf/vcf_v43.ragel"
+#line 918 "src/vcf/vcf_v43.ragel"
 
 
 namespace
@@ -39,7 +39,7 @@ static const int vcf_v43_en_meta_section_skip = 722;
 static const int vcf_v43_en_body_section_skip = 723;
 
 
-#line 925 "src/vcf/vcf_v43.ragel"
+#line 924 "src/vcf/vcf_v43.ragel"
 
 }
 
@@ -58,7 +58,7 @@ namespace ebi
 	cs = vcf_v43_start;
 	}
 
-#line 939 "src/vcf/vcf_v43.ragel"
+#line 938 "src/vcf/vcf_v43.ragel"
 
     }
 
@@ -87,8 +87,7 @@ tr14:
 #line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         p--; {goto st722;}
     }
 #line 60 "src/vcf/vcf_v43.ragel"
@@ -108,7 +107,7 @@ tr24:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 377 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -142,7 +141,7 @@ tr26:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 377 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -171,52 +170,52 @@ tr26:
     }
 	goto st0;
 tr29:
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 257 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 263 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 355 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 328 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -235,7 +234,7 @@ tr40:
     }
 	goto st0;
 tr126:
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -247,13 +246,13 @@ tr126:
     }
 	goto st0;
 tr134:
-#line 251 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -265,12 +264,12 @@ tr134:
     }
 	goto st0;
 tr153:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -282,12 +281,12 @@ tr153:
     }
 	goto st0;
 tr162:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -299,17 +298,17 @@ tr162:
     }
 	goto st0;
 tr176:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -321,17 +320,17 @@ tr176:
     }
 	goto st0;
 tr188:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -343,12 +342,12 @@ tr188:
     }
 	goto st0;
 tr194:
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -360,7 +359,7 @@ tr194:
     }
 	goto st0;
 tr197:
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -372,12 +371,12 @@ tr197:
     }
 	goto st0;
 tr207:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -389,12 +388,12 @@ tr207:
     }
 	goto st0;
 tr226:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -406,17 +405,17 @@ tr226:
     }
 	goto st0;
 tr248:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -428,17 +427,17 @@ tr248:
     }
 	goto st0;
 tr260:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -450,7 +449,7 @@ tr260:
     }
 	goto st0;
 tr266:
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -462,12 +461,12 @@ tr266:
     }
 	goto st0;
 tr276:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -479,12 +478,12 @@ tr276:
     }
 	goto st0;
 tr289:
-#line 281 "src/vcf/vcf_v43.ragel"
+#line 280 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -496,12 +495,12 @@ tr289:
     }
 	goto st0;
 tr298:
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 301 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -513,12 +512,12 @@ tr298:
     }
 	goto st0;
 tr315:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -530,17 +529,17 @@ tr315:
     }
 	goto st0;
 tr337:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -552,17 +551,17 @@ tr337:
     }
 	goto st0;
 tr349:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -574,7 +573,7 @@ tr349:
     }
 	goto st0;
 tr356:
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -586,12 +585,12 @@ tr356:
     }
 	goto st0;
 tr365:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -603,12 +602,12 @@ tr365:
     }
 	goto st0;
 tr378:
-#line 297 "src/vcf/vcf_v43.ragel"
+#line 296 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -620,12 +619,12 @@ tr378:
     }
 	goto st0;
 tr387:
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 301 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -637,12 +636,12 @@ tr387:
     }
 	goto st0;
 tr404:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -654,17 +653,17 @@ tr404:
     }
 	goto st0;
 tr426:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -676,17 +675,17 @@ tr426:
     }
 	goto st0;
 tr438:
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -698,7 +697,7 @@ tr438:
     }
 	goto st0;
 tr445:
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -710,12 +709,12 @@ tr445:
     }
 	goto st0;
 tr454:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -727,12 +726,12 @@ tr454:
     }
 	goto st0;
 tr467:
-#line 340 "src/vcf/vcf_v43.ragel"
+#line 339 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -744,12 +743,12 @@ tr467:
     }
 	goto st0;
 tr475:
-#line 345 "src/vcf/vcf_v43.ragel"
+#line 344 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -761,12 +760,12 @@ tr475:
     }
 	goto st0;
 tr492:
-#line 350 "src/vcf/vcf_v43.ragel"
+#line 349 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -778,7 +777,7 @@ tr492:
     }
 	goto st0;
 tr498:
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -790,12 +789,12 @@ tr498:
     }
 	goto st0;
 tr511:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -807,12 +806,12 @@ tr511:
     }
 	goto st0;
 tr517:
-#line 323 "src/vcf/vcf_v43.ragel"
+#line 322 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -824,12 +823,12 @@ tr517:
     }
 	goto st0;
 tr527:
-#line 318 "src/vcf/vcf_v43.ragel"
+#line 317 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -841,12 +840,12 @@ tr527:
     }
 	goto st0;
 tr564:
-#line 313 "src/vcf/vcf_v43.ragel"
+#line 312 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -858,7 +857,7 @@ tr564:
     }
 	goto st0;
 tr569:
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 355 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -870,12 +869,12 @@ tr569:
     }
 	goto st0;
 tr580:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 355 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -887,7 +886,7 @@ tr580:
     }
 	goto st0;
 tr620:
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 257 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -899,12 +898,12 @@ tr620:
     }
 	goto st0;
 tr629:
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 371 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 257 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -916,7 +915,7 @@ tr629:
     }
 	goto st0;
 tr650:
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 263 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -928,12 +927,12 @@ tr650:
     }
 	goto st0;
 tr661:
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 263 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -945,7 +944,7 @@ tr661:
     }
 	goto st0;
 tr699:
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 328 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -957,12 +956,12 @@ tr699:
     }
 	goto st0;
 tr711:
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 371 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 328 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -974,7 +973,7 @@ tr711:
     }
 	goto st0;
 tr734:
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 377 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -1018,7 +1017,7 @@ tr774:
     }
 	goto st0;
 tr789:
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 394 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st723;}
@@ -1030,7 +1029,7 @@ tr789:
     }
 	goto st0;
 tr792:
-#line 401 "src/vcf/vcf_v43.ragel"
+#line 400 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st723;}
@@ -1042,7 +1041,7 @@ tr792:
     }
 	goto st0;
 tr796:
-#line 407 "src/vcf/vcf_v43.ragel"
+#line 406 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st723;}
@@ -1054,7 +1053,7 @@ tr796:
     }
 	goto st0;
 tr801:
-#line 413 "src/vcf/vcf_v43.ragel"
+#line 412 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st723;}
@@ -1066,7 +1065,7 @@ tr801:
     }
 	goto st0;
 tr805:
-#line 419 "src/vcf/vcf_v43.ragel"
+#line 418 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st723;}
@@ -1078,7 +1077,7 @@ tr805:
     }
 	goto st0;
 tr814:
-#line 425 "src/vcf/vcf_v43.ragel"
+#line 424 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st723;}
@@ -1090,7 +1089,7 @@ tr814:
     }
 	goto st0;
 tr825:
-#line 431 "src/vcf/vcf_v43.ragel"
+#line 430 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st723;}
@@ -1102,12 +1101,12 @@ tr825:
     }
 	goto st0;
 tr833:
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1119,7 +1118,7 @@ tr833:
     }
 	goto st0;
 tr847:
-#line 621 "src/vcf/vcf_v43.ragel"
+#line 620 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st723;}
@@ -1131,14 +1130,14 @@ tr847:
     }
 	goto st0;
 tr852:
-#line 634 "src/vcf/vcf_v43.ragel"
+#line 633 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st723;}
     }
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 626 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1159,7 +1158,7 @@ tr860:
     }
 	goto st0;
 tr862:
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 626 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -1173,12 +1172,12 @@ tr862:
     }
 	goto st0;
 tr864:
-#line 447 "src/vcf/vcf_v43.ragel"
+#line 446 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1190,7 +1189,7 @@ tr864:
     }
 	goto st0;
 tr866:
-#line 612 "src/vcf/vcf_v43.ragel"
+#line 611 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1198,7 +1197,7 @@ tr866:
                 "1000G"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1210,7 +1209,7 @@ tr866:
     }
 	goto st0;
 tr870:
-#line 452 "src/vcf/vcf_v43.ragel"
+#line 451 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1218,7 +1217,7 @@ tr870:
                 "AA"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1230,7 +1229,7 @@ tr870:
     }
 	goto st0;
 tr873:
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 459 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1238,7 +1237,7 @@ tr873:
                 "AC"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1250,7 +1249,7 @@ tr873:
     }
 	goto st0;
 tr878:
-#line 468 "src/vcf/vcf_v43.ragel"
+#line 467 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1258,7 +1257,7 @@ tr878:
                 "AD"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1270,7 +1269,7 @@ tr878:
     }
 	goto st0;
 tr881:
-#line 476 "src/vcf/vcf_v43.ragel"
+#line 475 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1278,7 +1277,7 @@ tr881:
                 "ADF"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1290,7 +1289,7 @@ tr881:
     }
 	goto st0;
 tr884:
-#line 484 "src/vcf/vcf_v43.ragel"
+#line 483 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1298,7 +1297,7 @@ tr884:
                 "ADR"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1310,7 +1309,7 @@ tr884:
     }
 	goto st0;
 tr887:
-#line 492 "src/vcf/vcf_v43.ragel"
+#line 491 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1318,7 +1317,7 @@ tr887:
                 "AF"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1330,7 +1329,7 @@ tr887:
     }
 	goto st0;
 tr899:
-#line 500 "src/vcf/vcf_v43.ragel"
+#line 499 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1338,7 +1337,7 @@ tr899:
                 "AN"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1350,7 +1349,7 @@ tr899:
     }
 	goto st0;
 tr902:
-#line 508 "src/vcf/vcf_v43.ragel"
+#line 507 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1358,7 +1357,7 @@ tr902:
                 "BQ"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1370,7 +1369,7 @@ tr902:
     }
 	goto st0;
 tr914:
-#line 516 "src/vcf/vcf_v43.ragel"
+#line 515 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1378,7 +1377,7 @@ tr914:
                 "CIGAR"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1390,7 +1389,7 @@ tr914:
     }
 	goto st0;
 tr917:
-#line 524 "src/vcf/vcf_v43.ragel"
+#line 523 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1398,7 +1397,7 @@ tr917:
                 "DB"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1410,7 +1409,7 @@ tr917:
     }
 	goto st0;
 tr920:
-#line 532 "src/vcf/vcf_v43.ragel"
+#line 531 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1418,7 +1417,7 @@ tr920:
                 "DP"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1430,7 +1429,7 @@ tr920:
     }
 	goto st0;
 tr923:
-#line 540 "src/vcf/vcf_v43.ragel"
+#line 539 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1438,7 +1437,7 @@ tr923:
                 "END"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1450,7 +1449,7 @@ tr923:
     }
 	goto st0;
 tr925:
-#line 548 "src/vcf/vcf_v43.ragel"
+#line 547 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1458,7 +1457,7 @@ tr925:
                 "H2"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1470,7 +1469,7 @@ tr925:
     }
 	goto st0;
 tr927:
-#line 556 "src/vcf/vcf_v43.ragel"
+#line 555 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1478,7 +1477,7 @@ tr927:
                 "H3"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1490,7 +1489,7 @@ tr927:
     }
 	goto st0;
 tr932:
-#line 572 "src/vcf/vcf_v43.ragel"
+#line 571 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1498,7 +1497,7 @@ tr932:
                 "MQ0"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1510,7 +1509,7 @@ tr932:
     }
 	goto st0;
 tr934:
-#line 564 "src/vcf/vcf_v43.ragel"
+#line 563 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1518,7 +1517,7 @@ tr934:
                 "MQ"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1530,7 +1529,7 @@ tr934:
     }
 	goto st0;
 tr946:
-#line 580 "src/vcf/vcf_v43.ragel"
+#line 579 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1538,7 +1537,7 @@ tr946:
                 "NS"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1550,7 +1549,7 @@ tr946:
     }
 	goto st0;
 tr949:
-#line 588 "src/vcf/vcf_v43.ragel"
+#line 587 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1558,7 +1557,7 @@ tr949:
                 "SB"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1570,7 +1569,7 @@ tr949:
     }
 	goto st0;
 tr960:
-#line 596 "src/vcf/vcf_v43.ragel"
+#line 595 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1578,7 +1577,7 @@ tr960:
                 "SOMATIC"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1590,7 +1589,7 @@ tr960:
     }
 	goto st0;
 tr962:
-#line 604 "src/vcf/vcf_v43.ragel"
+#line 603 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1598,7 +1597,7 @@ tr962:
                 "VALIDATED"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1623,7 +1622,7 @@ tr1011:
         
         p--; {goto st723;}
     }
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 394 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st723;}
@@ -1635,7 +1634,7 @@ tr1011:
     }
 	goto st0;
 tr1018:
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1647,7 +1646,7 @@ tr1018:
     }
 	goto st0;
 tr1034:
-#line 612 "src/vcf/vcf_v43.ragel"
+#line 611 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1655,12 +1654,12 @@ tr1034:
                 "1000G"});
         p--; {goto st723;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1672,7 +1671,7 @@ tr1034:
     }
 	goto st0;
 tr1052:
-#line 524 "src/vcf/vcf_v43.ragel"
+#line 523 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1680,12 +1679,12 @@ tr1052:
                 "DB"});
         p--; {goto st723;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1697,7 +1696,7 @@ tr1052:
     }
 	goto st0;
 tr1058:
-#line 548 "src/vcf/vcf_v43.ragel"
+#line 547 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1705,12 +1704,12 @@ tr1058:
                 "H2"});
         p--; {goto st723;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1722,7 +1721,7 @@ tr1058:
     }
 	goto st0;
 tr1060:
-#line 556 "src/vcf/vcf_v43.ragel"
+#line 555 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1730,12 +1729,12 @@ tr1060:
                 "H3"});
         p--; {goto st723;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1747,7 +1746,7 @@ tr1060:
     }
 	goto st0;
 tr1075:
-#line 596 "src/vcf/vcf_v43.ragel"
+#line 595 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1755,12 +1754,12 @@ tr1075:
                 "SOMATIC"});
         p--; {goto st723;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1772,7 +1771,7 @@ tr1075:
     }
 	goto st0;
 tr1085:
-#line 604 "src/vcf/vcf_v43.ragel"
+#line 603 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -1780,12 +1779,12 @@ tr1085:
                 "VALIDATED"});
         p--; {goto st723;}
     }
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -1796,7 +1795,7 @@ tr1085:
         p--; {goto st723;}
     }
 	goto st0;
-#line 1800 "inc/vcf/validator_detail_v43.hpp"
+#line 1799 "inc/vcf/validator_detail_v43.hpp"
 st0:
 cs = 0;
 	goto _out;
@@ -1905,7 +1904,7 @@ st15:
 	if ( ++p == pe )
 		goto _test_eof15;
 case 15:
-#line 1909 "inc/vcf/validator_detail_v43.hpp"
+#line 1908 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 67 )
 		goto tr16;
 	goto tr14;
@@ -1919,7 +1918,7 @@ st16:
 	if ( ++p == pe )
 		goto _test_eof16;
 case 16:
-#line 1923 "inc/vcf/validator_detail_v43.hpp"
+#line 1922 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto tr17;
 	goto tr14;
@@ -1933,7 +1932,7 @@ st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1937 "inc/vcf/validator_detail_v43.hpp"
+#line 1936 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 118 )
 		goto tr18;
 	goto tr14;
@@ -1947,7 +1946,7 @@ st18:
 	if ( ++p == pe )
 		goto _test_eof18;
 case 18:
-#line 1951 "inc/vcf/validator_detail_v43.hpp"
+#line 1950 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 52 )
 		goto tr19;
 	goto tr14;
@@ -1961,7 +1960,7 @@ st19:
 	if ( ++p == pe )
 		goto _test_eof19;
 case 19:
-#line 1965 "inc/vcf/validator_detail_v43.hpp"
+#line 1964 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr20;
 	goto tr14;
@@ -1975,7 +1974,7 @@ st20:
 	if ( ++p == pe )
 		goto _test_eof20;
 case 20:
-#line 1979 "inc/vcf/validator_detail_v43.hpp"
+#line 1978 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 51 )
 		goto tr21;
 	goto tr14;
@@ -1989,7 +1988,7 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 1993 "inc/vcf/validator_detail_v43.hpp"
+#line 1992 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr22;
 		case 13: goto tr23;
@@ -2020,7 +2019,7 @@ st22:
 	if ( ++p == pe )
 		goto _test_eof22;
 case 22:
-#line 2024 "inc/vcf/validator_detail_v43.hpp"
+#line 2023 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr24;
@@ -2074,7 +2073,7 @@ st25:
 	if ( ++p == pe )
 		goto _test_eof25;
 case 25:
-#line 2078 "inc/vcf/validator_detail_v43.hpp"
+#line 2077 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr42;
 	if ( 32 <= (*p) && (*p) <= 126 )
@@ -2090,7 +2089,7 @@ st26:
 	if ( ++p == pe )
 		goto _test_eof26;
 case 26:
-#line 2094 "inc/vcf/validator_detail_v43.hpp"
+#line 2093 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto st30;
 		case 60: goto st35;
@@ -2118,7 +2117,7 @@ st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 2122 "inc/vcf/validator_detail_v43.hpp"
+#line 2121 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr47;
@@ -2174,7 +2173,7 @@ st28:
 	if ( ++p == pe )
 		goto _test_eof28;
 case 28:
-#line 2178 "inc/vcf/validator_detail_v43.hpp"
+#line 2177 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 35 )
 		goto st23;
 	goto tr26;
@@ -2226,7 +2225,7 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 2230 "inc/vcf/validator_detail_v43.hpp"
+#line 2229 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st28;
 	goto tr40;
@@ -2261,7 +2260,7 @@ st31:
 	if ( ++p == pe )
 		goto _test_eof31;
 case 31:
-#line 2265 "inc/vcf/validator_detail_v43.hpp"
+#line 2264 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr54;
 		case 92: goto tr55;
@@ -2289,7 +2288,7 @@ st32:
 	if ( ++p == pe )
 		goto _test_eof32;
 case 32:
-#line 2293 "inc/vcf/validator_detail_v43.hpp"
+#line 2292 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2315,7 +2314,7 @@ st33:
 	if ( ++p == pe )
 		goto _test_eof33;
 case 33:
-#line 2319 "inc/vcf/validator_detail_v43.hpp"
+#line 2318 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr58;
 		case 92: goto tr55;
@@ -2337,7 +2336,7 @@ st34:
 	if ( ++p == pe )
 		goto _test_eof34;
 case 34:
-#line 2341 "inc/vcf/validator_detail_v43.hpp"
+#line 2340 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2398,7 +2397,7 @@ st37:
 	if ( ++p == pe )
 		goto _test_eof37;
 case 37:
-#line 2402 "inc/vcf/validator_detail_v43.hpp"
+#line 2401 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 92: goto tr67;
@@ -2426,7 +2425,7 @@ st38:
 	if ( ++p == pe )
 		goto _test_eof38;
 case 38:
-#line 2430 "inc/vcf/validator_detail_v43.hpp"
+#line 2429 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto st32;
 	goto tr40;
@@ -2450,7 +2449,7 @@ st39:
 	if ( ++p == pe )
 		goto _test_eof39;
 case 39:
-#line 2454 "inc/vcf/validator_detail_v43.hpp"
+#line 2453 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr69;
 		case 92: goto tr67;
@@ -2472,7 +2471,7 @@ st40:
 	if ( ++p == pe )
 		goto _test_eof40;
 case 40:
-#line 2476 "inc/vcf/validator_detail_v43.hpp"
+#line 2475 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr66;
 		case 62: goto tr70;
@@ -2491,7 +2490,7 @@ st41:
 	if ( ++p == pe )
 		goto _test_eof41;
 case 41:
-#line 2495 "inc/vcf/validator_detail_v43.hpp"
+#line 2494 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -2511,7 +2510,7 @@ st42:
 	if ( ++p == pe )
 		goto _test_eof42;
 case 42:
-#line 2515 "inc/vcf/validator_detail_v43.hpp"
+#line 2514 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st42;
 	if ( (*p) < 48 ) {
@@ -2546,7 +2545,7 @@ st43:
 	if ( ++p == pe )
 		goto _test_eof43;
 case 43:
-#line 2550 "inc/vcf/validator_detail_v43.hpp"
+#line 2549 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr73;
 		case 95: goto tr72;
@@ -2573,7 +2572,7 @@ st44:
 	if ( ++p == pe )
 		goto _test_eof44;
 case 44:
-#line 2577 "inc/vcf/validator_detail_v43.hpp"
+#line 2576 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st63;
 	if ( (*p) < 45 ) {
@@ -2605,7 +2604,7 @@ st45:
 	if ( ++p == pe )
 		goto _test_eof45;
 case 45:
-#line 2609 "inc/vcf/validator_detail_v43.hpp"
+#line 2608 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr77;
 		case 62: goto tr54;
@@ -2626,7 +2625,7 @@ st46:
 	if ( ++p == pe )
 		goto _test_eof46;
 case 46:
-#line 2630 "inc/vcf/validator_detail_v43.hpp"
+#line 2629 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr78;
 	if ( (*p) < 48 ) {
@@ -2651,7 +2650,7 @@ st47:
 	if ( ++p == pe )
 		goto _test_eof47;
 case 47:
-#line 2655 "inc/vcf/validator_detail_v43.hpp"
+#line 2654 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st47;
 	if ( (*p) < 48 ) {
@@ -2686,7 +2685,7 @@ st48:
 	if ( ++p == pe )
 		goto _test_eof48;
 case 48:
-#line 2690 "inc/vcf/validator_detail_v43.hpp"
+#line 2689 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr82;
 		case 95: goto tr81;
@@ -2713,7 +2712,7 @@ st49:
 	if ( ++p == pe )
 		goto _test_eof49;
 case 49:
-#line 2717 "inc/vcf/validator_detail_v43.hpp"
+#line 2716 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st50;
 	if ( (*p) < 45 ) {
@@ -2756,7 +2755,7 @@ st51:
 	if ( ++p == pe )
 		goto _test_eof51;
 case 51:
-#line 2760 "inc/vcf/validator_detail_v43.hpp"
+#line 2759 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr89;
@@ -2784,7 +2783,7 @@ st52:
 	if ( ++p == pe )
 		goto _test_eof52;
 case 52:
-#line 2788 "inc/vcf/validator_detail_v43.hpp"
+#line 2787 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st46;
 		case 62: goto st32;
@@ -2810,7 +2809,7 @@ st53:
 	if ( ++p == pe )
 		goto _test_eof53;
 case 53:
-#line 2814 "inc/vcf/validator_detail_v43.hpp"
+#line 2813 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 92: goto tr89;
@@ -2832,7 +2831,7 @@ st54:
 	if ( ++p == pe )
 		goto _test_eof54;
 case 54:
-#line 2836 "inc/vcf/validator_detail_v43.hpp"
+#line 2835 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr92;
@@ -2872,7 +2871,7 @@ st55:
 	if ( ++p == pe )
 		goto _test_eof55;
 case 55:
-#line 2876 "inc/vcf/validator_detail_v43.hpp"
+#line 2875 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2923,7 +2922,7 @@ st56:
 	if ( ++p == pe )
 		goto _test_eof56;
 case 56:
-#line 2927 "inc/vcf/validator_detail_v43.hpp"
+#line 2926 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -2974,7 +2973,7 @@ st57:
 	if ( ++p == pe )
 		goto _test_eof57;
 case 57:
-#line 2978 "inc/vcf/validator_detail_v43.hpp"
+#line 2977 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr87;
@@ -3017,7 +3016,7 @@ st58:
 	if ( ++p == pe )
 		goto _test_eof58;
 case 58:
-#line 3021 "inc/vcf/validator_detail_v43.hpp"
+#line 3020 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr87;
@@ -3047,7 +3046,7 @@ st59:
 	if ( ++p == pe )
 		goto _test_eof59;
 case 59:
-#line 3051 "inc/vcf/validator_detail_v43.hpp"
+#line 3050 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr103;
@@ -3087,7 +3086,7 @@ st60:
 	if ( ++p == pe )
 		goto _test_eof60;
 case 60:
-#line 3091 "inc/vcf/validator_detail_v43.hpp"
+#line 3090 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3117,7 +3116,7 @@ st61:
 	if ( ++p == pe )
 		goto _test_eof61;
 case 61:
-#line 3121 "inc/vcf/validator_detail_v43.hpp"
+#line 3120 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr91;
 		case 44: goto tr103;
@@ -3137,7 +3136,7 @@ st62:
 	if ( ++p == pe )
 		goto _test_eof62;
 case 62:
-#line 3141 "inc/vcf/validator_detail_v43.hpp"
+#line 3140 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr85;
 		case 44: goto tr106;
@@ -3178,7 +3177,7 @@ st64:
 	if ( ++p == pe )
 		goto _test_eof64;
 case 64:
-#line 3182 "inc/vcf/validator_detail_v43.hpp"
+#line 3181 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 92: goto tr111;
@@ -3206,7 +3205,7 @@ st65:
 	if ( ++p == pe )
 		goto _test_eof65;
 case 65:
-#line 3210 "inc/vcf/validator_detail_v43.hpp"
+#line 3209 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 92: goto tr111;
@@ -3228,7 +3227,7 @@ st66:
 	if ( ++p == pe )
 		goto _test_eof66;
 case 66:
-#line 3232 "inc/vcf/validator_detail_v43.hpp"
+#line 3231 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr113;
@@ -3258,7 +3257,7 @@ st67:
 	if ( ++p == pe )
 		goto _test_eof67;
 case 67:
-#line 3262 "inc/vcf/validator_detail_v43.hpp"
+#line 3261 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3309,7 +3308,7 @@ st68:
 	if ( ++p == pe )
 		goto _test_eof68;
 case 68:
-#line 3313 "inc/vcf/validator_detail_v43.hpp"
+#line 3312 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3360,7 +3359,7 @@ st69:
 	if ( ++p == pe )
 		goto _test_eof69;
 case 69:
-#line 3364 "inc/vcf/validator_detail_v43.hpp"
+#line 3363 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 47: goto tr110;
@@ -3403,7 +3402,7 @@ st70:
 	if ( ++p == pe )
 		goto _test_eof70;
 case 70:
-#line 3407 "inc/vcf/validator_detail_v43.hpp"
+#line 3406 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr100;
 		case 44: goto tr110;
@@ -3433,7 +3432,7 @@ st71:
 	if ( ++p == pe )
 		goto _test_eof71;
 case 71:
-#line 3437 "inc/vcf/validator_detail_v43.hpp"
+#line 3436 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr88;
 		case 44: goto tr123;
@@ -3463,7 +3462,7 @@ st72:
 	if ( ++p == pe )
 		goto _test_eof72;
 case 72:
-#line 3467 "inc/vcf/validator_detail_v43.hpp"
+#line 3466 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -3493,7 +3492,7 @@ st73:
 	if ( ++p == pe )
 		goto _test_eof73;
 case 73:
-#line 3497 "inc/vcf/validator_detail_v43.hpp"
+#line 3496 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr112;
 		case 44: goto tr123;
@@ -3517,7 +3516,7 @@ st74:
 	if ( ++p == pe )
 		goto _test_eof74;
 case 74:
-#line 3521 "inc/vcf/validator_detail_v43.hpp"
+#line 3520 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr127;
@@ -3535,7 +3534,7 @@ st75:
 	if ( ++p == pe )
 		goto _test_eof75;
 case 75:
-#line 3539 "inc/vcf/validator_detail_v43.hpp"
+#line 3538 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st76;
@@ -3562,7 +3561,7 @@ st77:
 	if ( ++p == pe )
 		goto _test_eof77;
 case 77:
-#line 3566 "inc/vcf/validator_detail_v43.hpp"
+#line 3565 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st78;
 	goto tr126;
@@ -3634,7 +3633,7 @@ st82:
 	if ( ++p == pe )
 		goto _test_eof82;
 case 82:
-#line 3638 "inc/vcf/validator_detail_v43.hpp"
+#line 3637 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto st82;
 	if ( (*p) < 63 ) {
@@ -3688,7 +3687,7 @@ st83:
 	if ( ++p == pe )
 		goto _test_eof83;
 case 83:
-#line 3692 "inc/vcf/validator_detail_v43.hpp"
+#line 3691 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr139;
 		case 61: goto tr138;
@@ -3709,7 +3708,7 @@ st84:
 	if ( ++p == pe )
 		goto _test_eof84;
 case 84:
-#line 3713 "inc/vcf/validator_detail_v43.hpp"
+#line 3712 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st85;
 	goto tr126;
@@ -3807,7 +3806,7 @@ st97:
 	if ( ++p == pe )
 		goto _test_eof97;
 case 97:
-#line 3811 "inc/vcf/validator_detail_v43.hpp"
+#line 3810 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 92: goto tr156;
@@ -3835,7 +3834,7 @@ st98:
 	if ( ++p == pe )
 		goto _test_eof98;
 case 98:
-#line 3839 "inc/vcf/validator_detail_v43.hpp"
+#line 3838 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr159;
@@ -3863,7 +3862,7 @@ st99:
 	if ( ++p == pe )
 		goto _test_eof99;
 case 99:
-#line 3867 "inc/vcf/validator_detail_v43.hpp"
+#line 3866 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st100;
 		case 62: goto st114;
@@ -3897,7 +3896,7 @@ st101:
 	if ( ++p == pe )
 		goto _test_eof101;
 case 101:
-#line 3901 "inc/vcf/validator_detail_v43.hpp"
+#line 3900 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st101;
 	if ( (*p) < 48 ) {
@@ -3932,7 +3931,7 @@ st102:
 	if ( ++p == pe )
 		goto _test_eof102;
 case 102:
-#line 3936 "inc/vcf/validator_detail_v43.hpp"
+#line 3935 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr167;
 		case 95: goto tr166;
@@ -3959,7 +3958,7 @@ st103:
 	if ( ++p == pe )
 		goto _test_eof103;
 case 103:
-#line 3963 "inc/vcf/validator_detail_v43.hpp"
+#line 3962 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st104;
 	goto tr126;
@@ -3994,7 +3993,7 @@ st105:
 	if ( ++p == pe )
 		goto _test_eof105;
 case 105:
-#line 3998 "inc/vcf/validator_detail_v43.hpp"
+#line 3997 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 92: goto tr172;
@@ -4022,7 +4021,7 @@ st106:
 	if ( ++p == pe )
 		goto _test_eof106;
 case 106:
-#line 4026 "inc/vcf/validator_detail_v43.hpp"
+#line 4025 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr173;
 		case 92: goto tr172;
@@ -4044,7 +4043,7 @@ st107:
 	if ( ++p == pe )
 		goto _test_eof107;
 case 107:
-#line 4048 "inc/vcf/validator_detail_v43.hpp"
+#line 4047 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr174;
@@ -4074,7 +4073,7 @@ st108:
 	if ( ++p == pe )
 		goto _test_eof108;
 case 108:
-#line 4078 "inc/vcf/validator_detail_v43.hpp"
+#line 4077 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4125,7 +4124,7 @@ st109:
 	if ( ++p == pe )
 		goto _test_eof109;
 case 109:
-#line 4129 "inc/vcf/validator_detail_v43.hpp"
+#line 4128 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4176,7 +4175,7 @@ st110:
 	if ( ++p == pe )
 		goto _test_eof110;
 case 110:
-#line 4180 "inc/vcf/validator_detail_v43.hpp"
+#line 4179 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr171;
@@ -4219,7 +4218,7 @@ st111:
 	if ( ++p == pe )
 		goto _test_eof111;
 case 111:
-#line 4223 "inc/vcf/validator_detail_v43.hpp"
+#line 4222 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr172;
@@ -4237,7 +4236,7 @@ st112:
 	if ( ++p == pe )
 		goto _test_eof112;
 case 112:
-#line 4241 "inc/vcf/validator_detail_v43.hpp"
+#line 4240 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr155;
 		case 44: goto tr183;
@@ -4267,7 +4266,7 @@ st113:
 	if ( ++p == pe )
 		goto _test_eof113;
 case 113:
-#line 4271 "inc/vcf/validator_detail_v43.hpp"
+#line 4270 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4306,7 +4305,7 @@ st115:
 	if ( ++p == pe )
 		goto _test_eof115;
 case 115:
-#line 4310 "inc/vcf/validator_detail_v43.hpp"
+#line 4309 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr185;
 		case 92: goto tr159;
@@ -4328,7 +4327,7 @@ st116:
 	if ( ++p == pe )
 		goto _test_eof116;
 case 116:
-#line 4332 "inc/vcf/validator_detail_v43.hpp"
+#line 4331 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 44: goto tr186;
@@ -4348,7 +4347,7 @@ st117:
 	if ( ++p == pe )
 		goto _test_eof117;
 case 117:
-#line 4352 "inc/vcf/validator_detail_v43.hpp"
+#line 4351 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4399,7 +4398,7 @@ st118:
 	if ( ++p == pe )
 		goto _test_eof118;
 case 118:
-#line 4403 "inc/vcf/validator_detail_v43.hpp"
+#line 4402 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4450,7 +4449,7 @@ st119:
 	if ( ++p == pe )
 		goto _test_eof119;
 case 119:
-#line 4454 "inc/vcf/validator_detail_v43.hpp"
+#line 4453 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr158;
 		case 47: goto tr157;
@@ -4493,7 +4492,7 @@ st120:
 	if ( ++p == pe )
 		goto _test_eof120;
 case 120:
-#line 4497 "inc/vcf/validator_detail_v43.hpp"
+#line 4496 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr182;
 		case 92: goto tr159;
@@ -4511,7 +4510,7 @@ st121:
 	if ( ++p == pe )
 		goto _test_eof121;
 case 121:
-#line 4515 "inc/vcf/validator_detail_v43.hpp"
+#line 4514 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -4535,7 +4534,7 @@ st122:
 	if ( ++p == pe )
 		goto _test_eof122;
 case 122:
-#line 4539 "inc/vcf/validator_detail_v43.hpp"
+#line 4538 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr195;
@@ -4554,7 +4553,7 @@ st123:
 	if ( ++p == pe )
 		goto _test_eof123;
 case 123:
-#line 4558 "inc/vcf/validator_detail_v43.hpp"
+#line 4557 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr198;
@@ -4572,7 +4571,7 @@ st124:
 	if ( ++p == pe )
 		goto _test_eof124;
 case 124:
-#line 4576 "inc/vcf/validator_detail_v43.hpp"
+#line 4575 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr199;
@@ -4590,7 +4589,7 @@ st125:
 	if ( ++p == pe )
 		goto _test_eof125;
 case 125:
-#line 4594 "inc/vcf/validator_detail_v43.hpp"
+#line 4593 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr200;
@@ -4608,7 +4607,7 @@ st126:
 	if ( ++p == pe )
 		goto _test_eof126;
 case 126:
-#line 4612 "inc/vcf/validator_detail_v43.hpp"
+#line 4611 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto st127;
@@ -4635,7 +4634,7 @@ st128:
 	if ( ++p == pe )
 		goto _test_eof128;
 case 128:
-#line 4639 "inc/vcf/validator_detail_v43.hpp"
+#line 4638 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st129;
 	goto tr197;
@@ -4692,7 +4691,7 @@ st133:
 	if ( ++p == pe )
 		goto _test_eof133;
 case 133:
-#line 4696 "inc/vcf/validator_detail_v43.hpp"
+#line 4695 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st133;
 	if ( (*p) < 48 ) {
@@ -4731,7 +4730,7 @@ st134:
 	if ( ++p == pe )
 		goto _test_eof134;
 case 134:
-#line 4735 "inc/vcf/validator_detail_v43.hpp"
+#line 4734 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr212;
 		case 95: goto tr211;
@@ -4758,7 +4757,7 @@ st135:
 	if ( ++p == pe )
 		goto _test_eof135;
 case 135:
-#line 4762 "inc/vcf/validator_detail_v43.hpp"
+#line 4761 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st136;
 	goto tr197;
@@ -4856,7 +4855,7 @@ st148:
 	if ( ++p == pe )
 		goto _test_eof148;
 case 148:
-#line 4860 "inc/vcf/validator_detail_v43.hpp"
+#line 4859 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 92: goto tr229;
@@ -4884,7 +4883,7 @@ st149:
 	if ( ++p == pe )
 		goto _test_eof149;
 case 149:
-#line 4888 "inc/vcf/validator_detail_v43.hpp"
+#line 4887 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr232;
@@ -4912,7 +4911,7 @@ st150:
 	if ( ++p == pe )
 		goto _test_eof150;
 case 150:
-#line 4916 "inc/vcf/validator_detail_v43.hpp"
+#line 4915 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st151;
 		case 62: goto st165;
@@ -4946,7 +4945,7 @@ st152:
 	if ( ++p == pe )
 		goto _test_eof152;
 case 152:
-#line 4950 "inc/vcf/validator_detail_v43.hpp"
+#line 4949 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st152;
 	if ( (*p) < 48 ) {
@@ -4981,7 +4980,7 @@ st153:
 	if ( ++p == pe )
 		goto _test_eof153;
 case 153:
-#line 4985 "inc/vcf/validator_detail_v43.hpp"
+#line 4984 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr239;
 		case 95: goto tr238;
@@ -5008,7 +5007,7 @@ st154:
 	if ( ++p == pe )
 		goto _test_eof154;
 case 154:
-#line 5012 "inc/vcf/validator_detail_v43.hpp"
+#line 5011 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st155;
 	goto tr197;
@@ -5043,7 +5042,7 @@ st156:
 	if ( ++p == pe )
 		goto _test_eof156;
 case 156:
-#line 5047 "inc/vcf/validator_detail_v43.hpp"
+#line 5046 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 92: goto tr244;
@@ -5071,7 +5070,7 @@ st157:
 	if ( ++p == pe )
 		goto _test_eof157;
 case 157:
-#line 5075 "inc/vcf/validator_detail_v43.hpp"
+#line 5074 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr245;
 		case 92: goto tr244;
@@ -5093,7 +5092,7 @@ st158:
 	if ( ++p == pe )
 		goto _test_eof158;
 case 158:
-#line 5097 "inc/vcf/validator_detail_v43.hpp"
+#line 5096 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr246;
@@ -5123,7 +5122,7 @@ st159:
 	if ( ++p == pe )
 		goto _test_eof159;
 case 159:
-#line 5127 "inc/vcf/validator_detail_v43.hpp"
+#line 5126 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5174,7 +5173,7 @@ st160:
 	if ( ++p == pe )
 		goto _test_eof160;
 case 160:
-#line 5178 "inc/vcf/validator_detail_v43.hpp"
+#line 5177 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5225,7 +5224,7 @@ st161:
 	if ( ++p == pe )
 		goto _test_eof161;
 case 161:
-#line 5229 "inc/vcf/validator_detail_v43.hpp"
+#line 5228 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr243;
@@ -5268,7 +5267,7 @@ st162:
 	if ( ++p == pe )
 		goto _test_eof162;
 case 162:
-#line 5272 "inc/vcf/validator_detail_v43.hpp"
+#line 5271 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr244;
@@ -5286,7 +5285,7 @@ st163:
 	if ( ++p == pe )
 		goto _test_eof163;
 case 163:
-#line 5290 "inc/vcf/validator_detail_v43.hpp"
+#line 5289 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr228;
 		case 44: goto tr255;
@@ -5316,7 +5315,7 @@ st164:
 	if ( ++p == pe )
 		goto _test_eof164;
 case 164:
-#line 5320 "inc/vcf/validator_detail_v43.hpp"
+#line 5319 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5355,7 +5354,7 @@ st166:
 	if ( ++p == pe )
 		goto _test_eof166;
 case 166:
-#line 5359 "inc/vcf/validator_detail_v43.hpp"
+#line 5358 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr257;
 		case 92: goto tr232;
@@ -5377,7 +5376,7 @@ st167:
 	if ( ++p == pe )
 		goto _test_eof167;
 case 167:
-#line 5381 "inc/vcf/validator_detail_v43.hpp"
+#line 5380 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 44: goto tr258;
@@ -5397,7 +5396,7 @@ st168:
 	if ( ++p == pe )
 		goto _test_eof168;
 case 168:
-#line 5401 "inc/vcf/validator_detail_v43.hpp"
+#line 5400 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5448,7 +5447,7 @@ st169:
 	if ( ++p == pe )
 		goto _test_eof169;
 case 169:
-#line 5452 "inc/vcf/validator_detail_v43.hpp"
+#line 5451 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5499,7 +5498,7 @@ st170:
 	if ( ++p == pe )
 		goto _test_eof170;
 case 170:
-#line 5503 "inc/vcf/validator_detail_v43.hpp"
+#line 5502 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr231;
 		case 47: goto tr230;
@@ -5542,7 +5541,7 @@ st171:
 	if ( ++p == pe )
 		goto _test_eof171;
 case 171:
-#line 5546 "inc/vcf/validator_detail_v43.hpp"
+#line 5545 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr254;
 		case 92: goto tr232;
@@ -5560,7 +5559,7 @@ st172:
 	if ( ++p == pe )
 		goto _test_eof172;
 case 172:
-#line 5564 "inc/vcf/validator_detail_v43.hpp"
+#line 5563 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -5580,7 +5579,7 @@ st173:
 	if ( ++p == pe )
 		goto _test_eof173;
 case 173:
-#line 5584 "inc/vcf/validator_detail_v43.hpp"
+#line 5583 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr267;
@@ -5598,7 +5597,7 @@ st174:
 	if ( ++p == pe )
 		goto _test_eof174;
 case 174:
-#line 5602 "inc/vcf/validator_detail_v43.hpp"
+#line 5601 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr268;
@@ -5616,7 +5615,7 @@ st175:
 	if ( ++p == pe )
 		goto _test_eof175;
 case 175:
-#line 5620 "inc/vcf/validator_detail_v43.hpp"
+#line 5619 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr269;
@@ -5634,7 +5633,7 @@ st176:
 	if ( ++p == pe )
 		goto _test_eof176;
 case 176:
-#line 5638 "inc/vcf/validator_detail_v43.hpp"
+#line 5637 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto st177;
@@ -5661,7 +5660,7 @@ st178:
 	if ( ++p == pe )
 		goto _test_eof178;
 case 178:
-#line 5665 "inc/vcf/validator_detail_v43.hpp"
+#line 5664 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st179;
 	goto tr266;
@@ -5718,7 +5717,7 @@ st183:
 	if ( ++p == pe )
 		goto _test_eof183;
 case 183:
-#line 5722 "inc/vcf/validator_detail_v43.hpp"
+#line 5721 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st183;
 	if ( (*p) < 48 ) {
@@ -5757,7 +5756,7 @@ st184:
 	if ( ++p == pe )
 		goto _test_eof184;
 case 184:
-#line 5761 "inc/vcf/validator_detail_v43.hpp"
+#line 5760 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr281;
 		case 95: goto tr280;
@@ -5784,7 +5783,7 @@ st185:
 	if ( ++p == pe )
 		goto _test_eof185;
 case 185:
-#line 5788 "inc/vcf/validator_detail_v43.hpp"
+#line 5787 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st186;
 	goto tr266;
@@ -5861,7 +5860,7 @@ st193:
 	if ( ++p == pe )
 		goto _test_eof193;
 case 193:
-#line 5865 "inc/vcf/validator_detail_v43.hpp"
+#line 5864 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	goto tr289;
@@ -5875,7 +5874,7 @@ st194:
 	if ( ++p == pe )
 		goto _test_eof194;
 case 194:
-#line 5879 "inc/vcf/validator_detail_v43.hpp"
+#line 5878 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st195;
 	goto tr266;
@@ -5941,7 +5940,7 @@ st200:
 	if ( ++p == pe )
 		goto _test_eof200;
 case 200:
-#line 5945 "inc/vcf/validator_detail_v43.hpp"
+#line 5944 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr300;
 	if ( (*p) > 90 ) {
@@ -5960,7 +5959,7 @@ st201:
 	if ( ++p == pe )
 		goto _test_eof201;
 case 201:
-#line 5964 "inc/vcf/validator_detail_v43.hpp"
+#line 5963 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st202;
 	goto tr266;
@@ -6058,7 +6057,7 @@ st214:
 	if ( ++p == pe )
 		goto _test_eof214;
 case 214:
-#line 6062 "inc/vcf/validator_detail_v43.hpp"
+#line 6061 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 92: goto tr318;
@@ -6086,7 +6085,7 @@ st215:
 	if ( ++p == pe )
 		goto _test_eof215;
 case 215:
-#line 6090 "inc/vcf/validator_detail_v43.hpp"
+#line 6089 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr321;
@@ -6114,7 +6113,7 @@ st216:
 	if ( ++p == pe )
 		goto _test_eof216;
 case 216:
-#line 6118 "inc/vcf/validator_detail_v43.hpp"
+#line 6117 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st217;
 		case 62: goto st231;
@@ -6148,7 +6147,7 @@ st218:
 	if ( ++p == pe )
 		goto _test_eof218;
 case 218:
-#line 6152 "inc/vcf/validator_detail_v43.hpp"
+#line 6151 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st218;
 	if ( (*p) < 48 ) {
@@ -6183,7 +6182,7 @@ st219:
 	if ( ++p == pe )
 		goto _test_eof219;
 case 219:
-#line 6187 "inc/vcf/validator_detail_v43.hpp"
+#line 6186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr328;
 		case 95: goto tr327;
@@ -6210,7 +6209,7 @@ st220:
 	if ( ++p == pe )
 		goto _test_eof220;
 case 220:
-#line 6214 "inc/vcf/validator_detail_v43.hpp"
+#line 6213 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st221;
 	goto tr266;
@@ -6245,7 +6244,7 @@ st222:
 	if ( ++p == pe )
 		goto _test_eof222;
 case 222:
-#line 6249 "inc/vcf/validator_detail_v43.hpp"
+#line 6248 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 92: goto tr333;
@@ -6273,7 +6272,7 @@ st223:
 	if ( ++p == pe )
 		goto _test_eof223;
 case 223:
-#line 6277 "inc/vcf/validator_detail_v43.hpp"
+#line 6276 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr334;
 		case 92: goto tr333;
@@ -6295,7 +6294,7 @@ st224:
 	if ( ++p == pe )
 		goto _test_eof224;
 case 224:
-#line 6299 "inc/vcf/validator_detail_v43.hpp"
+#line 6298 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr335;
@@ -6325,7 +6324,7 @@ st225:
 	if ( ++p == pe )
 		goto _test_eof225;
 case 225:
-#line 6329 "inc/vcf/validator_detail_v43.hpp"
+#line 6328 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6376,7 +6375,7 @@ st226:
 	if ( ++p == pe )
 		goto _test_eof226;
 case 226:
-#line 6380 "inc/vcf/validator_detail_v43.hpp"
+#line 6379 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6427,7 +6426,7 @@ st227:
 	if ( ++p == pe )
 		goto _test_eof227;
 case 227:
-#line 6431 "inc/vcf/validator_detail_v43.hpp"
+#line 6430 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr332;
@@ -6470,7 +6469,7 @@ st228:
 	if ( ++p == pe )
 		goto _test_eof228;
 case 228:
-#line 6474 "inc/vcf/validator_detail_v43.hpp"
+#line 6473 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr333;
@@ -6488,7 +6487,7 @@ st229:
 	if ( ++p == pe )
 		goto _test_eof229;
 case 229:
-#line 6492 "inc/vcf/validator_detail_v43.hpp"
+#line 6491 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr317;
 		case 44: goto tr344;
@@ -6518,7 +6517,7 @@ st230:
 	if ( ++p == pe )
 		goto _test_eof230;
 case 230:
-#line 6522 "inc/vcf/validator_detail_v43.hpp"
+#line 6521 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6557,7 +6556,7 @@ st232:
 	if ( ++p == pe )
 		goto _test_eof232;
 case 232:
-#line 6561 "inc/vcf/validator_detail_v43.hpp"
+#line 6560 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr346;
 		case 92: goto tr321;
@@ -6579,7 +6578,7 @@ st233:
 	if ( ++p == pe )
 		goto _test_eof233;
 case 233:
-#line 6583 "inc/vcf/validator_detail_v43.hpp"
+#line 6582 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 44: goto tr347;
@@ -6599,7 +6598,7 @@ st234:
 	if ( ++p == pe )
 		goto _test_eof234;
 case 234:
-#line 6603 "inc/vcf/validator_detail_v43.hpp"
+#line 6602 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6650,7 +6649,7 @@ st235:
 	if ( ++p == pe )
 		goto _test_eof235;
 case 235:
-#line 6654 "inc/vcf/validator_detail_v43.hpp"
+#line 6653 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6701,7 +6700,7 @@ st236:
 	if ( ++p == pe )
 		goto _test_eof236;
 case 236:
-#line 6705 "inc/vcf/validator_detail_v43.hpp"
+#line 6704 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr320;
 		case 47: goto tr319;
@@ -6744,7 +6743,7 @@ st237:
 	if ( ++p == pe )
 		goto _test_eof237;
 case 237:
-#line 6748 "inc/vcf/validator_detail_v43.hpp"
+#line 6747 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr343;
 		case 92: goto tr321;
@@ -6762,7 +6761,7 @@ st238:
 	if ( ++p == pe )
 		goto _test_eof238;
 case 238:
-#line 6766 "inc/vcf/validator_detail_v43.hpp"
+#line 6765 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -6796,7 +6795,7 @@ st239:
 	if ( ++p == pe )
 		goto _test_eof239;
 case 239:
-#line 6800 "inc/vcf/validator_detail_v43.hpp"
+#line 6799 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr292;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -6816,7 +6815,7 @@ st240:
 	if ( ++p == pe )
 		goto _test_eof240;
 case 240:
-#line 6820 "inc/vcf/validator_detail_v43.hpp"
+#line 6819 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 78: goto tr357;
@@ -6834,7 +6833,7 @@ st241:
 	if ( ++p == pe )
 		goto _test_eof241;
 case 241:
-#line 6838 "inc/vcf/validator_detail_v43.hpp"
+#line 6837 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 70: goto tr358;
@@ -6852,7 +6851,7 @@ st242:
 	if ( ++p == pe )
 		goto _test_eof242;
 case 242:
-#line 6856 "inc/vcf/validator_detail_v43.hpp"
+#line 6855 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 79: goto st243;
@@ -6879,7 +6878,7 @@ st244:
 	if ( ++p == pe )
 		goto _test_eof244;
 case 244:
-#line 6883 "inc/vcf/validator_detail_v43.hpp"
+#line 6882 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st245;
 	goto tr356;
@@ -6936,7 +6935,7 @@ st249:
 	if ( ++p == pe )
 		goto _test_eof249;
 case 249:
-#line 6940 "inc/vcf/validator_detail_v43.hpp"
+#line 6939 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st249;
 	if ( (*p) < 48 ) {
@@ -6975,7 +6974,7 @@ st250:
 	if ( ++p == pe )
 		goto _test_eof250;
 case 250:
-#line 6979 "inc/vcf/validator_detail_v43.hpp"
+#line 6978 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr370;
 		case 95: goto tr369;
@@ -7002,7 +7001,7 @@ st251:
 	if ( ++p == pe )
 		goto _test_eof251;
 case 251:
-#line 7006 "inc/vcf/validator_detail_v43.hpp"
+#line 7005 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st252;
 	goto tr356;
@@ -7079,7 +7078,7 @@ st259:
 	if ( ++p == pe )
 		goto _test_eof259;
 case 259:
-#line 7083 "inc/vcf/validator_detail_v43.hpp"
+#line 7082 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	goto tr378;
@@ -7093,7 +7092,7 @@ st260:
 	if ( ++p == pe )
 		goto _test_eof260;
 case 260:
-#line 7097 "inc/vcf/validator_detail_v43.hpp"
+#line 7096 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 84 )
 		goto st261;
 	goto tr356;
@@ -7159,7 +7158,7 @@ st266:
 	if ( ++p == pe )
 		goto _test_eof266;
 case 266:
-#line 7163 "inc/vcf/validator_detail_v43.hpp"
+#line 7162 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr389;
 	if ( (*p) > 90 ) {
@@ -7178,7 +7177,7 @@ st267:
 	if ( ++p == pe )
 		goto _test_eof267;
 case 267:
-#line 7182 "inc/vcf/validator_detail_v43.hpp"
+#line 7181 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 68 )
 		goto st268;
 	goto tr356;
@@ -7276,7 +7275,7 @@ st280:
 	if ( ++p == pe )
 		goto _test_eof280;
 case 280:
-#line 7280 "inc/vcf/validator_detail_v43.hpp"
+#line 7279 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 92: goto tr407;
@@ -7304,7 +7303,7 @@ st281:
 	if ( ++p == pe )
 		goto _test_eof281;
 case 281:
-#line 7308 "inc/vcf/validator_detail_v43.hpp"
+#line 7307 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr410;
@@ -7332,7 +7331,7 @@ st282:
 	if ( ++p == pe )
 		goto _test_eof282;
 case 282:
-#line 7336 "inc/vcf/validator_detail_v43.hpp"
+#line 7335 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st283;
 		case 62: goto st297;
@@ -7366,7 +7365,7 @@ st284:
 	if ( ++p == pe )
 		goto _test_eof284;
 case 284:
-#line 7370 "inc/vcf/validator_detail_v43.hpp"
+#line 7369 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st284;
 	if ( (*p) < 48 ) {
@@ -7401,7 +7400,7 @@ st285:
 	if ( ++p == pe )
 		goto _test_eof285;
 case 285:
-#line 7405 "inc/vcf/validator_detail_v43.hpp"
+#line 7404 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr417;
 		case 95: goto tr416;
@@ -7428,7 +7427,7 @@ st286:
 	if ( ++p == pe )
 		goto _test_eof286;
 case 286:
-#line 7432 "inc/vcf/validator_detail_v43.hpp"
+#line 7431 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st287;
 	goto tr356;
@@ -7463,7 +7462,7 @@ st288:
 	if ( ++p == pe )
 		goto _test_eof288;
 case 288:
-#line 7467 "inc/vcf/validator_detail_v43.hpp"
+#line 7466 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 92: goto tr422;
@@ -7491,7 +7490,7 @@ st289:
 	if ( ++p == pe )
 		goto _test_eof289;
 case 289:
-#line 7495 "inc/vcf/validator_detail_v43.hpp"
+#line 7494 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr423;
 		case 92: goto tr422;
@@ -7513,7 +7512,7 @@ st290:
 	if ( ++p == pe )
 		goto _test_eof290;
 case 290:
-#line 7517 "inc/vcf/validator_detail_v43.hpp"
+#line 7516 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr424;
@@ -7543,7 +7542,7 @@ st291:
 	if ( ++p == pe )
 		goto _test_eof291;
 case 291:
-#line 7547 "inc/vcf/validator_detail_v43.hpp"
+#line 7546 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7594,7 +7593,7 @@ st292:
 	if ( ++p == pe )
 		goto _test_eof292;
 case 292:
-#line 7598 "inc/vcf/validator_detail_v43.hpp"
+#line 7597 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7645,7 +7644,7 @@ st293:
 	if ( ++p == pe )
 		goto _test_eof293;
 case 293:
-#line 7649 "inc/vcf/validator_detail_v43.hpp"
+#line 7648 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr421;
@@ -7688,7 +7687,7 @@ st294:
 	if ( ++p == pe )
 		goto _test_eof294;
 case 294:
-#line 7692 "inc/vcf/validator_detail_v43.hpp"
+#line 7691 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr422;
@@ -7706,7 +7705,7 @@ st295:
 	if ( ++p == pe )
 		goto _test_eof295;
 case 295:
-#line 7710 "inc/vcf/validator_detail_v43.hpp"
+#line 7709 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr406;
 		case 44: goto tr433;
@@ -7736,7 +7735,7 @@ st296:
 	if ( ++p == pe )
 		goto _test_eof296;
 case 296:
-#line 7740 "inc/vcf/validator_detail_v43.hpp"
+#line 7739 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -7775,7 +7774,7 @@ st298:
 	if ( ++p == pe )
 		goto _test_eof298;
 case 298:
-#line 7779 "inc/vcf/validator_detail_v43.hpp"
+#line 7778 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr435;
 		case 92: goto tr410;
@@ -7797,7 +7796,7 @@ st299:
 	if ( ++p == pe )
 		goto _test_eof299;
 case 299:
-#line 7801 "inc/vcf/validator_detail_v43.hpp"
+#line 7800 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 44: goto tr436;
@@ -7817,7 +7816,7 @@ st300:
 	if ( ++p == pe )
 		goto _test_eof300;
 case 300:
-#line 7821 "inc/vcf/validator_detail_v43.hpp"
+#line 7820 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7868,7 +7867,7 @@ st301:
 	if ( ++p == pe )
 		goto _test_eof301;
 case 301:
-#line 7872 "inc/vcf/validator_detail_v43.hpp"
+#line 7871 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7919,7 +7918,7 @@ st302:
 	if ( ++p == pe )
 		goto _test_eof302;
 case 302:
-#line 7923 "inc/vcf/validator_detail_v43.hpp"
+#line 7922 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr409;
 		case 47: goto tr408;
@@ -7962,7 +7961,7 @@ st303:
 	if ( ++p == pe )
 		goto _test_eof303;
 case 303:
-#line 7966 "inc/vcf/validator_detail_v43.hpp"
+#line 7965 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr432;
 		case 92: goto tr410;
@@ -7980,7 +7979,7 @@ st304:
 	if ( ++p == pe )
 		goto _test_eof304;
 case 304:
-#line 7984 "inc/vcf/validator_detail_v43.hpp"
+#line 7983 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -8014,7 +8013,7 @@ st305:
 	if ( ++p == pe )
 		goto _test_eof305;
 case 305:
-#line 8018 "inc/vcf/validator_detail_v43.hpp"
+#line 8017 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto tr381;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -8034,7 +8033,7 @@ st306:
 	if ( ++p == pe )
 		goto _test_eof306;
 case 306:
-#line 8038 "inc/vcf/validator_detail_v43.hpp"
+#line 8037 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr446;
@@ -8052,7 +8051,7 @@ st307:
 	if ( ++p == pe )
 		goto _test_eof307;
 case 307:
-#line 8056 "inc/vcf/validator_detail_v43.hpp"
+#line 8055 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 84: goto tr447;
@@ -8070,7 +8069,7 @@ st308:
 	if ( ++p == pe )
 		goto _test_eof308;
 case 308:
-#line 8074 "inc/vcf/validator_detail_v43.hpp"
+#line 8073 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto st309;
@@ -8097,7 +8096,7 @@ st310:
 	if ( ++p == pe )
 		goto _test_eof310;
 case 310:
-#line 8101 "inc/vcf/validator_detail_v43.hpp"
+#line 8100 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st311;
 	goto tr445;
@@ -8154,7 +8153,7 @@ st315:
 	if ( ++p == pe )
 		goto _test_eof315;
 case 315:
-#line 8158 "inc/vcf/validator_detail_v43.hpp"
+#line 8157 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st315;
 	if ( (*p) < 48 ) {
@@ -8193,7 +8192,7 @@ st316:
 	if ( ++p == pe )
 		goto _test_eof316;
 case 316:
-#line 8197 "inc/vcf/validator_detail_v43.hpp"
+#line 8196 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr459;
 		case 95: goto tr458;
@@ -8220,7 +8219,7 @@ st317:
 	if ( ++p == pe )
 		goto _test_eof317;
 case 317:
-#line 8224 "inc/vcf/validator_detail_v43.hpp"
+#line 8223 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto st318;
 	goto tr445;
@@ -8283,7 +8282,7 @@ st325:
 	if ( ++p == pe )
 		goto _test_eof325;
 case 325:
-#line 8287 "inc/vcf/validator_detail_v43.hpp"
+#line 8286 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 44 )
 		goto st326;
 	goto tr467;
@@ -8339,7 +8338,7 @@ st332:
 	if ( ++p == pe )
 		goto _test_eof332;
 case 332:
-#line 8343 "inc/vcf/validator_detail_v43.hpp"
+#line 8342 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 116 )
 		goto st333;
 	goto tr475;
@@ -8444,7 +8443,7 @@ st346:
 	if ( ++p == pe )
 		goto _test_eof346;
 case 346:
-#line 8448 "inc/vcf/validator_detail_v43.hpp"
+#line 8447 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr491;
 	if ( (*p) < 45 ) {
@@ -8476,7 +8475,7 @@ st347:
 	if ( ++p == pe )
 		goto _test_eof347;
 case 347:
-#line 8480 "inc/vcf/validator_detail_v43.hpp"
+#line 8479 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 61: goto tr493;
@@ -8498,7 +8497,7 @@ st348:
 	if ( ++p == pe )
 		goto _test_eof348;
 case 348:
-#line 8502 "inc/vcf/validator_detail_v43.hpp"
+#line 8501 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 32: goto tr496;
 		case 61: goto tr493;
@@ -8525,7 +8524,7 @@ st349:
 	if ( ++p == pe )
 		goto _test_eof349;
 case 349:
-#line 8529 "inc/vcf/validator_detail_v43.hpp"
+#line 8528 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr493;
 	if ( (*p) < 45 ) {
@@ -8551,7 +8550,7 @@ st350:
 	if ( ++p == pe )
 		goto _test_eof350;
 case 350:
-#line 8555 "inc/vcf/validator_detail_v43.hpp"
+#line 8554 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr494;
 		case 62: goto st351;
@@ -8586,7 +8585,7 @@ st352:
 	if ( ++p == pe )
 		goto _test_eof352;
 case 352:
-#line 8590 "inc/vcf/validator_detail_v43.hpp"
+#line 8589 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr499;
@@ -8604,7 +8603,7 @@ st353:
 	if ( ++p == pe )
 		goto _test_eof353;
 case 353:
-#line 8608 "inc/vcf/validator_detail_v43.hpp"
+#line 8607 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr500;
@@ -8622,7 +8621,7 @@ st354:
 	if ( ++p == pe )
 		goto _test_eof354;
 case 354:
-#line 8626 "inc/vcf/validator_detail_v43.hpp"
+#line 8625 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 73: goto tr501;
@@ -8640,7 +8639,7 @@ st355:
 	if ( ++p == pe )
 		goto _test_eof355;
 case 355:
-#line 8644 "inc/vcf/validator_detail_v43.hpp"
+#line 8643 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 71: goto tr502;
@@ -8658,7 +8657,7 @@ st356:
 	if ( ++p == pe )
 		goto _test_eof356;
 case 356:
-#line 8662 "inc/vcf/validator_detail_v43.hpp"
+#line 8661 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 82: goto tr503;
@@ -8676,7 +8675,7 @@ st357:
 	if ( ++p == pe )
 		goto _test_eof357;
 case 357:
-#line 8680 "inc/vcf/validator_detail_v43.hpp"
+#line 8679 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto tr504;
@@ -8694,7 +8693,7 @@ st358:
 	if ( ++p == pe )
 		goto _test_eof358;
 case 358:
-#line 8698 "inc/vcf/validator_detail_v43.hpp"
+#line 8697 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st359;
@@ -8721,7 +8720,7 @@ st360:
 	if ( ++p == pe )
 		goto _test_eof360;
 case 360:
-#line 8725 "inc/vcf/validator_detail_v43.hpp"
+#line 8724 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st361;
 	goto tr498;
@@ -8778,7 +8777,7 @@ st365:
 	if ( ++p == pe )
 		goto _test_eof365;
 case 365:
-#line 8782 "inc/vcf/validator_detail_v43.hpp"
+#line 8781 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st365;
 	if ( (*p) < 48 ) {
@@ -8817,7 +8816,7 @@ st366:
 	if ( ++p == pe )
 		goto _test_eof366;
 case 366:
-#line 8821 "inc/vcf/validator_detail_v43.hpp"
+#line 8820 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr516;
 		case 95: goto tr515;
@@ -8844,7 +8843,7 @@ st367:
 	if ( ++p == pe )
 		goto _test_eof367;
 case 367:
-#line 8848 "inc/vcf/validator_detail_v43.hpp"
+#line 8847 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 70: goto st368;
 		case 78: goto tr519;
@@ -8925,7 +8924,7 @@ st375:
 	if ( ++p == pe )
 		goto _test_eof375;
 case 375:
-#line 8929 "inc/vcf/validator_detail_v43.hpp"
+#line 8928 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st375;
 	if ( (*p) < 48 ) {
@@ -8964,7 +8963,7 @@ st376:
 	if ( ++p == pe )
 		goto _test_eof376;
 case 376:
-#line 8968 "inc/vcf/validator_detail_v43.hpp"
+#line 8967 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr532;
 		case 95: goto tr531;
@@ -8991,7 +8990,7 @@ st377:
 	if ( ++p == pe )
 		goto _test_eof377;
 case 377:
-#line 8995 "inc/vcf/validator_detail_v43.hpp"
+#line 8994 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 77 )
 		goto st378;
 	goto tr498;
@@ -9069,7 +9068,7 @@ st385:
 	if ( ++p == pe )
 		goto _test_eof385;
 case 385:
-#line 9073 "inc/vcf/validator_detail_v43.hpp"
+#line 9072 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st385;
 	if ( (*p) < 48 ) {
@@ -9108,7 +9107,7 @@ st386:
 	if ( ++p == pe )
 		goto _test_eof386;
 case 386:
-#line 9112 "inc/vcf/validator_detail_v43.hpp"
+#line 9111 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr543;
@@ -9135,7 +9134,7 @@ st387:
 	if ( ++p == pe )
 		goto _test_eof387;
 case 387:
-#line 9139 "inc/vcf/validator_detail_v43.hpp"
+#line 9138 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -9155,7 +9154,7 @@ st388:
 	if ( ++p == pe )
 		goto _test_eof388;
 case 388:
-#line 9159 "inc/vcf/validator_detail_v43.hpp"
+#line 9158 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr545;
 	goto tr517;
@@ -9169,7 +9168,7 @@ st389:
 	if ( ++p == pe )
 		goto _test_eof389;
 case 389:
-#line 9173 "inc/vcf/validator_detail_v43.hpp"
+#line 9172 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 109 )
 		goto tr546;
 	goto tr517;
@@ -9183,7 +9182,7 @@ st390:
 	if ( ++p == pe )
 		goto _test_eof390;
 case 390:
-#line 9187 "inc/vcf/validator_detail_v43.hpp"
+#line 9186 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 101 )
 		goto tr547;
 	goto tr517;
@@ -9197,7 +9196,7 @@ st391:
 	if ( ++p == pe )
 		goto _test_eof391;
 case 391:
-#line 9201 "inc/vcf/validator_detail_v43.hpp"
+#line 9200 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr548;
 	goto tr517;
@@ -9211,7 +9210,7 @@ st392:
 	if ( ++p == pe )
 		goto _test_eof392;
 case 392:
-#line 9215 "inc/vcf/validator_detail_v43.hpp"
+#line 9214 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr549;
 	goto tr517;
@@ -9225,7 +9224,7 @@ st393:
 	if ( ++p == pe )
 		goto _test_eof393;
 case 393:
-#line 9229 "inc/vcf/validator_detail_v43.hpp"
+#line 9228 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr550;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -9241,7 +9240,7 @@ st394:
 	if ( ++p == pe )
 		goto _test_eof394;
 case 394:
-#line 9245 "inc/vcf/validator_detail_v43.hpp"
+#line 9244 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr551;
 	if ( (*p) < 48 ) {
@@ -9266,7 +9265,7 @@ st395:
 	if ( ++p == pe )
 		goto _test_eof395;
 case 395:
-#line 9270 "inc/vcf/validator_detail_v43.hpp"
+#line 9269 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st395;
 	if ( (*p) < 48 ) {
@@ -9301,7 +9300,7 @@ st396:
 	if ( ++p == pe )
 		goto _test_eof396;
 case 396:
-#line 9305 "inc/vcf/validator_detail_v43.hpp"
+#line 9304 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr555;
 		case 62: goto tr544;
@@ -9329,7 +9328,7 @@ st397:
 	if ( ++p == pe )
 		goto _test_eof397;
 case 397:
-#line 9333 "inc/vcf/validator_detail_v43.hpp"
+#line 9332 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr519;
 	goto tr517;
@@ -9421,7 +9420,7 @@ st407:
 	if ( ++p == pe )
 		goto _test_eof407;
 case 407:
-#line 9425 "inc/vcf/validator_detail_v43.hpp"
+#line 9424 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st407;
 	if ( (*p) < 48 ) {
@@ -9460,7 +9459,7 @@ st408:
 	if ( ++p == pe )
 		goto _test_eof408;
 case 408:
-#line 9464 "inc/vcf/validator_detail_v43.hpp"
+#line 9463 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 62: goto tr544;
 		case 95: goto tr568;
@@ -9491,7 +9490,7 @@ st409:
 	if ( ++p == pe )
 		goto _test_eof409;
 case 409:
-#line 9495 "inc/vcf/validator_detail_v43.hpp"
+#line 9494 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 65: goto tr570;
@@ -9509,7 +9508,7 @@ st410:
 	if ( ++p == pe )
 		goto _test_eof410;
 case 410:
-#line 9513 "inc/vcf/validator_detail_v43.hpp"
+#line 9512 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 77: goto tr571;
@@ -9527,7 +9526,7 @@ st411:
 	if ( ++p == pe )
 		goto _test_eof411;
 case 411:
-#line 9531 "inc/vcf/validator_detail_v43.hpp"
+#line 9530 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 80: goto tr572;
@@ -9545,7 +9544,7 @@ st412:
 	if ( ++p == pe )
 		goto _test_eof412;
 case 412:
-#line 9549 "inc/vcf/validator_detail_v43.hpp"
+#line 9548 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 76: goto tr573;
@@ -9563,7 +9562,7 @@ st413:
 	if ( ++p == pe )
 		goto _test_eof413;
 case 413:
-#line 9567 "inc/vcf/validator_detail_v43.hpp"
+#line 9566 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 69: goto st414;
@@ -9590,7 +9589,7 @@ st415:
 	if ( ++p == pe )
 		goto _test_eof415;
 case 415:
-#line 9594 "inc/vcf/validator_detail_v43.hpp"
+#line 9593 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st416;
 	goto tr569;
@@ -9647,7 +9646,7 @@ st420:
 	if ( ++p == pe )
 		goto _test_eof420;
 case 420:
-#line 9651 "inc/vcf/validator_detail_v43.hpp"
+#line 9650 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st420;
 	if ( (*p) < 48 ) {
@@ -9686,7 +9685,7 @@ st421:
 	if ( ++p == pe )
 		goto _test_eof421;
 case 421:
-#line 9690 "inc/vcf/validator_detail_v43.hpp"
+#line 9689 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9714,7 +9713,7 @@ st422:
 	if ( ++p == pe )
 		goto _test_eof422;
 case 422:
-#line 9718 "inc/vcf/validator_detail_v43.hpp"
+#line 9717 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr587;
 	if ( (*p) < 48 ) {
@@ -9739,7 +9738,7 @@ st423:
 	if ( ++p == pe )
 		goto _test_eof423;
 case 423:
-#line 9743 "inc/vcf/validator_detail_v43.hpp"
+#line 9742 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st423;
 	if ( (*p) < 48 ) {
@@ -9774,7 +9773,7 @@ st424:
 	if ( ++p == pe )
 		goto _test_eof424;
 case 424:
-#line 9778 "inc/vcf/validator_detail_v43.hpp"
+#line 9777 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr591;
 		case 95: goto tr590;
@@ -9801,7 +9800,7 @@ st425:
 	if ( ++p == pe )
 		goto _test_eof425;
 case 425:
-#line 9805 "inc/vcf/validator_detail_v43.hpp"
+#line 9804 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st428;
 	if ( (*p) < 45 ) {
@@ -9833,7 +9832,7 @@ st426:
 	if ( ++p == pe )
 		goto _test_eof426;
 case 426:
-#line 9837 "inc/vcf/validator_detail_v43.hpp"
+#line 9836 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr585;
 		case 62: goto tr586;
@@ -9854,7 +9853,7 @@ st427:
 	if ( ++p == pe )
 		goto _test_eof427;
 case 427:
-#line 9858 "inc/vcf/validator_detail_v43.hpp"
+#line 9857 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -9891,7 +9890,7 @@ st429:
 	if ( ++p == pe )
 		goto _test_eof429;
 case 429:
-#line 9895 "inc/vcf/validator_detail_v43.hpp"
+#line 9894 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 92: goto tr600;
@@ -9919,7 +9918,7 @@ st430:
 	if ( ++p == pe )
 		goto _test_eof430;
 case 430:
-#line 9923 "inc/vcf/validator_detail_v43.hpp"
+#line 9922 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st422;
 		case 62: goto st427;
@@ -9945,7 +9944,7 @@ st431:
 	if ( ++p == pe )
 		goto _test_eof431;
 case 431:
-#line 9949 "inc/vcf/validator_detail_v43.hpp"
+#line 9948 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 92: goto tr600;
@@ -9967,7 +9966,7 @@ st432:
 	if ( ++p == pe )
 		goto _test_eof432;
 case 432:
-#line 9971 "inc/vcf/validator_detail_v43.hpp"
+#line 9970 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr604;
@@ -10007,7 +10006,7 @@ st433:
 	if ( ++p == pe )
 		goto _test_eof433;
 case 433:
-#line 10011 "inc/vcf/validator_detail_v43.hpp"
+#line 10010 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10058,7 +10057,7 @@ st434:
 	if ( ++p == pe )
 		goto _test_eof434;
 case 434:
-#line 10062 "inc/vcf/validator_detail_v43.hpp"
+#line 10061 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10109,7 +10108,7 @@ st435:
 	if ( ++p == pe )
 		goto _test_eof435;
 case 435:
-#line 10113 "inc/vcf/validator_detail_v43.hpp"
+#line 10112 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 47: goto tr598;
@@ -10152,7 +10151,7 @@ st436:
 	if ( ++p == pe )
 		goto _test_eof436;
 case 436:
-#line 10156 "inc/vcf/validator_detail_v43.hpp"
+#line 10155 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr612;
 		case 44: goto tr598;
@@ -10182,7 +10181,7 @@ st437:
 	if ( ++p == pe )
 		goto _test_eof437;
 case 437:
-#line 10186 "inc/vcf/validator_detail_v43.hpp"
+#line 10185 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr599;
 		case 44: goto tr615;
@@ -10222,7 +10221,7 @@ st438:
 	if ( ++p == pe )
 		goto _test_eof438;
 case 438:
-#line 10226 "inc/vcf/validator_detail_v43.hpp"
+#line 10225 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -10252,7 +10251,7 @@ st439:
 	if ( ++p == pe )
 		goto _test_eof439;
 case 439:
-#line 10256 "inc/vcf/validator_detail_v43.hpp"
+#line 10255 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr603;
 		case 44: goto tr615;
@@ -10272,7 +10271,7 @@ st440:
 	if ( ++p == pe )
 		goto _test_eof440;
 case 440:
-#line 10276 "inc/vcf/validator_detail_v43.hpp"
+#line 10275 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr596;
 		case 44: goto tr618;
@@ -10296,7 +10295,7 @@ st441:
 	if ( ++p == pe )
 		goto _test_eof441;
 case 441:
-#line 10300 "inc/vcf/validator_detail_v43.hpp"
+#line 10299 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr621;
@@ -10314,7 +10313,7 @@ st442:
 	if ( ++p == pe )
 		goto _test_eof442;
 case 442:
-#line 10318 "inc/vcf/validator_detail_v43.hpp"
+#line 10317 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 115: goto tr622;
@@ -10332,7 +10331,7 @@ st443:
 	if ( ++p == pe )
 		goto _test_eof443;
 case 443:
-#line 10336 "inc/vcf/validator_detail_v43.hpp"
+#line 10335 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr623;
@@ -10350,7 +10349,7 @@ st444:
 	if ( ++p == pe )
 		goto _test_eof444;
 case 444:
-#line 10354 "inc/vcf/validator_detail_v43.hpp"
+#line 10353 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 109: goto tr624;
@@ -10368,7 +10367,7 @@ st445:
 	if ( ++p == pe )
 		goto _test_eof445;
 case 445:
-#line 10372 "inc/vcf/validator_detail_v43.hpp"
+#line 10371 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 98: goto tr625;
@@ -10386,7 +10385,7 @@ st446:
 	if ( ++p == pe )
 		goto _test_eof446;
 case 446:
-#line 10390 "inc/vcf/validator_detail_v43.hpp"
+#line 10389 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 108: goto tr626;
@@ -10404,7 +10403,7 @@ st447:
 	if ( ++p == pe )
 		goto _test_eof447;
 case 447:
-#line 10408 "inc/vcf/validator_detail_v43.hpp"
+#line 10407 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 121: goto st448;
@@ -10431,7 +10430,7 @@ st449:
 	if ( ++p == pe )
 		goto _test_eof449;
 case 449:
-#line 10435 "inc/vcf/validator_detail_v43.hpp"
+#line 10434 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 90 ) {
 		if ( 97 <= (*p) && (*p) <= 122 )
 			goto tr630;
@@ -10448,7 +10447,7 @@ st450:
 	if ( ++p == pe )
 		goto _test_eof450;
 case 450:
-#line 10452 "inc/vcf/validator_detail_v43.hpp"
+#line 10451 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10474,7 +10473,7 @@ st451:
 	if ( ++p == pe )
 		goto _test_eof451;
 case 451:
-#line 10478 "inc/vcf/validator_detail_v43.hpp"
+#line 10477 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr629;
 		case 13: goto tr632;
@@ -10597,7 +10596,7 @@ st461:
 	if ( ++p == pe )
 		goto _test_eof461;
 case 461:
-#line 10601 "inc/vcf/validator_detail_v43.hpp"
+#line 10600 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr46;
 		case 13: goto tr646;
@@ -10665,7 +10664,7 @@ st468:
 	if ( ++p == pe )
 		goto _test_eof468;
 case 468:
-#line 10669 "inc/vcf/validator_detail_v43.hpp"
+#line 10668 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 111: goto tr651;
@@ -10683,7 +10682,7 @@ st469:
 	if ( ++p == pe )
 		goto _test_eof469;
 case 469:
-#line 10687 "inc/vcf/validator_detail_v43.hpp"
+#line 10686 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 110: goto tr652;
@@ -10701,7 +10700,7 @@ st470:
 	if ( ++p == pe )
 		goto _test_eof470;
 case 470:
-#line 10705 "inc/vcf/validator_detail_v43.hpp"
+#line 10704 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 116: goto tr653;
@@ -10719,7 +10718,7 @@ st471:
 	if ( ++p == pe )
 		goto _test_eof471;
 case 471:
-#line 10723 "inc/vcf/validator_detail_v43.hpp"
+#line 10722 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr654;
@@ -10737,7 +10736,7 @@ st472:
 	if ( ++p == pe )
 		goto _test_eof472;
 case 472:
-#line 10741 "inc/vcf/validator_detail_v43.hpp"
+#line 10740 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto st473;
@@ -10764,7 +10763,7 @@ st474:
 	if ( ++p == pe )
 		goto _test_eof474;
 case 474:
-#line 10768 "inc/vcf/validator_detail_v43.hpp"
+#line 10767 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st475;
 	goto tr650;
@@ -10837,7 +10836,7 @@ st479:
 	if ( ++p == pe )
 		goto _test_eof479;
 case 479:
-#line 10841 "inc/vcf/validator_detail_v43.hpp"
+#line 10840 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 59: goto tr663;
@@ -10866,7 +10865,7 @@ st480:
 	if ( ++p == pe )
 		goto _test_eof480;
 case 480:
-#line 10870 "inc/vcf/validator_detail_v43.hpp"
+#line 10869 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr666;
 	if ( (*p) < 48 ) {
@@ -10891,7 +10890,7 @@ st481:
 	if ( ++p == pe )
 		goto _test_eof481;
 case 481:
-#line 10895 "inc/vcf/validator_detail_v43.hpp"
+#line 10894 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto st481;
 	if ( (*p) < 48 ) {
@@ -10926,7 +10925,7 @@ st482:
 	if ( ++p == pe )
 		goto _test_eof482;
 case 482:
-#line 10930 "inc/vcf/validator_detail_v43.hpp"
+#line 10929 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr670;
 		case 95: goto tr669;
@@ -10953,7 +10952,7 @@ st483:
 	if ( ++p == pe )
 		goto _test_eof483;
 case 483:
-#line 10957 "inc/vcf/validator_detail_v43.hpp"
+#line 10956 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 34 )
 		goto st486;
 	if ( (*p) < 45 ) {
@@ -10985,7 +10984,7 @@ st484:
 	if ( ++p == pe )
 		goto _test_eof484;
 case 484:
-#line 10989 "inc/vcf/validator_detail_v43.hpp"
+#line 10988 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto tr664;
 		case 62: goto tr665;
@@ -11006,7 +11005,7 @@ st485:
 	if ( ++p == pe )
 		goto _test_eof485;
 case 485:
-#line 11010 "inc/vcf/validator_detail_v43.hpp"
+#line 11009 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11043,7 +11042,7 @@ st487:
 	if ( ++p == pe )
 		goto _test_eof487;
 case 487:
-#line 11047 "inc/vcf/validator_detail_v43.hpp"
+#line 11046 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 92: goto tr679;
@@ -11071,7 +11070,7 @@ st488:
 	if ( ++p == pe )
 		goto _test_eof488;
 case 488:
-#line 11075 "inc/vcf/validator_detail_v43.hpp"
+#line 11074 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 44: goto st480;
 		case 62: goto st485;
@@ -11097,7 +11096,7 @@ st489:
 	if ( ++p == pe )
 		goto _test_eof489;
 case 489:
-#line 11101 "inc/vcf/validator_detail_v43.hpp"
+#line 11100 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 92: goto tr679;
@@ -11119,7 +11118,7 @@ st490:
 	if ( ++p == pe )
 		goto _test_eof490;
 case 490:
-#line 11123 "inc/vcf/validator_detail_v43.hpp"
+#line 11122 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr683;
@@ -11159,7 +11158,7 @@ st491:
 	if ( ++p == pe )
 		goto _test_eof491;
 case 491:
-#line 11163 "inc/vcf/validator_detail_v43.hpp"
+#line 11162 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11210,7 +11209,7 @@ st492:
 	if ( ++p == pe )
 		goto _test_eof492;
 case 492:
-#line 11214 "inc/vcf/validator_detail_v43.hpp"
+#line 11213 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11261,7 +11260,7 @@ st493:
 	if ( ++p == pe )
 		goto _test_eof493;
 case 493:
-#line 11265 "inc/vcf/validator_detail_v43.hpp"
+#line 11264 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 47: goto tr677;
@@ -11304,7 +11303,7 @@ st494:
 	if ( ++p == pe )
 		goto _test_eof494;
 case 494:
-#line 11308 "inc/vcf/validator_detail_v43.hpp"
+#line 11307 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr691;
 		case 44: goto tr677;
@@ -11334,7 +11333,7 @@ st495:
 	if ( ++p == pe )
 		goto _test_eof495;
 case 495:
-#line 11338 "inc/vcf/validator_detail_v43.hpp"
+#line 11337 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr678;
 		case 44: goto tr694;
@@ -11374,7 +11373,7 @@ st496:
 	if ( ++p == pe )
 		goto _test_eof496;
 case 496:
-#line 11378 "inc/vcf/validator_detail_v43.hpp"
+#line 11377 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr57;
@@ -11404,7 +11403,7 @@ st497:
 	if ( ++p == pe )
 		goto _test_eof497;
 case 497:
-#line 11408 "inc/vcf/validator_detail_v43.hpp"
+#line 11407 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr682;
 		case 44: goto tr694;
@@ -11424,7 +11423,7 @@ st498:
 	if ( ++p == pe )
 		goto _test_eof498;
 case 498:
-#line 11428 "inc/vcf/validator_detail_v43.hpp"
+#line 11427 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 34: goto tr675;
 		case 44: goto tr697;
@@ -11448,7 +11447,7 @@ st499:
 	if ( ++p == pe )
 		goto _test_eof499;
 case 499:
-#line 11452 "inc/vcf/validator_detail_v43.hpp"
+#line 11451 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr700;
@@ -11466,7 +11465,7 @@ st500:
 	if ( ++p == pe )
 		goto _test_eof500;
 case 500:
-#line 11470 "inc/vcf/validator_detail_v43.hpp"
+#line 11469 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 100: goto tr701;
@@ -11484,7 +11483,7 @@ st501:
 	if ( ++p == pe )
 		goto _test_eof501;
 case 501:
-#line 11488 "inc/vcf/validator_detail_v43.hpp"
+#line 11487 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 105: goto tr702;
@@ -11502,7 +11501,7 @@ st502:
 	if ( ++p == pe )
 		goto _test_eof502;
 case 502:
-#line 11506 "inc/vcf/validator_detail_v43.hpp"
+#line 11505 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 103: goto tr703;
@@ -11520,7 +11519,7 @@ st503:
 	if ( ++p == pe )
 		goto _test_eof503;
 case 503:
-#line 11524 "inc/vcf/validator_detail_v43.hpp"
+#line 11523 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 114: goto tr704;
@@ -11538,7 +11537,7 @@ st504:
 	if ( ++p == pe )
 		goto _test_eof504;
 case 504:
-#line 11542 "inc/vcf/validator_detail_v43.hpp"
+#line 11541 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr705;
@@ -11556,7 +11555,7 @@ st505:
 	if ( ++p == pe )
 		goto _test_eof505;
 case 505:
-#line 11560 "inc/vcf/validator_detail_v43.hpp"
+#line 11559 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 101: goto tr706;
@@ -11574,7 +11573,7 @@ st506:
 	if ( ++p == pe )
 		goto _test_eof506;
 case 506:
-#line 11578 "inc/vcf/validator_detail_v43.hpp"
+#line 11577 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 68: goto tr707;
@@ -11592,7 +11591,7 @@ st507:
 	if ( ++p == pe )
 		goto _test_eof507;
 case 507:
-#line 11596 "inc/vcf/validator_detail_v43.hpp"
+#line 11595 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 61: goto tr42;
 		case 66: goto st508;
@@ -11619,7 +11618,7 @@ st509:
 	if ( ++p == pe )
 		goto _test_eof509;
 case 509:
-#line 11623 "inc/vcf/validator_detail_v43.hpp"
+#line 11622 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto st510;
 	goto tr699;
@@ -11643,7 +11642,7 @@ st511:
 	if ( ++p == pe )
 		goto _test_eof511;
 case 511:
-#line 11647 "inc/vcf/validator_detail_v43.hpp"
+#line 11646 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11669,7 +11668,7 @@ st512:
 	if ( ++p == pe )
 		goto _test_eof512;
 case 512:
-#line 11673 "inc/vcf/validator_detail_v43.hpp"
+#line 11672 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr714;
@@ -11780,7 +11779,7 @@ st522:
 	if ( ++p == pe )
 		goto _test_eof522;
 case 522:
-#line 11784 "inc/vcf/validator_detail_v43.hpp"
+#line 11783 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr711;
 		case 13: goto tr728;
@@ -11801,7 +11800,7 @@ st523:
 	if ( ++p == pe )
 		goto _test_eof523;
 case 523:
-#line 11805 "inc/vcf/validator_detail_v43.hpp"
+#line 11804 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr56;
 		case 13: goto tr730;
@@ -11836,7 +11835,7 @@ st524:
 	if ( ++p == pe )
 		goto _test_eof524;
 case 524:
-#line 11840 "inc/vcf/validator_detail_v43.hpp"
+#line 11839 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto st28;
 		case 13: goto tr728;
@@ -11936,7 +11935,7 @@ st536:
 	if ( ++p == pe )
 		goto _test_eof536;
 case 536:
-#line 11940 "inc/vcf/validator_detail_v43.hpp"
+#line 11939 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 80 )
 		goto st537;
 	goto tr734;
@@ -11971,7 +11970,7 @@ st540:
 	if ( ++p == pe )
 		goto _test_eof540;
 case 540:
-#line 11975 "inc/vcf/validator_detail_v43.hpp"
+#line 11974 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st541;
 	goto tr734;
@@ -11999,7 +11998,7 @@ st543:
 	if ( ++p == pe )
 		goto _test_eof543;
 case 543:
-#line 12003 "inc/vcf/validator_detail_v43.hpp"
+#line 12002 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 82 )
 		goto st544;
 	goto tr734;
@@ -12034,7 +12033,7 @@ st547:
 	if ( ++p == pe )
 		goto _test_eof547;
 case 547:
-#line 12038 "inc/vcf/validator_detail_v43.hpp"
+#line 12037 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 65 )
 		goto st548;
 	goto tr734;
@@ -12069,7 +12068,7 @@ st551:
 	if ( ++p == pe )
 		goto _test_eof551;
 case 551:
-#line 12073 "inc/vcf/validator_detail_v43.hpp"
+#line 12072 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 81 )
 		goto st552;
 	goto tr734;
@@ -12111,7 +12110,7 @@ st556:
 	if ( ++p == pe )
 		goto _test_eof556;
 case 556:
-#line 12115 "inc/vcf/validator_detail_v43.hpp"
+#line 12114 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st557;
 	goto tr734;
@@ -12167,7 +12166,7 @@ st563:
 	if ( ++p == pe )
 		goto _test_eof563;
 case 563:
-#line 12171 "inc/vcf/validator_detail_v43.hpp"
+#line 12170 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto st564;
 	goto tr734;
@@ -12212,7 +12211,7 @@ st568:
 	if ( ++p == pe )
 		goto _test_eof568;
 case 568:
-#line 12216 "inc/vcf/validator_detail_v43.hpp"
+#line 12215 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 70 )
 		goto st569;
 	goto tr774;
@@ -12278,7 +12277,7 @@ st575:
 	if ( ++p == pe )
 		goto _test_eof575;
 case 575:
-#line 12282 "inc/vcf/validator_detail_v43.hpp"
+#line 12281 "inc/vcf/validator_detail_v43.hpp"
 	if ( 32 <= (*p) && (*p) <= 126 )
 		goto tr782;
 	goto tr774;
@@ -12302,7 +12301,7 @@ st576:
 	if ( ++p == pe )
 		goto _test_eof576;
 case 576:
-#line 12306 "inc/vcf/validator_detail_v43.hpp"
+#line 12305 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr783;
 		case 10: goto tr784;
@@ -12351,7 +12350,7 @@ st724:
 	if ( ++p == pe )
 		goto _test_eof724;
 case 724:
-#line 12355 "inc/vcf/validator_detail_v43.hpp"
+#line 12354 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1012;
 		case 13: goto tr1013;
@@ -12411,7 +12410,7 @@ st725:
 	if ( ++p == pe )
 		goto _test_eof725;
 case 725:
-#line 12415 "inc/vcf/validator_detail_v43.hpp"
+#line 12414 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1016;
 		case 13: goto tr1017;
@@ -12453,7 +12452,7 @@ st577:
 	if ( ++p == pe )
 		goto _test_eof577;
 case 577:
-#line 12457 "inc/vcf/validator_detail_v43.hpp"
+#line 12456 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st725;
 	goto st0;
@@ -12495,7 +12494,7 @@ st578:
 	if ( ++p == pe )
 		goto _test_eof578;
 case 578:
-#line 12499 "inc/vcf/validator_detail_v43.hpp"
+#line 12498 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr790;
 		case 43: goto tr791;
@@ -12542,7 +12541,7 @@ st579:
 	if ( ++p == pe )
 		goto _test_eof579;
 case 579:
-#line 12546 "inc/vcf/validator_detail_v43.hpp"
+#line 12545 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr793;
 	goto tr792;
@@ -12566,7 +12565,7 @@ st580:
 	if ( ++p == pe )
 		goto _test_eof580;
 case 580:
-#line 12570 "inc/vcf/validator_detail_v43.hpp"
+#line 12569 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr794;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12596,7 +12595,7 @@ st581:
 	if ( ++p == pe )
 		goto _test_eof581;
 case 581:
-#line 12600 "inc/vcf/validator_detail_v43.hpp"
+#line 12599 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr797;
@@ -12623,7 +12622,7 @@ st582:
 	if ( ++p == pe )
 		goto _test_eof582;
 case 582:
-#line 12627 "inc/vcf/validator_detail_v43.hpp"
+#line 12626 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr798;
 		case 59: goto tr800;
@@ -12649,7 +12648,7 @@ st583:
 	if ( ++p == pe )
 		goto _test_eof583;
 case 583:
-#line 12653 "inc/vcf/validator_detail_v43.hpp"
+#line 12652 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr802;
 		case 67: goto tr802;
@@ -12683,7 +12682,7 @@ st584:
 	if ( ++p == pe )
 		goto _test_eof584;
 case 584:
-#line 12687 "inc/vcf/validator_detail_v43.hpp"
+#line 12686 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr803;
 		case 65: goto tr804;
@@ -12716,7 +12715,7 @@ st585:
 	if ( ++p == pe )
 		goto _test_eof585;
 case 585:
-#line 12720 "inc/vcf/validator_detail_v43.hpp"
+#line 12719 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr807;
@@ -12755,7 +12754,7 @@ st586:
 	if ( ++p == pe )
 		goto _test_eof586;
 case 586:
-#line 12759 "inc/vcf/validator_detail_v43.hpp"
+#line 12758 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -12779,7 +12778,7 @@ st587:
 	if ( ++p == pe )
 		goto _test_eof587;
 case 587:
-#line 12783 "inc/vcf/validator_detail_v43.hpp"
+#line 12782 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr815;
 		case 45: goto tr815;
@@ -12804,7 +12803,7 @@ st588:
 	if ( ++p == pe )
 		goto _test_eof588;
 case 588:
-#line 12808 "inc/vcf/validator_detail_v43.hpp"
+#line 12807 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr821;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -12830,7 +12829,7 @@ st589:
 	if ( ++p == pe )
 		goto _test_eof589;
 case 589:
-#line 12834 "inc/vcf/validator_detail_v43.hpp"
+#line 12833 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 46: goto tr823;
@@ -12858,7 +12857,7 @@ st590:
 	if ( ++p == pe )
 		goto _test_eof590;
 case 590:
-#line 12862 "inc/vcf/validator_detail_v43.hpp"
+#line 12861 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr827;
 		case 58: goto tr826;
@@ -12894,7 +12893,7 @@ st591:
 	if ( ++p == pe )
 		goto _test_eof591;
 case 591:
-#line 12898 "inc/vcf/validator_detail_v43.hpp"
+#line 12897 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto st591;
 	if ( (*p) < 65 ) {
@@ -12938,7 +12937,7 @@ st592:
 	if ( ++p == pe )
 		goto _test_eof592;
 case 592:
-#line 12942 "inc/vcf/validator_detail_v43.hpp"
+#line 12941 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 59: goto tr832;
@@ -12964,7 +12963,7 @@ st593:
 	if ( ++p == pe )
 		goto _test_eof593;
 case 593:
-#line 12968 "inc/vcf/validator_detail_v43.hpp"
+#line 12967 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr834;
 		case 49: goto tr836;
@@ -13003,7 +13002,7 @@ st726:
 	if ( ++p == pe )
 		goto _test_eof726;
 case 726:
-#line 13007 "inc/vcf/validator_detail_v43.hpp"
+#line 13006 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13034,7 +13033,7 @@ st594:
 	if ( ++p == pe )
 		goto _test_eof594;
 case 594:
-#line 13038 "inc/vcf/validator_detail_v43.hpp"
+#line 13037 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 95 )
 		goto tr848;
 	if ( (*p) > 90 ) {
@@ -13063,7 +13062,7 @@ st595:
 	if ( ++p == pe )
 		goto _test_eof595;
 case 595:
-#line 13067 "inc/vcf/validator_detail_v43.hpp"
+#line 13066 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 37: goto tr850;
@@ -13098,7 +13097,7 @@ st596:
 	if ( ++p == pe )
 		goto _test_eof596;
 case 596:
-#line 13102 "inc/vcf/validator_detail_v43.hpp"
+#line 13101 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 46 )
 		goto tr854;
 	if ( (*p) < 48 ) {
@@ -13130,7 +13129,7 @@ st727:
 	if ( ++p == pe )
 		goto _test_eof727;
 case 727:
-#line 13134 "inc/vcf/validator_detail_v43.hpp"
+#line 13133 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13189,7 +13188,7 @@ st728:
 	if ( ++p == pe )
 		goto _test_eof728;
 case 728:
-#line 13193 "inc/vcf/validator_detail_v43.hpp"
+#line 13192 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1016;
 		case 13: goto tr1017;
@@ -13227,7 +13226,7 @@ st597:
 	if ( ++p == pe )
 		goto _test_eof597;
 case 597:
-#line 13231 "inc/vcf/validator_detail_v43.hpp"
+#line 13230 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr856;
 		case 59: goto tr856;
@@ -13268,7 +13267,7 @@ st598:
 	if ( ++p == pe )
 		goto _test_eof598;
 case 598:
-#line 13272 "inc/vcf/validator_detail_v43.hpp"
+#line 13271 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr857;
 		case 59: goto tr857;
@@ -13297,7 +13296,7 @@ st599:
 	if ( ++p == pe )
 		goto _test_eof599;
 case 599:
-#line 13301 "inc/vcf/validator_detail_v43.hpp"
+#line 13300 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr859;
 	goto tr789;
@@ -13350,7 +13349,7 @@ st600:
 	if ( ++p == pe )
 		goto _test_eof600;
 case 600:
-#line 13354 "inc/vcf/validator_detail_v43.hpp"
+#line 13353 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st728;
 	goto tr860;
@@ -13364,7 +13363,7 @@ st601:
 	if ( ++p == pe )
 		goto _test_eof601;
 case 601:
-#line 13368 "inc/vcf/validator_detail_v43.hpp"
+#line 13367 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 57 ) {
 		if ( 59 <= (*p) && (*p) <= 126 )
 			goto tr863;
@@ -13391,7 +13390,7 @@ st729:
 	if ( ++p == pe )
 		goto _test_eof729;
 case 729:
-#line 13395 "inc/vcf/validator_detail_v43.hpp"
+#line 13394 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13413,7 +13412,7 @@ st730:
 	if ( ++p == pe )
 		goto _test_eof730;
 case 730:
-#line 13417 "inc/vcf/validator_detail_v43.hpp"
+#line 13416 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13450,7 +13449,7 @@ st731:
 	if ( ++p == pe )
 		goto _test_eof731;
 case 731:
-#line 13454 "inc/vcf/validator_detail_v43.hpp"
+#line 13453 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr849;
 		case 10: goto tr1020;
@@ -13488,7 +13487,7 @@ st732:
 	if ( ++p == pe )
 		goto _test_eof732;
 case 732:
-#line 13492 "inc/vcf/validator_detail_v43.hpp"
+#line 13491 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13517,7 +13516,7 @@ st602:
 	if ( ++p == pe )
 		goto _test_eof602;
 case 602:
-#line 13521 "inc/vcf/validator_detail_v43.hpp"
+#line 13520 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 49: goto tr836;
 		case 65: goto tr837;
@@ -13555,7 +13554,7 @@ st733:
 	if ( ++p == pe )
 		goto _test_eof733;
 case 733:
-#line 13559 "inc/vcf/validator_detail_v43.hpp"
+#line 13558 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13585,7 +13584,7 @@ st734:
 	if ( ++p == pe )
 		goto _test_eof734;
 case 734:
-#line 13589 "inc/vcf/validator_detail_v43.hpp"
+#line 13588 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13615,7 +13614,7 @@ st735:
 	if ( ++p == pe )
 		goto _test_eof735;
 case 735:
-#line 13619 "inc/vcf/validator_detail_v43.hpp"
+#line 13618 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13645,7 +13644,7 @@ st736:
 	if ( ++p == pe )
 		goto _test_eof736;
 case 736:
-#line 13649 "inc/vcf/validator_detail_v43.hpp"
+#line 13648 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13675,7 +13674,7 @@ st603:
 	if ( ++p == pe )
 		goto _test_eof603;
 case 603:
-#line 13679 "inc/vcf/validator_detail_v43.hpp"
+#line 13678 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) > 58 ) {
 		if ( 60 <= (*p) && (*p) <= 126 )
 			goto tr865;
@@ -13692,7 +13691,7 @@ st737:
 	if ( ++p == pe )
 		goto _test_eof737;
 case 737:
-#line 13696 "inc/vcf/validator_detail_v43.hpp"
+#line 13695 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13712,7 +13711,7 @@ st738:
 	if ( ++p == pe )
 		goto _test_eof738;
 case 738:
-#line 13716 "inc/vcf/validator_detail_v43.hpp"
+#line 13715 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13741,7 +13740,7 @@ st604:
 	if ( ++p == pe )
 		goto _test_eof604;
 case 604:
-#line 13745 "inc/vcf/validator_detail_v43.hpp"
+#line 13744 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr867;
 	goto tr866;
@@ -13755,7 +13754,7 @@ st739:
 	if ( ++p == pe )
 		goto _test_eof739;
 case 739:
-#line 13759 "inc/vcf/validator_detail_v43.hpp"
+#line 13758 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13777,7 +13776,7 @@ st740:
 	if ( ++p == pe )
 		goto _test_eof740;
 case 740:
-#line 13781 "inc/vcf/validator_detail_v43.hpp"
+#line 13780 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13811,7 +13810,7 @@ st605:
 	if ( ++p == pe )
 		goto _test_eof605;
 case 605:
-#line 13815 "inc/vcf/validator_detail_v43.hpp"
+#line 13814 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr869;
@@ -13836,7 +13835,7 @@ st606:
 	if ( ++p == pe )
 		goto _test_eof606;
 case 606:
-#line 13840 "inc/vcf/validator_detail_v43.hpp"
+#line 13839 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 60 )
 		goto tr871;
 	if ( (*p) < 45 ) {
@@ -13858,7 +13857,7 @@ st741:
 	if ( ++p == pe )
 		goto _test_eof741;
 case 741:
-#line 13862 "inc/vcf/validator_detail_v43.hpp"
+#line 13861 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13884,7 +13883,7 @@ st607:
 	if ( ++p == pe )
 		goto _test_eof607;
 case 607:
-#line 13888 "inc/vcf/validator_detail_v43.hpp"
+#line 13887 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr872;
@@ -13909,7 +13908,7 @@ st608:
 	if ( ++p == pe )
 		goto _test_eof608;
 case 608:
-#line 13913 "inc/vcf/validator_detail_v43.hpp"
+#line 13912 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr874;
 	goto tr873;
@@ -13923,7 +13922,7 @@ st742:
 	if ( ++p == pe )
 		goto _test_eof742;
 case 742:
-#line 13927 "inc/vcf/validator_detail_v43.hpp"
+#line 13926 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -13944,7 +13943,7 @@ st609:
 	if ( ++p == pe )
 		goto _test_eof609;
 case 609:
-#line 13948 "inc/vcf/validator_detail_v43.hpp"
+#line 13947 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr875;
@@ -13971,7 +13970,7 @@ st610:
 	if ( ++p == pe )
 		goto _test_eof610;
 case 610:
-#line 13975 "inc/vcf/validator_detail_v43.hpp"
+#line 13974 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr879;
 	goto tr878;
@@ -13985,7 +13984,7 @@ st743:
 	if ( ++p == pe )
 		goto _test_eof743;
 case 743:
-#line 13989 "inc/vcf/validator_detail_v43.hpp"
+#line 13988 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14006,7 +14005,7 @@ st611:
 	if ( ++p == pe )
 		goto _test_eof611;
 case 611:
-#line 14010 "inc/vcf/validator_detail_v43.hpp"
+#line 14009 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr880;
@@ -14031,7 +14030,7 @@ st612:
 	if ( ++p == pe )
 		goto _test_eof612;
 case 612:
-#line 14035 "inc/vcf/validator_detail_v43.hpp"
+#line 14034 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr882;
 	goto tr881;
@@ -14045,7 +14044,7 @@ st744:
 	if ( ++p == pe )
 		goto _test_eof744;
 case 744:
-#line 14049 "inc/vcf/validator_detail_v43.hpp"
+#line 14048 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14066,7 +14065,7 @@ st613:
 	if ( ++p == pe )
 		goto _test_eof613;
 case 613:
-#line 14070 "inc/vcf/validator_detail_v43.hpp"
+#line 14069 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr883;
@@ -14091,7 +14090,7 @@ st614:
 	if ( ++p == pe )
 		goto _test_eof614;
 case 614:
-#line 14095 "inc/vcf/validator_detail_v43.hpp"
+#line 14094 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr885;
 	goto tr884;
@@ -14105,7 +14104,7 @@ st745:
 	if ( ++p == pe )
 		goto _test_eof745;
 case 745:
-#line 14109 "inc/vcf/validator_detail_v43.hpp"
+#line 14108 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14126,7 +14125,7 @@ st615:
 	if ( ++p == pe )
 		goto _test_eof615;
 case 615:
-#line 14130 "inc/vcf/validator_detail_v43.hpp"
+#line 14129 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr886;
@@ -14151,7 +14150,7 @@ st616:
 	if ( ++p == pe )
 		goto _test_eof616;
 case 616:
-#line 14155 "inc/vcf/validator_detail_v43.hpp"
+#line 14154 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr888;
 		case 45: goto tr888;
@@ -14171,7 +14170,7 @@ st617:
 	if ( ++p == pe )
 		goto _test_eof617;
 case 617:
-#line 14175 "inc/vcf/validator_detail_v43.hpp"
+#line 14174 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr890;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14187,7 +14186,7 @@ st746:
 	if ( ++p == pe )
 		goto _test_eof746;
 case 746:
-#line 14191 "inc/vcf/validator_detail_v43.hpp"
+#line 14190 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14211,7 +14210,7 @@ st618:
 	if ( ++p == pe )
 		goto _test_eof618;
 case 618:
-#line 14215 "inc/vcf/validator_detail_v43.hpp"
+#line 14214 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr892;
 	goto tr887;
@@ -14225,7 +14224,7 @@ st747:
 	if ( ++p == pe )
 		goto _test_eof747;
 case 747:
-#line 14229 "inc/vcf/validator_detail_v43.hpp"
+#line 14228 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14248,7 +14247,7 @@ st619:
 	if ( ++p == pe )
 		goto _test_eof619;
 case 619:
-#line 14252 "inc/vcf/validator_detail_v43.hpp"
+#line 14251 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr893;
 		case 45: goto tr893;
@@ -14266,7 +14265,7 @@ st620:
 	if ( ++p == pe )
 		goto _test_eof620;
 case 620:
-#line 14270 "inc/vcf/validator_detail_v43.hpp"
+#line 14269 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr894;
 	goto tr887;
@@ -14280,7 +14279,7 @@ st748:
 	if ( ++p == pe )
 		goto _test_eof748;
 case 748:
-#line 14284 "inc/vcf/validator_detail_v43.hpp"
+#line 14283 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14301,7 +14300,7 @@ st621:
 	if ( ++p == pe )
 		goto _test_eof621;
 case 621:
-#line 14305 "inc/vcf/validator_detail_v43.hpp"
+#line 14304 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr895;
 	goto tr887;
@@ -14315,7 +14314,7 @@ st622:
 	if ( ++p == pe )
 		goto _test_eof622;
 case 622:
-#line 14319 "inc/vcf/validator_detail_v43.hpp"
+#line 14318 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr896;
 	goto tr887;
@@ -14329,7 +14328,7 @@ st749:
 	if ( ++p == pe )
 		goto _test_eof749;
 case 749:
-#line 14333 "inc/vcf/validator_detail_v43.hpp"
+#line 14332 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14348,7 +14347,7 @@ st623:
 	if ( ++p == pe )
 		goto _test_eof623;
 case 623:
-#line 14352 "inc/vcf/validator_detail_v43.hpp"
+#line 14351 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr897;
 	goto tr887;
@@ -14362,7 +14361,7 @@ st624:
 	if ( ++p == pe )
 		goto _test_eof624;
 case 624:
-#line 14366 "inc/vcf/validator_detail_v43.hpp"
+#line 14365 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr896;
 	goto tr887;
@@ -14376,7 +14375,7 @@ st625:
 	if ( ++p == pe )
 		goto _test_eof625;
 case 625:
-#line 14380 "inc/vcf/validator_detail_v43.hpp"
+#line 14379 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr898;
@@ -14401,7 +14400,7 @@ st626:
 	if ( ++p == pe )
 		goto _test_eof626;
 case 626:
-#line 14405 "inc/vcf/validator_detail_v43.hpp"
+#line 14404 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr900;
 	goto tr899;
@@ -14415,7 +14414,7 @@ st750:
 	if ( ++p == pe )
 		goto _test_eof750;
 case 750:
-#line 14419 "inc/vcf/validator_detail_v43.hpp"
+#line 14418 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14439,7 +14438,7 @@ st751:
 	if ( ++p == pe )
 		goto _test_eof751;
 case 751:
-#line 14443 "inc/vcf/validator_detail_v43.hpp"
+#line 14442 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14469,7 +14468,7 @@ st627:
 	if ( ++p == pe )
 		goto _test_eof627;
 case 627:
-#line 14473 "inc/vcf/validator_detail_v43.hpp"
+#line 14472 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr901;
@@ -14494,7 +14493,7 @@ st628:
 	if ( ++p == pe )
 		goto _test_eof628;
 case 628:
-#line 14498 "inc/vcf/validator_detail_v43.hpp"
+#line 14497 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr903;
 		case 45: goto tr903;
@@ -14514,7 +14513,7 @@ st629:
 	if ( ++p == pe )
 		goto _test_eof629;
 case 629:
-#line 14518 "inc/vcf/validator_detail_v43.hpp"
+#line 14517 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr905;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -14530,7 +14529,7 @@ st752:
 	if ( ++p == pe )
 		goto _test_eof752;
 case 752:
-#line 14534 "inc/vcf/validator_detail_v43.hpp"
+#line 14533 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14553,7 +14552,7 @@ st630:
 	if ( ++p == pe )
 		goto _test_eof630;
 case 630:
-#line 14557 "inc/vcf/validator_detail_v43.hpp"
+#line 14556 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr907;
 	goto tr902;
@@ -14567,7 +14566,7 @@ st753:
 	if ( ++p == pe )
 		goto _test_eof753;
 case 753:
-#line 14571 "inc/vcf/validator_detail_v43.hpp"
+#line 14570 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14589,7 +14588,7 @@ st631:
 	if ( ++p == pe )
 		goto _test_eof631;
 case 631:
-#line 14593 "inc/vcf/validator_detail_v43.hpp"
+#line 14592 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr908;
 		case 45: goto tr908;
@@ -14607,7 +14606,7 @@ st632:
 	if ( ++p == pe )
 		goto _test_eof632;
 case 632:
-#line 14611 "inc/vcf/validator_detail_v43.hpp"
+#line 14610 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr909;
 	goto tr902;
@@ -14621,7 +14620,7 @@ st754:
 	if ( ++p == pe )
 		goto _test_eof754;
 case 754:
-#line 14625 "inc/vcf/validator_detail_v43.hpp"
+#line 14624 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14641,7 +14640,7 @@ st633:
 	if ( ++p == pe )
 		goto _test_eof633;
 case 633:
-#line 14645 "inc/vcf/validator_detail_v43.hpp"
+#line 14644 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr910;
 	goto tr902;
@@ -14655,7 +14654,7 @@ st634:
 	if ( ++p == pe )
 		goto _test_eof634;
 case 634:
-#line 14659 "inc/vcf/validator_detail_v43.hpp"
+#line 14658 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr911;
 	goto tr902;
@@ -14669,7 +14668,7 @@ st755:
 	if ( ++p == pe )
 		goto _test_eof755;
 case 755:
-#line 14673 "inc/vcf/validator_detail_v43.hpp"
+#line 14672 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14687,7 +14686,7 @@ st635:
 	if ( ++p == pe )
 		goto _test_eof635;
 case 635:
-#line 14691 "inc/vcf/validator_detail_v43.hpp"
+#line 14690 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr912;
 	goto tr902;
@@ -14701,7 +14700,7 @@ st636:
 	if ( ++p == pe )
 		goto _test_eof636;
 case 636:
-#line 14705 "inc/vcf/validator_detail_v43.hpp"
+#line 14704 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr911;
 	goto tr902;
@@ -14719,7 +14718,7 @@ st756:
 	if ( ++p == pe )
 		goto _test_eof756;
 case 756:
-#line 14723 "inc/vcf/validator_detail_v43.hpp"
+#line 14722 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14749,7 +14748,7 @@ st757:
 	if ( ++p == pe )
 		goto _test_eof757;
 case 757:
-#line 14753 "inc/vcf/validator_detail_v43.hpp"
+#line 14752 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14779,7 +14778,7 @@ st758:
 	if ( ++p == pe )
 		goto _test_eof758;
 case 758:
-#line 14783 "inc/vcf/validator_detail_v43.hpp"
+#line 14782 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14809,7 +14808,7 @@ st759:
 	if ( ++p == pe )
 		goto _test_eof759;
 case 759:
-#line 14813 "inc/vcf/validator_detail_v43.hpp"
+#line 14812 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14839,7 +14838,7 @@ st637:
 	if ( ++p == pe )
 		goto _test_eof637;
 case 637:
-#line 14843 "inc/vcf/validator_detail_v43.hpp"
+#line 14842 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr913;
@@ -14864,7 +14863,7 @@ st638:
 	if ( ++p == pe )
 		goto _test_eof638;
 case 638:
-#line 14868 "inc/vcf/validator_detail_v43.hpp"
+#line 14867 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr915;
 	goto tr914;
@@ -14878,7 +14877,7 @@ st639:
 	if ( ++p == pe )
 		goto _test_eof639;
 case 639:
-#line 14882 "inc/vcf/validator_detail_v43.hpp"
+#line 14881 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 68: goto tr916;
 		case 80: goto tr916;
@@ -14904,7 +14903,7 @@ st760:
 	if ( ++p == pe )
 		goto _test_eof760;
 case 760:
-#line 14908 "inc/vcf/validator_detail_v43.hpp"
+#line 14907 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14929,7 +14928,7 @@ st761:
 	if ( ++p == pe )
 		goto _test_eof761;
 case 761:
-#line 14933 "inc/vcf/validator_detail_v43.hpp"
+#line 14932 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14960,7 +14959,7 @@ st762:
 	if ( ++p == pe )
 		goto _test_eof762;
 case 762:
-#line 14964 "inc/vcf/validator_detail_v43.hpp"
+#line 14963 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -14989,7 +14988,7 @@ st640:
 	if ( ++p == pe )
 		goto _test_eof640;
 case 640:
-#line 14993 "inc/vcf/validator_detail_v43.hpp"
+#line 14992 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr918;
 	goto tr917;
@@ -15003,7 +15002,7 @@ st763:
 	if ( ++p == pe )
 		goto _test_eof763;
 case 763:
-#line 15007 "inc/vcf/validator_detail_v43.hpp"
+#line 15006 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15021,7 +15020,7 @@ st641:
 	if ( ++p == pe )
 		goto _test_eof641;
 case 641:
-#line 15025 "inc/vcf/validator_detail_v43.hpp"
+#line 15024 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr919;
@@ -15046,7 +15045,7 @@ st642:
 	if ( ++p == pe )
 		goto _test_eof642;
 case 642:
-#line 15050 "inc/vcf/validator_detail_v43.hpp"
+#line 15049 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr921;
 	goto tr920;
@@ -15060,7 +15059,7 @@ st764:
 	if ( ++p == pe )
 		goto _test_eof764;
 case 764:
-#line 15064 "inc/vcf/validator_detail_v43.hpp"
+#line 15063 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15084,7 +15083,7 @@ st765:
 	if ( ++p == pe )
 		goto _test_eof765;
 case 765:
-#line 15088 "inc/vcf/validator_detail_v43.hpp"
+#line 15087 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15114,7 +15113,7 @@ st766:
 	if ( ++p == pe )
 		goto _test_eof766;
 case 766:
-#line 15118 "inc/vcf/validator_detail_v43.hpp"
+#line 15117 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15144,7 +15143,7 @@ st643:
 	if ( ++p == pe )
 		goto _test_eof643;
 case 643:
-#line 15148 "inc/vcf/validator_detail_v43.hpp"
+#line 15147 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr922;
@@ -15169,7 +15168,7 @@ st644:
 	if ( ++p == pe )
 		goto _test_eof644;
 case 644:
-#line 15173 "inc/vcf/validator_detail_v43.hpp"
+#line 15172 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr924;
 	goto tr923;
@@ -15183,7 +15182,7 @@ st767:
 	if ( ++p == pe )
 		goto _test_eof767;
 case 767:
-#line 15187 "inc/vcf/validator_detail_v43.hpp"
+#line 15186 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15207,7 +15206,7 @@ st768:
 	if ( ++p == pe )
 		goto _test_eof768;
 case 768:
-#line 15211 "inc/vcf/validator_detail_v43.hpp"
+#line 15210 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15238,7 +15237,7 @@ st769:
 	if ( ++p == pe )
 		goto _test_eof769;
 case 769:
-#line 15242 "inc/vcf/validator_detail_v43.hpp"
+#line 15241 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15267,7 +15266,7 @@ st645:
 	if ( ++p == pe )
 		goto _test_eof645;
 case 645:
-#line 15271 "inc/vcf/validator_detail_v43.hpp"
+#line 15270 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr926;
 	goto tr925;
@@ -15281,7 +15280,7 @@ st770:
 	if ( ++p == pe )
 		goto _test_eof770;
 case 770:
-#line 15285 "inc/vcf/validator_detail_v43.hpp"
+#line 15284 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15299,7 +15298,7 @@ st771:
 	if ( ++p == pe )
 		goto _test_eof771;
 case 771:
-#line 15303 "inc/vcf/validator_detail_v43.hpp"
+#line 15302 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15328,7 +15327,7 @@ st646:
 	if ( ++p == pe )
 		goto _test_eof646;
 case 646:
-#line 15332 "inc/vcf/validator_detail_v43.hpp"
+#line 15331 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr928;
 	goto tr927;
@@ -15342,7 +15341,7 @@ st772:
 	if ( ++p == pe )
 		goto _test_eof772;
 case 772:
-#line 15346 "inc/vcf/validator_detail_v43.hpp"
+#line 15345 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15364,7 +15363,7 @@ st773:
 	if ( ++p == pe )
 		goto _test_eof773;
 case 773:
-#line 15368 "inc/vcf/validator_detail_v43.hpp"
+#line 15367 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15394,7 +15393,7 @@ st647:
 	if ( ++p == pe )
 		goto _test_eof647;
 case 647:
-#line 15398 "inc/vcf/validator_detail_v43.hpp"
+#line 15397 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 48: goto tr929;
@@ -15420,7 +15419,7 @@ st648:
 	if ( ++p == pe )
 		goto _test_eof648;
 case 648:
-#line 15424 "inc/vcf/validator_detail_v43.hpp"
+#line 15423 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr931;
@@ -15445,7 +15444,7 @@ st649:
 	if ( ++p == pe )
 		goto _test_eof649;
 case 649:
-#line 15449 "inc/vcf/validator_detail_v43.hpp"
+#line 15448 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr933;
 	goto tr932;
@@ -15459,7 +15458,7 @@ st774:
 	if ( ++p == pe )
 		goto _test_eof774;
 case 774:
-#line 15463 "inc/vcf/validator_detail_v43.hpp"
+#line 15462 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15479,7 +15478,7 @@ st650:
 	if ( ++p == pe )
 		goto _test_eof650;
 case 650:
-#line 15483 "inc/vcf/validator_detail_v43.hpp"
+#line 15482 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr935;
 		case 45: goto tr935;
@@ -15499,7 +15498,7 @@ st651:
 	if ( ++p == pe )
 		goto _test_eof651;
 case 651:
-#line 15503 "inc/vcf/validator_detail_v43.hpp"
+#line 15502 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr937;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15515,7 +15514,7 @@ st775:
 	if ( ++p == pe )
 		goto _test_eof775;
 case 775:
-#line 15519 "inc/vcf/validator_detail_v43.hpp"
+#line 15518 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15538,7 +15537,7 @@ st652:
 	if ( ++p == pe )
 		goto _test_eof652;
 case 652:
-#line 15542 "inc/vcf/validator_detail_v43.hpp"
+#line 15541 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr939;
 	goto tr934;
@@ -15552,7 +15551,7 @@ st776:
 	if ( ++p == pe )
 		goto _test_eof776;
 case 776:
-#line 15556 "inc/vcf/validator_detail_v43.hpp"
+#line 15555 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15574,7 +15573,7 @@ st653:
 	if ( ++p == pe )
 		goto _test_eof653;
 case 653:
-#line 15578 "inc/vcf/validator_detail_v43.hpp"
+#line 15577 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr940;
 		case 45: goto tr940;
@@ -15592,7 +15591,7 @@ st654:
 	if ( ++p == pe )
 		goto _test_eof654;
 case 654:
-#line 15596 "inc/vcf/validator_detail_v43.hpp"
+#line 15595 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr941;
 	goto tr934;
@@ -15606,7 +15605,7 @@ st777:
 	if ( ++p == pe )
 		goto _test_eof777;
 case 777:
-#line 15610 "inc/vcf/validator_detail_v43.hpp"
+#line 15609 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15626,7 +15625,7 @@ st655:
 	if ( ++p == pe )
 		goto _test_eof655;
 case 655:
-#line 15630 "inc/vcf/validator_detail_v43.hpp"
+#line 15629 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr942;
 	goto tr934;
@@ -15640,7 +15639,7 @@ st656:
 	if ( ++p == pe )
 		goto _test_eof656;
 case 656:
-#line 15644 "inc/vcf/validator_detail_v43.hpp"
+#line 15643 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr943;
 	goto tr934;
@@ -15654,7 +15653,7 @@ st778:
 	if ( ++p == pe )
 		goto _test_eof778;
 case 778:
-#line 15658 "inc/vcf/validator_detail_v43.hpp"
+#line 15657 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15672,7 +15671,7 @@ st657:
 	if ( ++p == pe )
 		goto _test_eof657;
 case 657:
-#line 15676 "inc/vcf/validator_detail_v43.hpp"
+#line 15675 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr944;
 	goto tr934;
@@ -15686,7 +15685,7 @@ st658:
 	if ( ++p == pe )
 		goto _test_eof658;
 case 658:
-#line 15690 "inc/vcf/validator_detail_v43.hpp"
+#line 15689 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr943;
 	goto tr934;
@@ -15704,7 +15703,7 @@ st779:
 	if ( ++p == pe )
 		goto _test_eof779;
 case 779:
-#line 15708 "inc/vcf/validator_detail_v43.hpp"
+#line 15707 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15734,7 +15733,7 @@ st659:
 	if ( ++p == pe )
 		goto _test_eof659;
 case 659:
-#line 15738 "inc/vcf/validator_detail_v43.hpp"
+#line 15737 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr945;
@@ -15759,7 +15758,7 @@ st660:
 	if ( ++p == pe )
 		goto _test_eof660;
 case 660:
-#line 15763 "inc/vcf/validator_detail_v43.hpp"
+#line 15762 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr947;
 	goto tr946;
@@ -15773,7 +15772,7 @@ st780:
 	if ( ++p == pe )
 		goto _test_eof780;
 case 780:
-#line 15777 "inc/vcf/validator_detail_v43.hpp"
+#line 15776 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15797,7 +15796,7 @@ st781:
 	if ( ++p == pe )
 		goto _test_eof781;
 case 781:
-#line 15801 "inc/vcf/validator_detail_v43.hpp"
+#line 15800 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15828,7 +15827,7 @@ st661:
 	if ( ++p == pe )
 		goto _test_eof661;
 case 661:
-#line 15832 "inc/vcf/validator_detail_v43.hpp"
+#line 15831 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 46: goto tr868;
 		case 61: goto tr948;
@@ -15853,7 +15852,7 @@ st662:
 	if ( ++p == pe )
 		goto _test_eof662;
 case 662:
-#line 15857 "inc/vcf/validator_detail_v43.hpp"
+#line 15856 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr950;
 		case 45: goto tr950;
@@ -15873,7 +15872,7 @@ st663:
 	if ( ++p == pe )
 		goto _test_eof663;
 case 663:
-#line 15877 "inc/vcf/validator_detail_v43.hpp"
+#line 15876 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 73 )
 		goto tr952;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -15889,7 +15888,7 @@ st782:
 	if ( ++p == pe )
 		goto _test_eof782;
 case 782:
-#line 15893 "inc/vcf/validator_detail_v43.hpp"
+#line 15892 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15912,7 +15911,7 @@ st664:
 	if ( ++p == pe )
 		goto _test_eof664;
 case 664:
-#line 15916 "inc/vcf/validator_detail_v43.hpp"
+#line 15915 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr954;
 	goto tr949;
@@ -15926,7 +15925,7 @@ st783:
 	if ( ++p == pe )
 		goto _test_eof783;
 case 783:
-#line 15930 "inc/vcf/validator_detail_v43.hpp"
+#line 15929 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -15948,7 +15947,7 @@ st665:
 	if ( ++p == pe )
 		goto _test_eof665;
 case 665:
-#line 15952 "inc/vcf/validator_detail_v43.hpp"
+#line 15951 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr955;
 		case 45: goto tr955;
@@ -15966,7 +15965,7 @@ st666:
 	if ( ++p == pe )
 		goto _test_eof666;
 case 666:
-#line 15970 "inc/vcf/validator_detail_v43.hpp"
+#line 15969 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr956;
 	goto tr949;
@@ -15980,7 +15979,7 @@ st784:
 	if ( ++p == pe )
 		goto _test_eof784;
 case 784:
-#line 15984 "inc/vcf/validator_detail_v43.hpp"
+#line 15983 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16000,7 +15999,7 @@ st667:
 	if ( ++p == pe )
 		goto _test_eof667;
 case 667:
-#line 16004 "inc/vcf/validator_detail_v43.hpp"
+#line 16003 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr957;
 	goto tr949;
@@ -16014,7 +16013,7 @@ st668:
 	if ( ++p == pe )
 		goto _test_eof668;
 case 668:
-#line 16018 "inc/vcf/validator_detail_v43.hpp"
+#line 16017 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr958;
 	goto tr949;
@@ -16028,7 +16027,7 @@ st785:
 	if ( ++p == pe )
 		goto _test_eof785;
 case 785:
-#line 16032 "inc/vcf/validator_detail_v43.hpp"
+#line 16031 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16046,7 +16045,7 @@ st669:
 	if ( ++p == pe )
 		goto _test_eof669;
 case 669:
-#line 16050 "inc/vcf/validator_detail_v43.hpp"
+#line 16049 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr959;
 	goto tr949;
@@ -16060,7 +16059,7 @@ st670:
 	if ( ++p == pe )
 		goto _test_eof670;
 case 670:
-#line 16064 "inc/vcf/validator_detail_v43.hpp"
+#line 16063 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr958;
 	goto tr949;
@@ -16074,7 +16073,7 @@ st786:
 	if ( ++p == pe )
 		goto _test_eof786;
 case 786:
-#line 16078 "inc/vcf/validator_detail_v43.hpp"
+#line 16077 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16104,7 +16103,7 @@ st787:
 	if ( ++p == pe )
 		goto _test_eof787;
 case 787:
-#line 16108 "inc/vcf/validator_detail_v43.hpp"
+#line 16107 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16134,7 +16133,7 @@ st788:
 	if ( ++p == pe )
 		goto _test_eof788;
 case 788:
-#line 16138 "inc/vcf/validator_detail_v43.hpp"
+#line 16137 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16164,7 +16163,7 @@ st789:
 	if ( ++p == pe )
 		goto _test_eof789;
 case 789:
-#line 16168 "inc/vcf/validator_detail_v43.hpp"
+#line 16167 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16194,7 +16193,7 @@ st790:
 	if ( ++p == pe )
 		goto _test_eof790;
 case 790:
-#line 16198 "inc/vcf/validator_detail_v43.hpp"
+#line 16197 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16224,7 +16223,7 @@ st791:
 	if ( ++p == pe )
 		goto _test_eof791;
 case 791:
-#line 16228 "inc/vcf/validator_detail_v43.hpp"
+#line 16227 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16253,7 +16252,7 @@ st671:
 	if ( ++p == pe )
 		goto _test_eof671;
 case 671:
-#line 16257 "inc/vcf/validator_detail_v43.hpp"
+#line 16256 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr961;
 	goto tr960;
@@ -16267,7 +16266,7 @@ st792:
 	if ( ++p == pe )
 		goto _test_eof792;
 case 792:
-#line 16271 "inc/vcf/validator_detail_v43.hpp"
+#line 16270 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16289,7 +16288,7 @@ st793:
 	if ( ++p == pe )
 		goto _test_eof793;
 case 793:
-#line 16293 "inc/vcf/validator_detail_v43.hpp"
+#line 16292 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16319,7 +16318,7 @@ st794:
 	if ( ++p == pe )
 		goto _test_eof794;
 case 794:
-#line 16323 "inc/vcf/validator_detail_v43.hpp"
+#line 16322 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16349,7 +16348,7 @@ st795:
 	if ( ++p == pe )
 		goto _test_eof795;
 case 795:
-#line 16353 "inc/vcf/validator_detail_v43.hpp"
+#line 16352 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16379,7 +16378,7 @@ st796:
 	if ( ++p == pe )
 		goto _test_eof796;
 case 796:
-#line 16383 "inc/vcf/validator_detail_v43.hpp"
+#line 16382 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16409,7 +16408,7 @@ st797:
 	if ( ++p == pe )
 		goto _test_eof797;
 case 797:
-#line 16413 "inc/vcf/validator_detail_v43.hpp"
+#line 16412 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16439,7 +16438,7 @@ st798:
 	if ( ++p == pe )
 		goto _test_eof798;
 case 798:
-#line 16443 "inc/vcf/validator_detail_v43.hpp"
+#line 16442 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16469,7 +16468,7 @@ st799:
 	if ( ++p == pe )
 		goto _test_eof799;
 case 799:
-#line 16473 "inc/vcf/validator_detail_v43.hpp"
+#line 16472 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16499,7 +16498,7 @@ st800:
 	if ( ++p == pe )
 		goto _test_eof800;
 case 800:
-#line 16503 "inc/vcf/validator_detail_v43.hpp"
+#line 16502 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16529,7 +16528,7 @@ st801:
 	if ( ++p == pe )
 		goto _test_eof801;
 case 801:
-#line 16533 "inc/vcf/validator_detail_v43.hpp"
+#line 16532 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16558,7 +16557,7 @@ st672:
 	if ( ++p == pe )
 		goto _test_eof672;
 case 672:
-#line 16562 "inc/vcf/validator_detail_v43.hpp"
+#line 16561 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 49 )
 		goto tr963;
 	goto tr962;
@@ -16572,7 +16571,7 @@ st802:
 	if ( ++p == pe )
 		goto _test_eof802;
 case 802:
-#line 16576 "inc/vcf/validator_detail_v43.hpp"
+#line 16575 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr1019;
 		case 10: goto tr1020;
@@ -16590,7 +16589,7 @@ st673:
 	if ( ++p == pe )
 		goto _test_eof673;
 case 673:
-#line 16594 "inc/vcf/validator_detail_v43.hpp"
+#line 16593 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr826;
 	if ( (*p) < 65 ) {
@@ -16628,7 +16627,7 @@ st674:
 	if ( ++p == pe )
 		goto _test_eof674;
 case 674:
-#line 16632 "inc/vcf/validator_detail_v43.hpp"
+#line 16631 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr831;
 		case 58: goto st591;
@@ -16664,7 +16663,7 @@ st675:
 	if ( ++p == pe )
 		goto _test_eof675;
 case 675:
-#line 16668 "inc/vcf/validator_detail_v43.hpp"
+#line 16667 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr964;
 	goto tr814;
@@ -16678,7 +16677,7 @@ st676:
 	if ( ++p == pe )
 		goto _test_eof676;
 case 676:
-#line 16682 "inc/vcf/validator_detail_v43.hpp"
+#line 16681 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr822;
 		case 69: goto tr824;
@@ -16697,7 +16696,7 @@ st677:
 	if ( ++p == pe )
 		goto _test_eof677;
 case 677:
-#line 16701 "inc/vcf/validator_detail_v43.hpp"
+#line 16700 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr965;
 		case 45: goto tr965;
@@ -16715,7 +16714,7 @@ st678:
 	if ( ++p == pe )
 		goto _test_eof678;
 case 678:
-#line 16719 "inc/vcf/validator_detail_v43.hpp"
+#line 16718 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr966;
 	goto tr814;
@@ -16729,7 +16728,7 @@ st679:
 	if ( ++p == pe )
 		goto _test_eof679;
 case 679:
-#line 16733 "inc/vcf/validator_detail_v43.hpp"
+#line 16732 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -16755,7 +16754,7 @@ st680:
 	if ( ++p == pe )
 		goto _test_eof680;
 case 680:
-#line 16759 "inc/vcf/validator_detail_v43.hpp"
+#line 16758 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 110 )
 		goto tr967;
 	goto tr814;
@@ -16769,7 +16768,7 @@ st681:
 	if ( ++p == pe )
 		goto _test_eof681;
 case 681:
-#line 16773 "inc/vcf/validator_detail_v43.hpp"
+#line 16772 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 102 )
 		goto tr968;
 	goto tr814;
@@ -16793,7 +16792,7 @@ st682:
 	if ( ++p == pe )
 		goto _test_eof682;
 case 682:
-#line 16797 "inc/vcf/validator_detail_v43.hpp"
+#line 16796 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 9 )
 		goto tr822;
 	goto tr814;
@@ -16811,7 +16810,7 @@ st683:
 	if ( ++p == pe )
 		goto _test_eof683;
 case 683:
-#line 16815 "inc/vcf/validator_detail_v43.hpp"
+#line 16814 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 97 )
 		goto tr969;
 	goto tr814;
@@ -16825,7 +16824,7 @@ st684:
 	if ( ++p == pe )
 		goto _test_eof684;
 case 684:
-#line 16829 "inc/vcf/validator_detail_v43.hpp"
+#line 16828 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 78 )
 		goto tr968;
 	goto tr814;
@@ -16839,7 +16838,7 @@ st685:
 	if ( ++p == pe )
 		goto _test_eof685;
 case 685:
-#line 16843 "inc/vcf/validator_detail_v43.hpp"
+#line 16842 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 42: goto tr806;
 		case 46: goto tr970;
@@ -16878,7 +16877,7 @@ st686:
 	if ( ++p == pe )
 		goto _test_eof686;
 case 686:
-#line 16882 "inc/vcf/validator_detail_v43.hpp"
+#line 16881 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 65: goto tr971;
 		case 67: goto tr971;
@@ -16902,7 +16901,7 @@ st687:
 	if ( ++p == pe )
 		goto _test_eof687;
 case 687:
-#line 16906 "inc/vcf/validator_detail_v43.hpp"
+#line 16905 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -16938,7 +16937,7 @@ st688:
 	if ( ++p == pe )
 		goto _test_eof688;
 case 688:
-#line 16942 "inc/vcf/validator_detail_v43.hpp"
+#line 16941 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 61 )
 		goto tr972;
 	if ( (*p) < 63 ) {
@@ -16978,7 +16977,7 @@ st689:
 	if ( ++p == pe )
 		goto _test_eof689;
 case 689:
-#line 16982 "inc/vcf/validator_detail_v43.hpp"
+#line 16981 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 62 )
 		goto tr974;
 	if ( (*p) < 45 ) {
@@ -17010,7 +17009,7 @@ st690:
 	if ( ++p == pe )
 		goto _test_eof690;
 case 690:
-#line 17014 "inc/vcf/validator_detail_v43.hpp"
+#line 17013 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 44: goto tr813;
@@ -17039,7 +17038,7 @@ st691:
 	if ( ++p == pe )
 		goto _test_eof691;
 case 691:
-#line 17043 "inc/vcf/validator_detail_v43.hpp"
+#line 17042 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr978;
 		case 59: goto tr978;
@@ -17071,7 +17070,7 @@ st692:
 	if ( ++p == pe )
 		goto _test_eof692;
 case 692:
-#line 17075 "inc/vcf/validator_detail_v43.hpp"
+#line 17074 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr978;
 		case 58: goto tr980;
@@ -17099,7 +17098,7 @@ st693:
 	if ( ++p == pe )
 		goto _test_eof693;
 case 693:
-#line 17103 "inc/vcf/validator_detail_v43.hpp"
+#line 17102 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr981;
 	goto tr805;
@@ -17113,7 +17112,7 @@ st694:
 	if ( ++p == pe )
 		goto _test_eof694;
 case 694:
-#line 17117 "inc/vcf/validator_detail_v43.hpp"
+#line 17116 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr974;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17129,7 +17128,7 @@ st695:
 	if ( ++p == pe )
 		goto _test_eof695;
 case 695:
-#line 17133 "inc/vcf/validator_detail_v43.hpp"
+#line 17132 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr982;
 		case 59: goto tr982;
@@ -17160,7 +17159,7 @@ st696:
 	if ( ++p == pe )
 		goto _test_eof696;
 case 696:
-#line 17164 "inc/vcf/validator_detail_v43.hpp"
+#line 17163 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr982;
 		case 59: goto tr982;
@@ -17189,7 +17188,7 @@ st697:
 	if ( ++p == pe )
 		goto _test_eof697;
 case 697:
-#line 17193 "inc/vcf/validator_detail_v43.hpp"
+#line 17192 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr980;
 	goto tr805;
@@ -17203,7 +17202,7 @@ st698:
 	if ( ++p == pe )
 		goto _test_eof698;
 case 698:
-#line 17207 "inc/vcf/validator_detail_v43.hpp"
+#line 17206 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr984;
 		case 59: goto tr984;
@@ -17235,7 +17234,7 @@ st699:
 	if ( ++p == pe )
 		goto _test_eof699;
 case 699:
-#line 17239 "inc/vcf/validator_detail_v43.hpp"
+#line 17238 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr984;
 		case 58: goto tr986;
@@ -17263,7 +17262,7 @@ st700:
 	if ( ++p == pe )
 		goto _test_eof700;
 case 700:
-#line 17267 "inc/vcf/validator_detail_v43.hpp"
+#line 17266 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr987;
 	goto tr805;
@@ -17277,7 +17276,7 @@ st701:
 	if ( ++p == pe )
 		goto _test_eof701;
 case 701:
-#line 17281 "inc/vcf/validator_detail_v43.hpp"
+#line 17280 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr974;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17293,7 +17292,7 @@ st702:
 	if ( ++p == pe )
 		goto _test_eof702;
 case 702:
-#line 17297 "inc/vcf/validator_detail_v43.hpp"
+#line 17296 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr988;
 		case 59: goto tr988;
@@ -17324,7 +17323,7 @@ st703:
 	if ( ++p == pe )
 		goto _test_eof703;
 case 703:
-#line 17328 "inc/vcf/validator_detail_v43.hpp"
+#line 17327 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr988;
 		case 59: goto tr988;
@@ -17353,7 +17352,7 @@ st704:
 	if ( ++p == pe )
 		goto _test_eof704;
 case 704:
-#line 17357 "inc/vcf/validator_detail_v43.hpp"
+#line 17356 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr986;
 	goto tr805;
@@ -17371,7 +17370,7 @@ st705:
 	if ( ++p == pe )
 		goto _test_eof705;
 case 705:
-#line 17375 "inc/vcf/validator_detail_v43.hpp"
+#line 17374 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr990;
 		case 59: goto tr990;
@@ -17403,7 +17402,7 @@ st706:
 	if ( ++p == pe )
 		goto _test_eof706;
 case 706:
-#line 17407 "inc/vcf/validator_detail_v43.hpp"
+#line 17406 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr990;
 		case 58: goto tr992;
@@ -17431,7 +17430,7 @@ st707:
 	if ( ++p == pe )
 		goto _test_eof707;
 case 707:
-#line 17435 "inc/vcf/validator_detail_v43.hpp"
+#line 17434 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr993;
 	goto tr805;
@@ -17445,7 +17444,7 @@ st708:
 	if ( ++p == pe )
 		goto _test_eof708;
 case 708:
-#line 17449 "inc/vcf/validator_detail_v43.hpp"
+#line 17448 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 91 )
 		goto tr994;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17461,7 +17460,7 @@ st709:
 	if ( ++p == pe )
 		goto _test_eof709;
 case 709:
-#line 17465 "inc/vcf/validator_detail_v43.hpp"
+#line 17464 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr995;
 		case 59: goto tr995;
@@ -17492,7 +17491,7 @@ st710:
 	if ( ++p == pe )
 		goto _test_eof710;
 case 710:
-#line 17496 "inc/vcf/validator_detail_v43.hpp"
+#line 17495 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr995;
 		case 59: goto tr995;
@@ -17521,7 +17520,7 @@ st711:
 	if ( ++p == pe )
 		goto _test_eof711;
 case 711:
-#line 17525 "inc/vcf/validator_detail_v43.hpp"
+#line 17524 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr992;
 	goto tr805;
@@ -17539,7 +17538,7 @@ st712:
 	if ( ++p == pe )
 		goto _test_eof712;
 case 712:
-#line 17543 "inc/vcf/validator_detail_v43.hpp"
+#line 17542 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr997;
 		case 59: goto tr997;
@@ -17571,7 +17570,7 @@ st713:
 	if ( ++p == pe )
 		goto _test_eof713;
 case 713:
-#line 17575 "inc/vcf/validator_detail_v43.hpp"
+#line 17574 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr997;
 		case 58: goto tr999;
@@ -17599,7 +17598,7 @@ st714:
 	if ( ++p == pe )
 		goto _test_eof714;
 case 714:
-#line 17603 "inc/vcf/validator_detail_v43.hpp"
+#line 17602 "inc/vcf/validator_detail_v43.hpp"
 	if ( 48 <= (*p) && (*p) <= 57 )
 		goto tr1000;
 	goto tr805;
@@ -17613,7 +17612,7 @@ st715:
 	if ( ++p == pe )
 		goto _test_eof715;
 case 715:
-#line 17617 "inc/vcf/validator_detail_v43.hpp"
+#line 17616 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 93 )
 		goto tr994;
 	if ( 48 <= (*p) && (*p) <= 57 )
@@ -17629,7 +17628,7 @@ st716:
 	if ( ++p == pe )
 		goto _test_eof716;
 case 716:
-#line 17633 "inc/vcf/validator_detail_v43.hpp"
+#line 17632 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1001;
 		case 59: goto tr1001;
@@ -17660,7 +17659,7 @@ st717:
 	if ( ++p == pe )
 		goto _test_eof717;
 case 717:
-#line 17664 "inc/vcf/validator_detail_v43.hpp"
+#line 17663 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 43: goto tr1001;
 		case 59: goto tr1001;
@@ -17689,7 +17688,7 @@ st718:
 	if ( ++p == pe )
 		goto _test_eof718;
 case 718:
-#line 17693 "inc/vcf/validator_detail_v43.hpp"
+#line 17692 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 58 )
 		goto tr999;
 	goto tr805;
@@ -17707,7 +17706,7 @@ st719:
 	if ( ++p == pe )
 		goto _test_eof719;
 case 719:
-#line 17711 "inc/vcf/validator_detail_v43.hpp"
+#line 17710 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 9: goto tr812;
 		case 65: goto tr971;
@@ -17762,7 +17761,7 @@ st720:
 	if ( ++p == pe )
 		goto _test_eof720;
 case 720:
-#line 17766 "inc/vcf/validator_detail_v43.hpp"
+#line 17765 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st724;
 	goto tr774;
@@ -17791,7 +17790,7 @@ st721:
 	if ( ++p == pe )
 		goto _test_eof721;
 case 721:
-#line 17795 "inc/vcf/validator_detail_v43.hpp"
+#line 17794 "inc/vcf/validator_detail_v43.hpp"
 	if ( (*p) == 10 )
 		goto st22;
 	goto tr0;
@@ -17811,7 +17810,7 @@ st722:
 	if ( ++p == pe )
 		goto _test_eof722;
 case 722:
-#line 17815 "inc/vcf/validator_detail_v43.hpp"
+#line 17814 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1006;
 		case 13: goto tr1007;
@@ -17828,14 +17827,14 @@ tr1006:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 917 "src/vcf/vcf_v43.ragel"
+#line 916 "src/vcf/vcf_v43.ragel"
 	{ {goto st28;} }
 	goto st803;
 st803:
 	if ( ++p == pe )
 		goto _test_eof803;
 case 803:
-#line 17839 "inc/vcf/validator_detail_v43.hpp"
+#line 17838 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 tr1010:
 #line 43 "src/vcf/vcf_v43.ragel"
@@ -17853,7 +17852,7 @@ st723:
 	if ( ++p == pe )
 		goto _test_eof723;
 case 723:
-#line 17857 "inc/vcf/validator_detail_v43.hpp"
+#line 17856 "inc/vcf/validator_detail_v43.hpp"
 	switch( (*p) ) {
 		case 10: goto tr1009;
 		case 13: goto tr1010;
@@ -17870,14 +17869,14 @@ tr1009:
             std::cout << "Lines read: " << n_lines << std::endl;
         }
     }
-#line 918 "src/vcf/vcf_v43.ragel"
+#line 917 "src/vcf/vcf_v43.ragel"
 	{ {goto st728;} }
 	goto st804;
 st804:
 	if ( ++p == pe )
 		goto _test_eof804;
 case 804:
-#line 17881 "inc/vcf/validator_detail_v43.hpp"
+#line 17880 "inc/vcf/validator_detail_v43.hpp"
 	goto st0;
 	}
 	_test_eof2: cs = 2; goto _test_eof; 
@@ -18805,8 +18804,7 @@ case 804:
 #line 238 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         p--; {goto st722;}
     }
 #line 60 "src/vcf/vcf_v43.ragel"
@@ -18837,7 +18835,7 @@ case 804:
 	case 96: 
 	case 103: 
 	case 114: 
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -18856,7 +18854,7 @@ case 804:
 	case 446: 
 	case 447: 
 	case 448: 
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 257 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -18896,7 +18894,7 @@ case 804:
 	case 496: 
 	case 497: 
 	case 498: 
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 263 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -18931,7 +18929,7 @@ case 804:
 	case 147: 
 	case 154: 
 	case 165: 
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -18978,7 +18976,7 @@ case 804:
 	case 213: 
 	case 220: 
 	case 231: 
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19024,7 +19022,7 @@ case 804:
 	case 279: 
 	case 286: 
 	case 297: 
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19069,7 +19067,7 @@ case 804:
 	case 403: 
 	case 404: 
 	case 405: 
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19091,7 +19089,7 @@ case 804:
 	case 507: 
 	case 508: 
 	case 509: 
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 328 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -19134,7 +19132,7 @@ case 804:
 	case 348: 
 	case 349: 
 	case 351: 
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19174,7 +19172,7 @@ case 804:
 	case 438: 
 	case 439: 
 	case 440: 
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 355 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -19189,7 +19187,7 @@ case 804:
 	case 597: 
 	case 598: 
 	case 599: 
-#line 395 "src/vcf/vcf_v43.ragel"
+#line 394 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ChromosomeBodyError{n_lines});
         p--; {goto st723;}
@@ -19202,7 +19200,7 @@ case 804:
 	break;
 	case 579: 
 	case 580: 
-#line 401 "src/vcf/vcf_v43.ragel"
+#line 400 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new PositionBodyError{n_lines});
         p--; {goto st723;}
@@ -19215,7 +19213,7 @@ case 804:
 	break;
 	case 581: 
 	case 582: 
-#line 407 "src/vcf/vcf_v43.ragel"
+#line 406 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new IdBodyError{n_lines});
         p--; {goto st723;}
@@ -19228,7 +19226,7 @@ case 804:
 	break;
 	case 583: 
 	case 584: 
-#line 413 "src/vcf/vcf_v43.ragel"
+#line 412 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new ReferenceAlleleBodyError{n_lines});
         p--; {goto st723;}
@@ -19276,7 +19274,7 @@ case 804:
 	case 717: 
 	case 718: 
 	case 719: 
-#line 419 "src/vcf/vcf_v43.ragel"
+#line 418 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new AlternateAllelesBodyError{n_lines});
         p--; {goto st723;}
@@ -19300,7 +19298,7 @@ case 804:
 	case 682: 
 	case 683: 
 	case 684: 
-#line 425 "src/vcf/vcf_v43.ragel"
+#line 424 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new QualityBodyError{n_lines});
         p--; {goto st723;}
@@ -19316,7 +19314,7 @@ case 804:
 	case 592: 
 	case 673: 
 	case 674: 
-#line 431 "src/vcf/vcf_v43.ragel"
+#line 430 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FilterBodyError{n_lines});
         p--; {goto st723;}
@@ -19329,7 +19327,7 @@ case 804:
 	break;
 	case 594: 
 	case 595: 
-#line 621 "src/vcf/vcf_v43.ragel"
+#line 620 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new FormatBodyError{n_lines, "Format does not start with a letter/underscore followed by alphanumeric/underscore/dot characters"});
         p--; {goto st723;}
@@ -19349,7 +19347,7 @@ case 804:
 	case 574: 
 	case 575: 
 	case 576: 
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
@@ -19371,13 +19369,13 @@ case 804:
 	case 81: 
 	case 82: 
 	case 83: 
-#line 251 "src/vcf/vcf_v43.ragel"
+#line 250 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines,
             "ALT metadata ID is not prefixed by DEL/INS/DUP/INV/CNV and suffixed by ':' and a text sequence"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -19389,12 +19387,12 @@ case 804:
     }
 	break;
 	case 122: 
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19408,12 +19406,12 @@ case 804:
 	case 192: 
 	case 193: 
 	case 239: 
-#line 281 "src/vcf/vcf_v43.ragel"
+#line 280 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "FORMAT metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19427,12 +19425,12 @@ case 804:
 	case 258: 
 	case 259: 
 	case 305: 
-#line 297 "src/vcf/vcf_v43.ragel"
+#line 296 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Number is not a number, A, R, G or dot"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19445,12 +19443,12 @@ case 804:
 	break;
 	case 199: 
 	case 200: 
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 301 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19463,12 +19461,12 @@ case 804:
 	break;
 	case 265: 
 	case 266: 
-#line 302 "src/vcf/vcf_v43.ragel"
+#line 301 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "INFO metadata Type is not Integer, Float, Flag, Character or String"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19482,12 +19480,12 @@ case 804:
 	case 406: 
 	case 407: 
 	case 408: 
-#line 313 "src/vcf/vcf_v43.ragel"
+#line 312 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Original is not valid"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19504,12 +19502,12 @@ case 804:
 	case 384: 
 	case 385: 
 	case 386: 
-#line 318 "src/vcf/vcf_v43.ragel"
+#line 317 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata Father or Mother is not valid"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19531,12 +19529,12 @@ case 804:
 	case 395: 
 	case 396: 
 	case 397: 
-#line 323 "src/vcf/vcf_v43.ragel"
+#line 322 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "PEDIGREE metadata sequence of Name_N is not valid"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19549,12 +19547,12 @@ case 804:
 	break;
 	case 324: 
 	case 325: 
-#line 340 "src/vcf/vcf_v43.ragel"
+#line 339 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Number is not a dot"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19572,12 +19570,12 @@ case 804:
 	case 335: 
 	case 336: 
 	case 337: 
-#line 345 "src/vcf/vcf_v43.ragel"
+#line 344 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Type is not String"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19590,12 +19588,12 @@ case 804:
 	break;
 	case 347: 
 	case 350: 
-#line 350 "src/vcf/vcf_v43.ragel"
+#line 349 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "META metadata Values is not a square-bracket delimited list of values"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19609,12 +19607,12 @@ case 804:
 	case 100: 
 	case 101: 
 	case 102: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -19627,12 +19625,12 @@ case 804:
 	break;
 	case 478: 
 	case 479: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 263 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
@@ -19649,12 +19647,12 @@ case 804:
 	case 151: 
 	case 152: 
 	case 153: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -19671,12 +19669,12 @@ case 804:
 	case 217: 
 	case 218: 
 	case 219: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19693,12 +19691,12 @@ case 804:
 	case 283: 
 	case 284: 
 	case 285: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19712,12 +19710,12 @@ case 804:
 	case 364: 
 	case 365: 
 	case 366: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
@@ -19731,12 +19729,12 @@ case 804:
 	case 314: 
 	case 315: 
 	case 316: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
@@ -19750,12 +19748,12 @@ case 804:
 	case 419: 
 	case 420: 
 	case 421: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 355 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
@@ -19780,12 +19778,12 @@ case 804:
 	case 116: 
 	case 120: 
 	case 121: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -19810,12 +19808,12 @@ case 804:
 	case 167: 
 	case 171: 
 	case 172: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -19840,12 +19838,12 @@ case 804:
 	case 233: 
 	case 237: 
 	case 238: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -19870,12 +19868,12 @@ case 804:
 	case 299: 
 	case 303: 
 	case 304: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -19905,12 +19903,12 @@ case 804:
 	case 465: 
 	case 466: 
 	case 467: 
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 371 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 257 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
@@ -19942,12 +19940,12 @@ case 804:
 	case 528: 
 	case 529: 
 	case 530: 
-#line 372 "src/vcf/vcf_v43.ragel"
+#line 371 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata URL is not valid"});
         p--; {goto st722;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 328 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -19995,12 +19993,12 @@ case 804:
 	case 565: 
 	case 566: 
 	case 567: 
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 377 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -20029,12 +20027,12 @@ case 804:
     }
 	break;
 	case 601: 
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 626 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -20128,7 +20126,7 @@ case 804:
 	{
         ParsePolicy::handle_column_end(*this, n_columns);
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
@@ -20166,12 +20164,12 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 377 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -20202,17 +20200,17 @@ case 804:
 	case 108: 
 	case 109: 
 	case 110: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -20226,17 +20224,17 @@ case 804:
 	case 159: 
 	case 160: 
 	case 161: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -20250,17 +20248,17 @@ case 804:
 	case 225: 
 	case 226: 
 	case 227: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -20274,17 +20272,17 @@ case 804:
 	case 291: 
 	case 292: 
 	case 293: 
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -20298,17 +20296,17 @@ case 804:
 	case 117: 
 	case 118: 
 	case 119: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
@@ -20322,17 +20320,17 @@ case 804:
 	case 168: 
 	case 169: 
 	case 170: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
@@ -20346,17 +20344,17 @@ case 804:
 	case 234: 
 	case 235: 
 	case 236: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
@@ -20370,17 +20368,17 @@ case 804:
 	case 300: 
 	case 301: 
 	case 302: 
-#line 367 "src/vcf/vcf_v43.ragel"
+#line 366 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata description string is not valid"});
         p--; {goto st722;}
     }
-#line 362 "src/vcf/vcf_v43.ragel"
+#line 361 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Metadata ID contains a character different from alphanumeric, dot, underscore and dash"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
@@ -20408,17 +20406,17 @@ case 804:
 	case 648: 
 	case 659: 
 	case 661: 
-#line 442 "src/vcf/vcf_v43.ragel"
+#line 441 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info key is not a sequence of alphanumeric and/or punctuation characters"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20430,17 +20428,17 @@ case 804:
     }
 	break;
 	case 603: 
-#line 447 "src/vcf/vcf_v43.ragel"
+#line 446 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info field value is not a comma-separated list of valid strings (maybe it contains whitespaces?)"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20452,7 +20450,7 @@ case 804:
     }
 	break;
 	case 606: 
-#line 452 "src/vcf/vcf_v43.ragel"
+#line 451 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20460,12 +20458,12 @@ case 804:
                 "AA"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20477,7 +20475,7 @@ case 804:
     }
 	break;
 	case 608: 
-#line 460 "src/vcf/vcf_v43.ragel"
+#line 459 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20485,12 +20483,12 @@ case 804:
                 "AC"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20502,7 +20500,7 @@ case 804:
     }
 	break;
 	case 610: 
-#line 468 "src/vcf/vcf_v43.ragel"
+#line 467 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20510,12 +20508,12 @@ case 804:
                 "AD"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20527,7 +20525,7 @@ case 804:
     }
 	break;
 	case 612: 
-#line 476 "src/vcf/vcf_v43.ragel"
+#line 475 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20535,12 +20533,12 @@ case 804:
                 "ADF"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20552,7 +20550,7 @@ case 804:
     }
 	break;
 	case 614: 
-#line 484 "src/vcf/vcf_v43.ragel"
+#line 483 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20560,12 +20558,12 @@ case 804:
                 "ADR"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20585,7 +20583,7 @@ case 804:
 	case 622: 
 	case 623: 
 	case 624: 
-#line 492 "src/vcf/vcf_v43.ragel"
+#line 491 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20593,12 +20591,12 @@ case 804:
                 "AF"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20610,7 +20608,7 @@ case 804:
     }
 	break;
 	case 626: 
-#line 500 "src/vcf/vcf_v43.ragel"
+#line 499 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20618,12 +20616,12 @@ case 804:
                 "AN"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20643,7 +20641,7 @@ case 804:
 	case 634: 
 	case 635: 
 	case 636: 
-#line 508 "src/vcf/vcf_v43.ragel"
+#line 507 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20651,12 +20649,12 @@ case 804:
                 "BQ"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20669,7 +20667,7 @@ case 804:
 	break;
 	case 638: 
 	case 639: 
-#line 516 "src/vcf/vcf_v43.ragel"
+#line 515 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20677,12 +20675,12 @@ case 804:
                 "CIGAR"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20694,7 +20692,7 @@ case 804:
     }
 	break;
 	case 640: 
-#line 524 "src/vcf/vcf_v43.ragel"
+#line 523 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20702,12 +20700,12 @@ case 804:
                 "DB"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20719,7 +20717,7 @@ case 804:
     }
 	break;
 	case 642: 
-#line 532 "src/vcf/vcf_v43.ragel"
+#line 531 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20727,12 +20725,12 @@ case 804:
                 "DP"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20744,7 +20742,7 @@ case 804:
     }
 	break;
 	case 644: 
-#line 540 "src/vcf/vcf_v43.ragel"
+#line 539 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20752,12 +20750,12 @@ case 804:
                 "END"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20769,7 +20767,7 @@ case 804:
     }
 	break;
 	case 645: 
-#line 548 "src/vcf/vcf_v43.ragel"
+#line 547 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20777,12 +20775,12 @@ case 804:
                 "H2"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20794,7 +20792,7 @@ case 804:
     }
 	break;
 	case 646: 
-#line 556 "src/vcf/vcf_v43.ragel"
+#line 555 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20802,12 +20800,12 @@ case 804:
                 "H3"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20827,7 +20825,7 @@ case 804:
 	case 656: 
 	case 657: 
 	case 658: 
-#line 564 "src/vcf/vcf_v43.ragel"
+#line 563 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20835,12 +20833,12 @@ case 804:
                 "MQ"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20852,7 +20850,7 @@ case 804:
     }
 	break;
 	case 649: 
-#line 572 "src/vcf/vcf_v43.ragel"
+#line 571 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20860,12 +20858,12 @@ case 804:
                 "MQ0"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20877,7 +20875,7 @@ case 804:
     }
 	break;
 	case 660: 
-#line 580 "src/vcf/vcf_v43.ragel"
+#line 579 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20885,12 +20883,12 @@ case 804:
                 "NS"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20910,7 +20908,7 @@ case 804:
 	case 668: 
 	case 669: 
 	case 670: 
-#line 588 "src/vcf/vcf_v43.ragel"
+#line 587 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20918,12 +20916,12 @@ case 804:
                 "SB"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20935,7 +20933,7 @@ case 804:
     }
 	break;
 	case 671: 
-#line 596 "src/vcf/vcf_v43.ragel"
+#line 595 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20943,12 +20941,12 @@ case 804:
                 "SOMATIC"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20960,7 +20958,7 @@ case 804:
     }
 	break;
 	case 672: 
-#line 604 "src/vcf/vcf_v43.ragel"
+#line 603 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20968,12 +20966,12 @@ case 804:
                 "VALIDATED"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -20985,7 +20983,7 @@ case 804:
     }
 	break;
 	case 604: 
-#line 612 "src/vcf/vcf_v43.ragel"
+#line 611 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{
                 n_lines,
@@ -20993,12 +20991,12 @@ case 804:
                 "1000G"});
         p--; {goto st723;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 437 "src/vcf/vcf_v43.ragel"
+#line 436 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new InfoBodyError{n_lines, "Info is not a single dot or a semicolon-separated list of key-value pairs"});
         p--; {goto st723;}
@@ -21012,7 +21010,7 @@ case 804:
 	case 729: 
 	case 730: 
 	case 731: 
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
@@ -21052,19 +21050,19 @@ case 804:
     }
 	break;
 	case 596: 
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 634 "src/vcf/vcf_v43.ragel"
+#line 633 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " does not start with a valid genotype";
         ErrorPolicy::handle_error(*this, new SamplesFieldBodyError{n_lines, message_stream.str(), "GT"});
         p--; {goto st723;}
     }
-#line 627 "src/vcf/vcf_v43.ragel"
+#line 626 "src/vcf/vcf_v43.ragel"
 	{
         std::ostringstream message_stream;
         message_stream << "Sample #" << (n_columns - 9) << " is not a valid string";
@@ -21088,12 +21086,12 @@ case 804:
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines});
         p--; {goto st722;}
     }
-#line 641 "src/vcf/vcf_v43.ragel"
+#line 640 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new BodySectionError{n_lines, "There is no newline at the end of the file"});
         p--; {goto st723;}
     }
-#line 378 "src/vcf/vcf_v43.ragel"
+#line 377 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new HeaderSectionError{n_lines,
             "The header line does not start with the mandatory columns: CHROM, POS, ID, REF, ALT, QUAL, FILTER and INFO"});
@@ -21122,52 +21120,52 @@ case 804:
     }
 	break;
 	case 24: 
-#line 246 "src/vcf/vcf_v43.ragel"
+#line 245 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in ALT metadata"});
         p--; {goto st722;}
     }
-#line 270 "src/vcf/vcf_v43.ragel"
+#line 269 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FILTER metadata"});
         p--; {goto st722;}
     }
-#line 276 "src/vcf/vcf_v43.ragel"
+#line 275 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in FORMAT metadata"});
         p--; {goto st722;}
     }
-#line 292 "src/vcf/vcf_v43.ragel"
+#line 291 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in INFO metadata"});
         p--; {goto st722;}
     }
-#line 258 "src/vcf/vcf_v43.ragel"
+#line 257 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in assembly metadata"});
         p--; {goto st722;}
     }
-#line 264 "src/vcf/vcf_v43.ragel"
+#line 263 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in contig metadata"});
         p--; {goto st722;}
     }
-#line 335 "src/vcf/vcf_v43.ragel"
+#line 334 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in META metadata"});
         p--; {goto st722;}
     }
-#line 356 "src/vcf/vcf_v43.ragel"
+#line 355 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in SAMPLE metadata"});
         p--; {goto st722;}
     }
-#line 308 "src/vcf/vcf_v43.ragel"
+#line 307 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in PEDIGREE metadata"});
         p--; {goto st722;}
     }
-#line 329 "src/vcf/vcf_v43.ragel"
+#line 328 "src/vcf/vcf_v43.ragel"
 	{
         ErrorPolicy::handle_error(*this, new MetaSectionError{n_lines, "Error in pedigreeDB metadata"});
         p--; {goto st722;}
@@ -21178,14 +21176,14 @@ case 804:
         p--; {goto st722;}
     }
 	break;
-#line 21182 "inc/vcf/validator_detail_v43.hpp"
+#line 21180 "inc/vcf/validator_detail_v43.hpp"
 	}
 	}
 
 	_out: {}
 	}
 
-#line 947 "src/vcf/vcf_v43.ragel"
+#line 946 "src/vcf/vcf_v43.ragel"
 
     }
     

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -226,8 +226,7 @@
     # Fileformat line
     action fileformat_error {
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
         fhold; fgoto meta_section_skip;
     } 
 

--- a/src/vcf/vcf_v41.ragel
+++ b/src/vcf/vcf_v41.ragel
@@ -226,7 +226,8 @@
     # Fileformat line
     action fileformat_error {
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.1'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         fhold; fgoto meta_section_skip;
     } 
 

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -226,8 +226,7 @@
     # Fileformat line
     action fileformat_error {
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
         fhold; fgoto meta_section_skip;
     } 
 

--- a/src/vcf/vcf_v42.ragel
+++ b/src/vcf/vcf_v42.ragel
@@ -226,7 +226,8 @@
     # Fileformat line
     action fileformat_error {
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.2'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         fhold; fgoto meta_section_skip;
     } 
 

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -237,8 +237,7 @@
     # Fileformat line
     action fileformat_error {
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines,
-                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
+                new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
         fhold; fgoto meta_section_skip;
     } 
 

--- a/src/vcf/vcf_v43.ragel
+++ b/src/vcf/vcf_v43.ragel
@@ -237,7 +237,8 @@
     # Fileformat line
     action fileformat_error {
         ErrorPolicy::handle_error(*this,
-            new FileformatError{n_lines, "The fileformat declaration is not 'fileformat=VCFv4.3'"});
+            new FileformatError{n_lines,
+                "The fileformat declaration is not valid (value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')"});
         fhold; fgoto meta_section_skip;
     } 
 

--- a/test/input_files/v4.1/failed/failed_fileformat_002.vcf
+++ b/test/input_files/v4.1/failed/failed_fileformat_002.vcf
@@ -1,4 +1,0 @@
-##fileformat=VCFv4.2
-##CauseOfFailure=Non-matching version in fileformat
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/input_files/v4.2/failed/failed_fileformat_002.vcf
+++ b/test/input_files/v4.2/failed/failed_fileformat_002.vcf
@@ -1,4 +1,0 @@
-##fileformat=VCFv4.3
-##CauseOfFailure=Non-matching version in fileformat
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/input_files/v4.3/failed/failed_fileformat_002.vcf
+++ b/test/input_files/v4.3/failed/failed_fileformat_002.vcf
@@ -1,4 +1,0 @@
-##fileformat=VCFv4.1
-##CauseOfFailure=Non-matching version in fileformat
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/vcf/debugulator_integration_test.cpp
+++ b/test/vcf/debugulator_integration_test.cpp
@@ -28,10 +28,8 @@ namespace ebi
   static const std::string BEFORE_TAG = "before";
   static const std::string AFTER_TAG = "after";
 
-  bool validate(std::istream &file, const boost::filesystem::path &path, std::string report_tag, vcf::Version version)
+  bool validate(std::istream &file, const boost::filesystem::path &path, std::string report_tag)
   {
-      auto validator = ebi::vcf::build_parser("", ebi::vcf::ValidationLevel::warning, version, 2);
-
       auto db_path = boost::filesystem::path{"/tmp/"} / path.filename();
       db_path += ".debugulator_test." + report_tag + ".db";
       boost::filesystem::remove(db_path);   // make sure the db doesn't exist from previous runs
@@ -40,7 +38,7 @@ namespace ebi
       std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> reports;
       reports.emplace_back(report);
 
-      return is_valid_vcf_file(file, *validator, reports);
+      return vcf::is_valid_vcf_file(file, path.generic_string(), ebi::vcf::ValidationLevel::warning, 2, reports);
   }
 
   std::tuple<std::unique_ptr<std::stringstream>, long> fix(const boost::filesystem::path &path, std::string report_tag)
@@ -94,7 +92,6 @@ namespace ebi
 
   TEST_CASE("Fixing a VCF with duplicates", "[debugulator]")
   {
-      ebi::vcf::Version version = ebi::vcf::Version::v41;
       bool first_validation, second_validation;
       std::string debug_message;
       std::unique_ptr<std::stringstream> fixed_vcf;
@@ -104,23 +101,21 @@ namespace ebi
           auto path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_duplicated_001.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
-              first_validation = validate(file, path, BEFORE_TAG, version);
+              first_validation = validate(file, path, BEFORE_TAG);
               REQUIRE_FALSE(first_validation);
               std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
-              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG);
               debug_message = handle_test_results(path, second_validation, *fixed_vcf);
               INFO(debug_message);
               REQUIRE(second_validation);
               REQUIRE(lines == 6);
           }
-          version = static_cast<ebi::vcf::Version>(i);
       }
   }
 
   TEST_CASE("Fixing a VCF with wrong INFO fields", "[debugulator]")
   {
       boost::filesystem::path path;
-      ebi::vcf::Version version = ebi::vcf::Version::v41;
       bool first_validation, second_validation;
       std::string debug_message;
       std::unique_ptr<std::stringstream> fixed_vcf;
@@ -132,10 +127,10 @@ namespace ebi
                   "test/input_files/v4." + std::to_string(i) + "/failed/failed_body_info_038.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
-              first_validation = validate(file, path, BEFORE_TAG, version);
+              first_validation = validate(file, path, BEFORE_TAG);
               REQUIRE_FALSE(first_validation);
               std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
-              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG);
               debug_message = handle_test_results(path, second_validation, *fixed_vcf);
               INFO(debug_message);
               REQUIRE(second_validation);
@@ -147,24 +142,21 @@ namespace ebi
                   "test/input_files/v4." + std::to_string(i) + "/failed/failed_body_info_034.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
-              first_validation = validate(file, path, BEFORE_TAG, version);
+              first_validation = validate(file, path, BEFORE_TAG);
               REQUIRE_FALSE(first_validation);
               std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
-              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG);
               debug_message = handle_test_results(path, second_validation, *fixed_vcf);
               INFO(debug_message);
               REQUIRE(second_validation);
               REQUIRE(lines == 5);
           }
-
-          version = static_cast<ebi::vcf::Version>(i);
       }
   }
 
   TEST_CASE("Fixing a VCF with wrong SAMPLE fields", "[debugulator]")
   {
       boost::filesystem::path path;
-      ebi::vcf::Version version = ebi::vcf::Version::v41;
       bool first_validation, second_validation;
       std::string debug_message;
       std::unique_ptr<std::stringstream> fixed_vcf;
@@ -175,10 +167,10 @@ namespace ebi
           path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_sample_002.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
-              first_validation = validate(file, path, BEFORE_TAG, version);
+              first_validation = validate(file, path, BEFORE_TAG);
               REQUIRE_FALSE(first_validation);
               std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
-              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG);
               debug_message = handle_test_results(path, second_validation, *fixed_vcf);
               INFO(debug_message);
               REQUIRE(second_validation);
@@ -189,10 +181,10 @@ namespace ebi
           path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_sample_005.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
-              first_validation = validate(file, path, BEFORE_TAG, version);
+              first_validation = validate(file, path, BEFORE_TAG);
               REQUIRE_FALSE(first_validation);
               std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
-              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG);
               debug_message = handle_test_results(path, second_validation, *fixed_vcf);
               INFO(debug_message);
               REQUIRE(second_validation);
@@ -203,17 +195,15 @@ namespace ebi
           path = boost::filesystem::path("test/input_files/v4." + std::to_string(i) + "/failed/failed_body_sample_006.vcf");
           SECTION(path.string()) {
               std::ifstream file{path.c_str()};
-              first_validation = validate(file, path, BEFORE_TAG, version);
+              first_validation = validate(file, path, BEFORE_TAG);
               REQUIRE_FALSE(first_validation);
               std::tie(fixed_vcf, lines) = fix(path, BEFORE_TAG);
-              second_validation = validate(*fixed_vcf, path, AFTER_TAG, version);
+              second_validation = validate(*fixed_vcf, path, AFTER_TAG);
               debug_message = handle_test_results(path, second_validation, *fixed_vcf);
               INFO(debug_message);
               REQUIRE(second_validation);
               REQUIRE(lines == 5);
           }
-
-          version = static_cast<ebi::vcf::Version>(i);
       }
   }
 }

--- a/test/vcf/debugulator_integration_test.cpp
+++ b/test/vcf/debugulator_integration_test.cpp
@@ -38,7 +38,7 @@ namespace ebi
       std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> reports;
       reports.emplace_back(report);
 
-      return vcf::is_valid_vcf_file(file, path.generic_string(), ebi::vcf::ValidationLevel::warning, 2, reports);
+      return vcf::is_valid_vcf_file(file, path.string(), vcf::ValidationLevel::warning, vcf::Ploidy{2}, reports);
   }
 
   std::tuple<std::unique_ptr<std::stringstream>, long> fix(const boost::filesystem::path &path, std::string report_tag)

--- a/test/vcf/metaentry_test.cpp
+++ b/test/vcf/metaentry_test.cpp
@@ -32,7 +32,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v41,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             
@@ -59,7 +59,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v42,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
 
@@ -93,7 +93,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v43,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             
@@ -129,7 +129,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v41,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             
@@ -233,7 +233,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v42,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             
@@ -266,7 +266,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v43,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             
@@ -300,7 +300,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v41,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             
@@ -436,7 +436,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v42,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             
@@ -578,7 +578,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v43,
-            2,
+            vcf::Ploidy{2},
             {},
             { "Sample1", "Sample2", "Sample3" }};
             

--- a/test/vcf/parser_test_aux.hpp
+++ b/test/vcf/parser_test_aux.hpp
@@ -36,7 +36,7 @@ namespace ebi
         std::ifstream input{path};
         std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> outputs;
 
-        return vcf::is_valid_vcf_file(input, path, vcf::ValidationLevel::warning, 2, outputs);
+        return vcf::is_valid_vcf_file(input, path, vcf::ValidationLevel::warning, vcf::Ploidy{2}, outputs);
     }
 }
 

--- a/test/vcf/parser_test_aux.hpp
+++ b/test/vcf/parser_test_aux.hpp
@@ -31,13 +31,12 @@
 
 namespace ebi
 {
-    inline bool is_valid(std::string path, vcf::Version version)
+    inline bool is_valid(std::string path)
     {
         std::ifstream input{path};
-        auto validator = vcf::build_parser(path, vcf::ValidationLevel::warning, version, 2);
         std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> outputs;
 
-        return vcf::is_valid_vcf_file(input, *validator, outputs);
+        return vcf::is_valid_vcf_file(input, path, vcf::ValidationLevel::warning, 2, outputs);
     }
 }
 

--- a/test/vcf/parser_v41_test.cpp
+++ b/test/vcf/parser_v41_test.cpp
@@ -29,7 +29,7 @@ namespace ebi
       {
           SECTION(path.string())
           {
-              CHECK_FALSE(is_valid(path.string(), vcf::Version::v41));
+              CHECK_FALSE(is_valid(path.string()));
           }
       }
   }
@@ -44,7 +44,7 @@ namespace ebi
       {
           SECTION(path.string())
           {
-              CHECK(is_valid(path.string(), vcf::Version::v41));
+              CHECK(is_valid(path.string()));
           }
       }
   }

--- a/test/vcf/parser_v42_test.cpp
+++ b/test/vcf/parser_v42_test.cpp
@@ -29,7 +29,7 @@ namespace ebi
       {
           SECTION(path.string())
           {
-              CHECK_FALSE(is_valid(path.string(), vcf::Version::v42));
+              CHECK_FALSE(is_valid(path.string()));
           }
       }
   }
@@ -44,7 +44,7 @@ namespace ebi
       {
           SECTION(path.string())
           {
-              CHECK(is_valid(path.string(), vcf::Version::v42));
+              CHECK(is_valid(path.string()));
           }
       }
   }

--- a/test/vcf/parser_v43_test.cpp
+++ b/test/vcf/parser_v43_test.cpp
@@ -29,7 +29,7 @@ namespace ebi
       {
           SECTION(path.string())
           {
-              CHECK_FALSE(is_valid(path.string(), vcf::Version::v43));
+              CHECK_FALSE(is_valid(path.string()));
           }
       }
   }
@@ -44,7 +44,7 @@ namespace ebi
       {
           SECTION(path.string())
           {
-              CHECK(is_valid(path.string(), vcf::Version::v43));
+              CHECK(is_valid(path.string()));
           }
       }
   }

--- a/test/vcf/ploidy_test.cpp
+++ b/test/vcf/ploidy_test.cpp
@@ -31,10 +31,9 @@ namespace ebi
           std::string path = "test/input_files/v4.1/ploidy/passed_ploidy_000.vcf";
           std::ifstream input{path};
           vcf::Ploidy ploidy{3};
-          auto validator = vcf::build_parser(path, vcf::ValidationLevel::warning, vcf::Version::v41, ploidy);
           std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> outputs;
 
-          CHECK(vcf::is_valid_vcf_file(input, *validator, outputs));
+          CHECK(vcf::is_valid_vcf_file(input, path, vcf::ValidationLevel::warning, ploidy, outputs));
       }
 
       SECTION("File with 2 different ploidies")
@@ -42,10 +41,9 @@ namespace ebi
           std::string path = "test/input_files/v4.1/ploidy/passed_ploidy_001.vcf";
           std::ifstream input{path};
           vcf::Ploidy ploidy{2, {{"Y", 1}}};
-          auto validator = vcf::build_parser(path, vcf::ValidationLevel::warning, vcf::Version::v41, ploidy);
           std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> outputs;
 
-          CHECK(vcf::is_valid_vcf_file(input, *validator, outputs));
+          CHECK(vcf::is_valid_vcf_file(input, path, vcf::ValidationLevel::warning, ploidy, outputs));
       }
 
       SECTION("File with several ploidies")
@@ -53,10 +51,9 @@ namespace ebi
           std::string path = "test/input_files/v4.1/ploidy/passed_ploidy_002.vcf";
           std::ifstream input{path};
           vcf::Ploidy ploidy{2, {{"Y", 1}, {"Triploid", 3}, {"Tetraploid", 4}}};
-          auto validator = vcf::build_parser(path, vcf::ValidationLevel::warning, vcf::Version::v41, ploidy);
           std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> outputs;
 
-          CHECK(vcf::is_valid_vcf_file(input, *validator, outputs));
+          CHECK(vcf::is_valid_vcf_file(input, path, vcf::ValidationLevel::warning, ploidy, outputs));
       }
   }
 

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -30,7 +30,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v41,
-            {2, {{"Y", 1}}},
+            vcf::Ploidy{2, {{"Y", 1}}},
             {},
             { "Sample1" }};
             
@@ -431,7 +431,7 @@ namespace ebi
             "Example VCF source",
             vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
             vcf::Version::v43,
-            {2, {{"Y", 1}}},
+            vcf::Ploidy{2, {{"Y", 1}}},
             {},
             { "Sample1" }};
             

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -139,7 +139,7 @@ namespace ebi
 
   TEST_CASE("Integration test: validator and odb", "[output]")
   {
-      auto path = boost::filesystem::path("test/input_files/v4.1/failed/failed_fileformat_000.vcf");
+      auto path = boost::filesystem::path("test/input_files/v4.1/failed/failed_body_sample_000.vcf");
 
       std::string db_name = path.string() + ".errors.db";
 
@@ -160,7 +160,7 @@ namespace ebi
           }
 
           CHECK(count_errors == 1);
-          CHECK(count_warnings == 2);
+          CHECK(count_warnings == 1);
       }
 
       SECTION(path.string() + " error details")
@@ -169,9 +169,8 @@ namespace ebi
           ebi::vcf::OdbReportRW errorsDAO{db_name};
 
           errorsDAO.for_each_error([&errors_read](std::shared_ptr<ebi::vcf::Error> error) {
-              CHECK(error->line == 1);
-              CHECK(error->message == "The fileformat declaration is not valid "
-                      "(value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')");
+              CHECK(error->line == 4);
+              CHECK(error->message == "Allele index C is not an integer number");
               errors_read++;
           });
 

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -38,11 +38,10 @@ namespace ebi
       if (!input) {
           throw std::runtime_error("file not found: " + path);
       }
-      auto validator = ebi::vcf::build_parser(path, ebi::vcf::ValidationLevel::warning, ebi::vcf::Version::v41, 2);
       std::vector<std::unique_ptr<vcf::ReportWriter>> outputs;
       outputs.push_back(std::move(output));
 
-      return ebi::vcf::is_valid_vcf_file(input, *validator, outputs);
+      return ebi::vcf::is_valid_vcf_file(input, path, ebi::vcf::ValidationLevel::warning, 2, outputs);
   }
 
   TEST_CASE("Unit test: odb", "[output]")
@@ -171,7 +170,8 @@ namespace ebi
 
           errorsDAO.for_each_error([&errors_read](std::shared_ptr<ebi::vcf::Error> error) {
               CHECK(error->line == 1);
-              CHECK(error->message == "The fileformat declaration is not 'fileformat=VCFv4.1'");
+              CHECK(error->message == "The fileformat declaration is not valid "
+                      "(value must be one of 'VCFv4.1', 'VCFv4.2' or 'VCFv4.3')");
               errors_read++;
           });
 

--- a/test/vcf/report_writer_test.cpp
+++ b/test/vcf/report_writer_test.cpp
@@ -41,7 +41,7 @@ namespace ebi
       std::vector<std::unique_ptr<vcf::ReportWriter>> outputs;
       outputs.push_back(std::move(output));
 
-      return ebi::vcf::is_valid_vcf_file(input, path, ebi::vcf::ValidationLevel::warning, 2, outputs);
+      return ebi::vcf::is_valid_vcf_file(input, path, vcf::ValidationLevel::warning, vcf::Ploidy{2}, outputs);
   }
 
   TEST_CASE("Unit test: odb", "[output]")

--- a/test/vcf/test_utils.hpp
+++ b/test/vcf/test_utils.hpp
@@ -44,8 +44,12 @@ namespace ebi
   {
 
 //      std::shared_ptr<vcf::Source> source{std::make_shared<Source>(
-      std::shared_ptr<vcf::Source> source{new vcf::Source{
-              "filename.vcf", vcf::VCF_FILE_VCF, vcf::Version::v41, 2, {}, {"NA001", "NA002", "NA003", "NA004"}}};
+      std::shared_ptr<vcf::Source> source{new vcf::Source{"filename.vcf",
+                                                          vcf::VCF_FILE_VCF,
+                                                          vcf::Version::v41,
+                                                          vcf::Ploidy{2},
+                                                          {},
+                                                          {"NA001", "NA002", "NA003", "NA004"}}};
 
       source->meta_entries.emplace("FORMAT",
                                    vcf::MetaEntry{


### PR DESCRIPTION
Basically, remove the `-v` / `--version` parameter. 

To achieve this (even reading from stdin) we have to read the first line, choose a parser version, and send the first line to the parser to be processed again.

A better design would be a further refactor that joins the 3 ragel machines (one per VCF version) in a single machine, that branches into 3 sub-machines after the first line. To keep the version grammars independent (and extract common actions and basic machines) we can use the "include" feature from ragel, following the structure in [this example repo](https://github.com/jmmut/ragel-includes-test)