### PR TITLE
Extracted record.cpp check blocks into private methods

### DIFF
--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -171,19 +171,42 @@ namespace ebi
          * @throw std::invalid_argument
          */
         void check_chromosome() const;
-        
-        void check_chromosome_colons() const;
-        void check_chromosome_whitespaces() const;
 
         /**
-         * Checks that IDs are alphanumeric
+         * Checks that chromosome does not contain any colons
+         * 
+         * @throw std::invalid_argument
+         */
+        void check_chromosome_no_colons() const;
+
+        /**
+         * Checks that chromosome does not contain any white-spaces
+         * 
+         * @throw std::invalid_argument        
+         */
+        void check_chromosome_no_whitespaces() const;
+
+        /**
+         * Checks that IDs are alphanumeric and do not contain duplicate values
          * 
          * @throw std::invalid_argument
          */
         void check_ids() const;
         
-        void check_ids_semicolons_whitespaces() const;
-        void check_ids_duplicates() const;
+        /**
+         * Checks that ID contains no semicolons or white-spaces
+         * 
+         * @throw std::invalid_argument
+         */
+        void check_ids_no_semicolons_whitespaces() const;
+
+        /**
+         * Checks that ID contains no duplicate values in the same line
+         * 
+         * @throw std::invalid_argument
+         */
+        void check_ids_no_duplicates() const;
+
         /**
          * Checks the structure of an alternate allele and its accordance to the meta section
          * 
@@ -201,7 +224,12 @@ namespace ebi
          */
         void check_alternate_allele_structure(std::string const & alternate, RecordType type) const;
         
-        void check_alternate_allele_beginning(std::string const & alternate) const;
+        /**
+         * Check that alternates of the form <SOME_ALT> begin with DEL, INS, DUP, INV or CNV
+         * 
+         * @throw std::invalid_argument
+         */
+        void check_alternate_allele_symbolic_prefix(std::string const & alternate) const;
 
         /**
          * Checks that alternates of the form <SOME_ALT_ID> are described in the meta section
@@ -234,15 +262,25 @@ namespace ebi
         void check_info() const;
         
         /**
-         * Checks that format starts with GT
+         * Checks that format starts with GT and has no duplicate fields
          * 
          * @throw std::invalid_argument
          */
         void check_format() const;
-        
+
+        /**
+         * Checks that GT is the fisrt field in the FORMAT column
+         * 
+         * @throw std::invalid_argument
+         */
         void check_format_GT() const;
 
-        void check_format_duplicates() const;
+        /**
+         * Checks that format has no duplicate fields
+         * 
+         * @throw std::invalid_argument
+         */
+        void check_format_no_duplicates() const;
 
         /**
          * Checks that the samples in the record:
@@ -260,9 +298,19 @@ namespace ebi
          * @throw std::invalid_argument
          */
         void check_samples_alleles(std::vector<std::string> const & alleles) const;
-        
+
+        /**
+         * Checks that the allele index in a sample is an integer number
+         * 
+         * @throw std::invalid_argument
+         */        
         void check_samples_alleles_int(std::string const & allele, long ploidy) const;
 
+        /**
+         * Checks that the allele index is in range
+         * 
+         * @throw std::invalid_argument
+         */
         void check_samples_alleles_range(std::string const & allele, long ploidy) const;
 
         /**

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -221,7 +221,7 @@ namespace ebi
          * - Shares the first nucleotide with the reference (does not apply to SV, break-ends and custom ALTs)
          * 
          * @throw AlternateAllelesBodyError
-	 */
+         */
         void check_alternate_allele_structure(std::string const & alternate, RecordType type) const;
         
         /**
@@ -230,14 +230,6 @@ namespace ebi
          * @throw AlternateAllelesBodyError
          */
         void check_alternate_allele_symbolic_prefix(std::string const & alternate) const;
-
-        /**
-         * Checks that alternates of the form <SOME_ALT_ID> are described in the meta section
-         * 
-         * @throw AlternateAllelesBodyError
-         */
-        void check_alternate_allele_meta(std::string const & alt_id,
-                                         std::pair<meta_iterator, meta_iterator> range) const;
         
         /**
          * Checks that quality is zero or greater
@@ -331,21 +323,21 @@ namespace ebi
          * 
          * @throw SamplesFieldBodyError
          */
-        void check_samples_alleles(std::vector<std::string> const & alleles) const;
+        void check_sample_alleles(std::vector<std::string> subfields) const;
 
         /**
          * Checks that the allele index in a sample is an integer number
          * 
          * @throw SamplesFieldBodyError
          */        
-        void check_samples_alleles_is_integer(std::string const & allele, long ploidy) const;
+        void check_sample_alleles_is_integer(std::string const & allele, long ploidy) const;
 
         /**
          * Checks that the allele index is in range
          * 
          * @throw SamplesFieldBodyError
          */
-        void check_samples_alleles_range(std::string const & allele, long ploidy) const;
+        void check_sample_alleles_range(std::string const & allele, long ploidy) const;
 
         /**
          * Checks that every field in a sample matches the Number specification in the FORMAT meta

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -172,6 +172,9 @@ namespace ebi
          */
         void check_chromosome() const;
         
+        void check_chromosome_colons() const;
+        void check_chromosome_whitespaces() const;
+
         /**
          * Checks that IDs are alphanumeric
          * 
@@ -179,6 +182,8 @@ namespace ebi
          */
         void check_ids() const;
         
+        void check_ids_semicolons_whitespaces() const;
+        void check_ids_duplicates() const;
         /**
          * Checks the structure of an alternate allele and its accordance to the meta section
          * 
@@ -196,6 +201,8 @@ namespace ebi
          */
         void check_alternate_allele_structure(std::string const & alternate, RecordType type) const;
         
+        void check_alternate_allele_beginning(std::string const & alternate) const;
+
         /**
          * Checks that alternates of the form <SOME_ALT_ID> are described in the meta section
          * 
@@ -233,6 +240,10 @@ namespace ebi
          */
         void check_format() const;
         
+        void check_format_GT() const;
+
+        void check_format_duplicates() const;
+
         /**
          * Checks that the samples in the record:
          * - Are the same number as specified in the Source object
@@ -250,6 +261,10 @@ namespace ebi
          */
         void check_samples_alleles(std::vector<std::string> const & alleles) const;
         
+        void check_samples_alleles_int(std::string const & allele, long ploidy) const;
+
+        void check_samples_alleles_range(std::string const & allele, long ploidy) const;
+
         /**
          * Checks that every field in a sample matches the Number specification in the FORMAT meta
          * 

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -168,73 +168,73 @@ namespace ebi
         /**
          * Checks that chromosome does not contain colons or white-spaces
          * 
-         * @throw std::invalid_argument
+         * @throw ChromosomeBodyError
          */
         void check_chromosome() const;
 
         /**
          * Checks that chromosome does not contain any colons
          * 
-         * @throw std::invalid_argument
+         * @throw ChromosomeBodyError
          */
         void check_chromosome_no_colons() const;
 
         /**
          * Checks that chromosome does not contain any white-spaces
          * 
-         * @throw std::invalid_argument        
+         * @throw ChromosomeBodyError
          */
         void check_chromosome_no_whitespaces() const;
 
         /**
          * Checks that IDs are alphanumeric and do not contain duplicate values
          * 
-         * @throw std::invalid_argument
+         * @throw IdBodyError
          */
         void check_ids() const;
         
         /**
          * Checks that ID contains no semicolons or white-spaces
          * 
-         * @throw std::invalid_argument
+         * @throw IdBodyError
          */
         void check_ids_no_semicolons_whitespaces() const;
 
         /**
          * Checks that ID contains no duplicate values in the same line
          * 
-         * @throw std::invalid_argument
+         * @throw IdBodyError
          */
         void check_ids_no_duplicates() const;
 
         /**
          * Checks the structure of an alternate allele and its accordance to the meta section
          * 
-         * @throw std::invalid_argument
+         * @throw AlternateAllelesBodyError
          */
         void check_alternate_alleles() const;
         
         /**
-         * Checks the structure of an alternate allele:
+         * Checks the structure of an alternate allele against the reference:
          * - The dot is not combined with others
          * - Is not the same as the reference
          * - Shares the first nucleotide with the reference (does not apply to SV, break-ends and custom ALTs)
          * 
-         * @throw std::invalid_argument
-         */
+         * @throw AlternateAllelesBodyError
+	 */
         void check_alternate_allele_structure(std::string const & alternate, RecordType type) const;
         
         /**
          * Check that alternates of the form <SOME_ALT> begin with DEL, INS, DUP, INV or CNV
          * 
-         * @throw std::invalid_argument
+         * @throw AlternateAllelesBodyError
          */
         void check_alternate_allele_symbolic_prefix(std::string const & alternate) const;
 
         /**
          * Checks that alternates of the form <SOME_ALT_ID> are described in the meta section
          * 
-         * @throw std::invalid_argument
+         * @throw AlternateAllelesBodyError
          */
         void check_alternate_allele_meta(std::string const & alt_id,
                                          std::pair<meta_iterator, meta_iterator> range) const;
@@ -242,14 +242,14 @@ namespace ebi
         /**
          * Checks that quality is zero or greater
          * 
-         * @throw std::invalid_argument
+         * @throw QualityBodyError
          */
         void check_quality() const;
         
         /**
          * Checks that all the filters are listed in the meta section
          * 
-         * @throw std::invalid_argument
+         * @throw FilterBodyError
          */
         void check_filter() const;
         
@@ -257,28 +257,28 @@ namespace ebi
          * Checks that all the INFO fields are listed in the meta section, and their number and 
          * type match those specifications
          * 
-         * @throw std::invalid_argument
+         * @throw InfoBodyError
          */
         void check_info() const;
         
         /**
          * Checks that format starts with GT and has no duplicate fields
          * 
-         * @throw std::invalid_argument
+         * @throw FormatBodyError
          */
         void check_format() const;
 
         /**
-         * Checks that GT is the fisrt field in the FORMAT column
+         * Checks that GT is the first field in the FORMAT column
          * 
-         * @throw std::invalid_argument
+         * @throw FormatBodyError
          */
         void check_format_GT() const;
 
         /**
          * Checks that format has no duplicate fields
          * 
-         * @throw std::invalid_argument
+         * @throw FormatBodyError
          */
         void check_format_no_duplicates() const;
 
@@ -288,28 +288,62 @@ namespace ebi
          * - Their allele indexes are not greater than the total number of alleles
          * - The number and type of the fields match the FORMAT meta information
          * 
-         * @throw std::invalid_argument
+         * @throw SamplesBodyError
          */
         void check_samples() const;
+
+        /**
+         * Checks that the number of samples matches those listed in the header line
+         * 
+         * @throw SamplesBodyError
+         */
+        void check_samples_count() const;
+
+        /**
+         * Returns a vector of MetaEntry objects in the same order as they are displayed in the samples
+         */
+        std::vector<MetaEntry> get_meta_entry_objects() const;
+
+        /**
+         * Checks the sample contents and accordance to the meta section
+         * 
+         * @throw SamplesBodyError
+         * @throw SamplesFieldBodyError
+         */
+        void check_sample(size_t i, std::vector<MetaEntry> format_meta) const;
+
+        /**
+         * Checks that the number of subfields in the sample is not greater than the number in the FORMAT column
+         * 
+         * @throw SamplesBodyError
+         */
+        void check_sample_subfields_count(size_t i, std::vector<std::string> subfields) const;
+
+        /**
+         * Checks that the cardinality and type of the fields in the sample match the FORMAT meta information
+         * 
+         * @throw SamplesFieldBodyError
+         */
+        void check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> subfields, std::vector<MetaEntry> format_meta) const;
         
         /**
          * Check that the allele indexes in a sample are not greater than the total number of alleles
          * 
-         * @throw std::invalid_argument
+         * @throw SamplesFieldBodyError
          */
         void check_samples_alleles(std::vector<std::string> const & alleles) const;
 
         /**
          * Checks that the allele index in a sample is an integer number
          * 
-         * @throw std::invalid_argument
+         * @throw SamplesFieldBodyError
          */        
-        void check_samples_alleles_int(std::string const & allele, long ploidy) const;
+        void check_samples_alleles_is_integer(std::string const & allele, long ploidy) const;
 
         /**
          * Checks that the allele index is in range
          * 
-         * @throw std::invalid_argument
+         * @throw SamplesFieldBodyError
          */
         void check_samples_alleles_range(std::string const & allele, long ploidy) const;
 

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -302,28 +302,28 @@ namespace ebi
          * @throw SamplesBodyError
          * @throw SamplesFieldBodyError
          */
-        void check_sample(size_t i, std::vector<MetaEntry> format_meta) const;
+        void check_sample(size_t i, std::vector<MetaEntry> const & format_meta) const;
 
         /**
          * Checks that the number of subfields in the sample is not greater than the number in the FORMAT column
          * 
          * @throw SamplesBodyError
          */
-        void check_sample_subfields_count(size_t i, std::vector<std::string> subfields) const;
+        void check_sample_subfields_count(size_t i, std::vector<std::string> const & subfields) const;
 
         /**
          * Checks that the cardinality and type of the fields in the sample match the FORMAT meta information
          * 
          * @throw SamplesFieldBodyError
          */
-        void check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> subfields, std::vector<MetaEntry> format_meta) const;
+        void check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> const & subfields, std::vector<MetaEntry> const & format_meta) const;
         
         /**
          * Check that the allele indexes in a sample are not greater than the total number of alleles
          * 
          * @throw SamplesFieldBodyError
          */
-        void check_sample_alleles(std::vector<std::string> subfields) const;
+        void check_sample_alleles(std::vector<std::string> const & subfields) const;
 
         /**
          * Checks that the allele index in a sample is an integer number

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -154,10 +154,7 @@ namespace ebi
             auto & alternate = alternate_alleles[i];
             auto & type = types[i];
             
-            // Check alternate allele structure against the reference
             check_alternate_allele_structure(alternate, type);
-            
-            // Check that an alternate of the form <SOME_ALT> begins with DEL, INS, DUP, INV or CNV
             check_alternate_allele_symbolic_prefix(alternate);
         }
         
@@ -279,19 +276,32 @@ namespace ebi
 
     void Record::check_samples() const
     {
-        if (samples.size() != source->samples_names.size()) {
-            throw new SamplesBodyError{line, "The number of samples must match those listed in the header line"};
-        }
-     
+        check_samples_count();        
+        
         if (samples.size() == 0) {
             return; // Nothing to check if no samples are listed in the file
         }
         
-        // Get the MetaEntry objects in the same order as they are displayed in the samples
+        std::vector<MetaEntry> format_meta = get_meta_entry_objects();
+
+        for (size_t i = 0; i < samples.size(); ++i) {
+            check_sample(i, format_meta);
+        }
+    }
+    
+    void Record::check_samples_count() const
+    {
+        if (samples.size() != source->samples_names.size()) {
+            throw new SamplesBodyError{line, "The number of samples must match those listed in the header line"};
+        }
+    }
+
+    std::vector<MetaEntry> Record::get_meta_entry_objects() const
+    {
         typedef std::multimap<std::string, MetaEntry>::iterator iter;
         std::pair<iter, iter> range = source->meta_entries.equal_range("FORMAT");
         std::vector<MetaEntry> format_meta;
-        
+
         for (auto & fm : format) {
             bool found_in_header = false;
             
@@ -310,73 +320,81 @@ namespace ebi
                 format_meta.push_back(MetaEntry{line, ""});
             }
         }
+
+        return format_meta;
+    }
+
+    void Record::check_sample(size_t i, std::vector<MetaEntry> format_meta) const
+    {
+        std::vector<std::string> subfields;
+        util::string_split(samples[i], ":", subfields);
         
-        // Check the samples contents and accordance to the meta section
-        for (size_t i = 0; i < samples.size(); ++i) {
-            std::vector<std::string> subfields;
-            util::string_split(samples[i], ":", subfields);
+        check_sample_subfields_count(i, subfields);
+        
+        std::vector<std::string> alleles;
+        // If the first format field is not a GT, then no alleles need to be checked
+        if (format[0] == "GT") {
+            util::string_split(subfields[0], "|/", alleles);
+                
+            // The allele indexes must not be greater than the total number of alleles
+            check_samples_alleles(alleles);
+        }
+        
+        check_sample_subfields_cardinality_type(i, subfields, format_meta);
+    }
+
+    void Record::check_sample_subfields_count(size_t i, std::vector<std::string> subfields) const
+    {
+        if (subfields.size() > format.size()) {
+            throw new SamplesBodyError{line, "Sample #" + std::to_string(i+1) +
+                    " has more fields than specified in the FORMAT column"};
+        }
+    }
+
+    void Record::check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> subfields, std::vector<MetaEntry> format_meta) const
+    {
+        for (size_t j = 0; j < subfields.size(); ++j) {
+            MetaEntry meta = format_meta[j];
+            auto & subfield = subfields[j];
             
-            // The number of subfields can't be greater than the number in the FORMAT column
-            if (subfields.size() > format.size()) {
-                throw new SamplesBodyError{line, "Sample #" + std::to_string(i+1) +
-                        " has more fields than specified in the FORMAT column"};
+            if (meta.id == "") {
+                // FORMAT fields not described in the meta section can't be checked
+                continue;
             }
             
-            std::vector<std::string> alleles;
-            // If the first format field is not a GT, then no alleles need to be checked
-            if (format[0] == "GT") {
-                util::string_split(subfields[0], "|/", alleles);
-            
-                // The allele indexes must not be greater than the total number of alleles
-                check_samples_alleles(alleles);
-            }
-            
-            // The cardinality and type of the fields match the FORMAT meta information
-            for (size_t j = 0; j < subfields.size(); ++j) {
-                MetaEntry meta = format_meta[j];
-                auto & subfield = subfields[j];
-                
-                if (meta.id == "") {
-                    // FORMAT fields not described in the meta section can't be checked
-                    continue;
-                }
-                
-                auto & key_values = boost::get<std::map < std::string, std::string>>(meta.value);
+            auto & key_values = boost::get<std::map < std::string, std::string>>(meta.value);
 
-                size_t ploidy = source->ploidy.get_ploidy(chromosome);
-                try {
-                    std::vector<std::string> values;
-                    util::string_split(subfield, ",", values);
+            size_t ploidy = source->ploidy.get_ploidy(chromosome);
+            try {
+                std::vector<std::string> values;
+                util::string_split(subfield, ",", values);
 
-                    check_field_cardinality(subfield, values, key_values["Number"], ploidy);
-                    check_field_type(subfield, values, key_values["Type"]);
-                } catch (std::shared_ptr<Error> ex) {
-                    long cardinality;
-                    bool valid = is_valid_cardinality(key_values["Number"], alternate_alleles.size(), ploidy, cardinality);
-                    long number = valid ? cardinality : -1;
-                    std::string message = "Sample #" + std::to_string(i + 1) + ", "
-                            + key_values["ID"] + "=" + ex->message;
-                    throw new SamplesFieldBodyError{line, message, key_values["ID"], number};
-                }
+                check_field_cardinality(subfield, values, key_values["Number"], ploidy);
+                check_field_type(subfield, values, key_values["Type"]);
+            } catch (std::shared_ptr<Error> ex) {
+                long cardinality;
+                bool valid = is_valid_cardinality(key_values["Number"], alternate_alleles.size(), ploidy, cardinality);
+                long number = valid ? cardinality : -1;
+                std::string message = "Sample #" + std::to_string(i + 1) + ", "
+                        + key_values["ID"] + "=" + ex->message;
+                throw new SamplesFieldBodyError{line, message, key_values["ID"], number};
             }
         }
     }
-    
+
     void Record::check_samples_alleles(std::vector<std::string> const & alleles) const
     {
         long ploidy = static_cast<long>(source->ploidy.get_ploidy(chromosome));
         for (auto & allele : alleles) {
             if (allele == ".") { continue; } // No need to check missing alleles
 
-            // Discard non-integer numbers
-            check_samples_alleles_int(allele, ploidy);
+            check_samples_alleles_is_integer(allele, ploidy);
 
-            // After guaranteeing the number is an integer, check it is in range
             check_samples_alleles_range(allele, ploidy);
         }
     }
 
-    void Record::check_samples_alleles_int(std::string const & allele, long ploidy) const
+    void Record::check_samples_alleles_is_integer(std::string const & allele, long ploidy) const
     {
         if (std::find_if_not(allele.begin(), allele.end(), isdigit) != allele.end()) {
             throw new SamplesFieldBodyError{line, "Allele index " + allele + " is not an integer number",

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -324,7 +324,7 @@ namespace ebi
         return format_meta;
     }
 
-    void Record::check_sample(size_t i, std::vector<MetaEntry> format_meta) const
+    void Record::check_sample(size_t i, std::vector<MetaEntry> const & format_meta) const
     {
         std::vector<std::string> subfields;
         util::string_split(samples[i], ":", subfields);
@@ -339,7 +339,7 @@ namespace ebi
         check_sample_subfields_cardinality_type(i, subfields, format_meta);
     }
 
-    void Record::check_sample_subfields_count(size_t i, std::vector<std::string> subfields) const
+    void Record::check_sample_subfields_count(size_t i, std::vector<std::string> const & subfields) const
     {
         if (subfields.size() > format.size()) {
             throw new SamplesBodyError{line, "Sample #" + std::to_string(i+1) +
@@ -347,7 +347,7 @@ namespace ebi
         }
     }
 
-    void Record::check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> subfields, std::vector<MetaEntry> format_meta) const
+    void Record::check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> const & subfields, std::vector<MetaEntry> const & format_meta) const
     {
         for (size_t j = 0; j < subfields.size(); ++j) {
             MetaEntry meta = format_meta[j];
@@ -378,7 +378,7 @@ namespace ebi
         }
     }
 
-    void Record::check_sample_alleles(std::vector<std::string> subfields) const
+    void Record::check_sample_alleles(std::vector<std::string> const & subfields) const
     {
         std::vector<std::string> alleles;
         util::string_split(subfields[0], "|/", alleles);

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -100,18 +100,18 @@ namespace ebi
     
     void Record::check_chromosome() const
     {
-        check_chromosome_colons();
-        check_chromosome_whitespaces();
+        check_chromosome_no_colons();
+        check_chromosome_no_whitespaces();
     }
 
-    void Record::check_chromosome_colons() const
+    void Record::check_chromosome_no_colons() const
     {
         if (chromosome.find(':') != std::string::npos) {
             throw new ChromosomeBodyError{line, "Chromosome must not contain colons"};
         }
     }
 
-    void Record::check_chromosome_whitespaces() const
+    void Record::check_chromosome_no_whitespaces() const
     {
         if (chromosome.find(' ') != std::string::npos) {
             throw new ChromosomeBodyError{line, "Chromosome must not contain white-spaces"};
@@ -124,11 +124,11 @@ namespace ebi
             return; // No need to check if no IDs are provided
         }
         
-        check_ids_semicolons_whitespaces();
-        check_ids_duplicates();
+        check_ids_no_semicolons_whitespaces();
+        check_ids_no_duplicates();
     }
 
-    void Record::check_ids_semicolons_whitespaces() const {
+    void Record::check_ids_no_semicolons_whitespaces() const {
         for (auto & id : ids) {
             if (std::find_if(id.begin(), id.end(), [](char c) { return c == ' ' || c == ';'; }) != id.end()) {
                 throw new IdBodyError{line, "ID must not contain semicolons or whitespaces"};
@@ -136,7 +136,7 @@ namespace ebi
         }
     }
 
-    void Record::check_ids_duplicates() const {
+    void Record::check_ids_no_duplicates() const {
         if (ids.size() > 1 && source->version == Version::v43) {
             std::map<std::string, int> counter;
             for (auto & id : ids) {
@@ -158,7 +158,7 @@ namespace ebi
             check_alternate_allele_structure(alternate, type);
             
             // Check that an alternate of the form <SOME_ALT> begins with DEL, INS, DUP, INV or CNV
-            check_alternate_allele_beginning(alternate);
+            check_alternate_allele_symbolic_prefix(alternate);
         }
         
     }
@@ -188,7 +188,7 @@ namespace ebi
         
     }
     
-    void Record::check_alternate_allele_beginning(std::string const & alternate) const
+    void Record::check_alternate_allele_symbolic_prefix(std::string const & alternate) const
     {
         static boost::regex square_brackets_regex("<([a-zA-Z0-9:_]+)>");
         boost::cmatch pieces_match;
@@ -254,7 +254,7 @@ namespace ebi
         }
         
         check_format_GT();
-        check_format_duplicates();
+        check_format_no_duplicates();
     }
 
     void Record::check_format_GT() const
@@ -264,7 +264,7 @@ namespace ebi
         }
     }
 
-    void Record::check_format_duplicates() const
+    void Record::check_format_no_duplicates() const
     {
         if (format.size() > 1 && source->version == Version::v43) {
             std::map<std::string, int> counter;

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -331,14 +331,10 @@ namespace ebi
         
         check_sample_subfields_count(i, subfields);
         
-        std::vector<std::string> alleles;
         // If the first format field is not a GT, then no alleles need to be checked
         if (format[0] == "GT") {
-            util::string_split(subfields[0], "|/", alleles);
-                
-            // The allele indexes must not be greater than the total number of alleles
-            check_samples_alleles(alleles);
-        }
+            check_sample_alleles(subfields);
+        }        
         
         check_sample_subfields_cardinality_type(i, subfields, format_meta);
     }
@@ -382,19 +378,21 @@ namespace ebi
         }
     }
 
-    void Record::check_samples_alleles(std::vector<std::string> const & alleles) const
+    void Record::check_sample_alleles(std::vector<std::string> subfields) const
     {
+        std::vector<std::string> alleles;
+        util::string_split(subfields[0], "|/", alleles);
         long ploidy = static_cast<long>(source->ploidy.get_ploidy(chromosome));
         for (auto & allele : alleles) {
             if (allele == ".") { continue; } // No need to check missing alleles
 
-            check_samples_alleles_is_integer(allele, ploidy);
+            check_sample_alleles_is_integer(allele, ploidy);
 
-            check_samples_alleles_range(allele, ploidy);
+            check_sample_alleles_range(allele, ploidy);
         }
     }
 
-    void Record::check_samples_alleles_is_integer(std::string const & allele, long ploidy) const
+    void Record::check_sample_alleles_is_integer(std::string const & allele, long ploidy) const
     {
         if (std::find_if_not(allele.begin(), allele.end(), isdigit) != allele.end()) {
             throw new SamplesFieldBodyError{line, "Allele index " + allele + " is not an integer number",
@@ -402,7 +400,7 @@ namespace ebi
         }        
     }
 
-    void Record::check_samples_alleles_range(std::string const & allele, long ploidy) const
+    void Record::check_sample_alleles_range(std::string const & allele, long ploidy) const
     {
         size_t num_allele = std::stoi(allele);
         if (num_allele > alternate_alleles.size()) {

--- a/test/input_files/v4.1/failed/failed_body_id_003.vcf
+++ b/test/input_files/v4.1/failed/failed_body_id_003.vcf
@@ -1,4 +1,0 @@
-##fileformat=VCFv4.1
-##CauseOfFailure=ID contains duplicate values in a single line
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00096	HG00097
-1	123	rs180734498;rs180734498	C	T	100	PASS	AN=2184;AC=249;AF=0.11	GT:DS:GL	0|0:0.050:-0.13,-0.58,-3.62	0|1:1.000:-2.45,-0.00,-5.00

--- a/test/input_files/v4.2/failed/failed_body_id_003.vcf
+++ b/test/input_files/v4.2/failed/failed_body_id_003.vcf
@@ -1,4 +1,0 @@
-##fileformat=VCFv4.2
-##CauseOfFailure=ID contains duplicate values in a single line
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG00096	HG00097
-1	123	rs180734498;rs180734498	C	T	100	PASS	AN=2184;AC=249;AF=0.11	GT:DS:GL	0|0:0.050:-0.13,-0.58,-3.62	0|1:1.000:-2.45,-0.00,-5.00

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -181,24 +181,6 @@ namespace ebi
                             vcf::IdBodyError*);
         }
 
-        SECTION("Duplicate IDs") 
-        {
-            CHECK_THROWS_AS( (vcf::Record{
-                                1,
-                                "chr1", 
-                                123456, 
-                                { "id123", "id123" }, 
-                                "A", 
-                                { "AC", "AT" }, 
-                                1.0, 
-                                { "PASS" }, 
-                                { {"AN", "12,7"}, {"AF", "0.5,0.3"} }, 
-                                { "GT", "DP" }, 
-                                { "0|1" },
-                                std::make_shared<vcf::Source>(source)}),
-                            vcf::IdBodyError*);
-        }
-
         SECTION("Different length alleles")
         {
             CHECK_NOTHROW( (vcf::Record{
@@ -283,7 +265,7 @@ namespace ebi
                             vcf::QualityBodyError*);
         }
 
-        SECTION("Emtpy INFO") 
+        SECTION("Empty INFO") 
         {
             CHECK_NOTHROW( (vcf::Record{
                                 1,
@@ -483,7 +465,7 @@ namespace ebi
                 }
             });
 
-        SECTION("Multi-field format") 
+        SECTION("Duplicate FORMATs") 
         {
             CHECK_THROWS_AS( (vcf::Record{
                                 1,
@@ -499,6 +481,24 @@ namespace ebi
                                 { "12:13" },
                                 std::make_shared<vcf::Source>(source)}),
                             vcf::FormatBodyError*);
+        }
+
+        SECTION("Duplicate IDs") 
+        {
+            CHECK_THROWS_AS( (vcf::Record{
+                                1,
+                                "chr1", 
+                                123456, 
+                                { "id123", "id123" }, 
+                                "A", 
+                                { "AC", "AT" }, 
+                                1.0, 
+                                { "PASS" }, 
+                                { {"AN", "12,7"}, {"AF", "0.5,0.3"} }, 
+                                { "GT", "DP" }, 
+                                { "0|1" },
+                                std::make_shared<vcf::Source>(source)}),
+                            vcf::IdBodyError*);
         }
     }
 }


### PR DESCRIPTION
In this PR, the various check blocks of the methods in record.cpp have been extracted into new private methods. 
Though it is unrelated to this PR, I have added the version checking for duplicate ID, because in earlier commits, duplicate IDs threw an error for v4.1 and v4.2, which was wrong. So, now it only throws error for v4.3 in case of duplicate IDs.