### PR TITLE
Add new data line fixing functionality in the debugulator

### DIFF
--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -3924,12 +3924,46 @@ namespace odb
     id_type_;
 
     static const id_type_ id;
+
+    // error_fix
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::ebi::vcf::ErrorFix,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    error_fix_type_;
+
+    static const error_fix_type_ error_fix;
+
+    // field
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    field_type_;
+
+    static const field_type_ field;
   };
 
   template <typename A>
   const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::id_type_
   query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::error_fix_type_
+  query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
+  error_fix (A::table_name, "\"error_fix\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
+  field (A::table_name, "\"field\"", 0);
 
   template <typename A>
   struct pointer_query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >:
@@ -3958,6 +3992,17 @@ namespace odb
       //
       long long id_value;
       bool id_null;
+
+      // error_fix
+      //
+      long long error_fix_value;
+      bool error_fix_null;
+
+      // field
+      //
+      details::buffer field_value;
+      std::size_t field_size;
+      bool field_null;
 
       std::size_t version;
     };
@@ -4011,10 +4056,10 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 1UL;
+    static const std::size_t column_count = 3UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t readonly_column_count = 1UL;
     static const std::size_t managed_optimistic_column_count = 0UL;
 
     static const std::size_t separate_load_column_count = 0UL;
@@ -4025,6 +4070,7 @@ namespace odb
     static const char persist_statement[];
     static const char* const find_statements[depth];
     static const std::size_t find_column_counts[depth];
+    static const char update_statement[];
     static const char erase_statement[];
     static const char query_statement[];
     static const char erase_query_statement[];

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -2702,6 +2702,18 @@ namespace odb
 
     static const id_type_ id;
 
+    // error_fix
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::ebi::vcf::ErrorFix,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    error_fix_type_;
+
+    static const error_fix_type_ error_fix;
+
     // field
     //
     typedef
@@ -2719,6 +2731,11 @@ namespace odb
   const typename query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::id_type_
   query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::error_fix_type_
+  query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::
+  error_fix (A::table_name, "\"error_fix\"", 0);
 
   template <typename A>
   const typename query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::field_type_
@@ -2752,6 +2769,11 @@ namespace odb
       //
       long long id_value;
       bool id_null;
+
+      // error_fix
+      //
+      long long error_fix_value;
+      bool error_fix_null;
 
       // field
       //
@@ -2811,10 +2833,10 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 2UL;
+    static const std::size_t column_count = 3UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t readonly_column_count = 1UL;
     static const std::size_t managed_optimistic_column_count = 0UL;
 
     static const std::size_t separate_load_column_count = 0UL;
@@ -3434,6 +3456,18 @@ namespace odb
 
     static const id_type_ id;
 
+    // error_fix
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::ebi::vcf::ErrorFix,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    error_fix_type_;
+
+    static const error_fix_type_ error_fix;
+
     // field
     //
     typedef
@@ -3451,6 +3485,11 @@ namespace odb
   const typename query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::id_type_
   query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::error_fix_type_
+  query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::
+  error_fix (A::table_name, "\"error_fix\"", 0);
 
   template <typename A>
   const typename query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::field_type_
@@ -3484,6 +3523,11 @@ namespace odb
       //
       long long id_value;
       bool id_null;
+
+      // error_fix
+      //
+      long long error_fix_value;
+      bool error_fix_null;
 
       // field
       //
@@ -3543,10 +3587,10 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 2UL;
+    static const std::size_t column_count = 3UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t readonly_column_count = 1UL;
     static const std::size_t managed_optimistic_column_count = 0UL;
 
     static const std::size_t separate_load_column_count = 0UL;
@@ -3635,6 +3679,18 @@ namespace odb
 
     static const id_type_ id;
 
+    // error_fix
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::ebi::vcf::ErrorFix,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    error_fix_type_;
+
+    static const error_fix_type_ error_fix;
+
     // field
     //
     typedef
@@ -3664,6 +3720,11 @@ namespace odb
   const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::id_type_
   query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::error_fix_type_
+  query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::
+  error_fix (A::table_name, "\"error_fix\"", 0);
 
   template <typename A>
   const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::field_type_
@@ -3702,6 +3763,11 @@ namespace odb
       //
       long long id_value;
       bool id_null;
+
+      // error_fix
+      //
+      long long error_fix_value;
+      bool error_fix_null;
 
       // field
       //
@@ -3767,10 +3833,10 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 3UL;
+    static const std::size_t column_count = 4UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t readonly_column_count = 2UL;
     static const std::size_t managed_optimistic_column_count = 0UL;
 
     static const std::size_t separate_load_column_count = 0UL;
@@ -3858,29 +3924,12 @@ namespace odb
     id_type_;
 
     static const id_type_ id;
-
-    // field
-    //
-    typedef
-    sqlite::query_column<
-      sqlite::value_traits<
-        ::std::string,
-        sqlite::id_text >::query_type,
-      sqlite::id_text >
-    field_type_;
-
-    static const field_type_ field;
   };
 
   template <typename A>
   const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::id_type_
   query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
-
-  template <typename A>
-  const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::field_type_
-  query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
-  field (A::table_name, "\"field\"", 0);
 
   template <typename A>
   struct pointer_query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >:
@@ -3909,12 +3958,6 @@ namespace odb
       //
       long long id_value;
       bool id_null;
-
-      // field
-      //
-      details::buffer field_value;
-      std::size_t field_size;
-      bool field_null;
 
       std::size_t version;
     };
@@ -3968,7 +4011,7 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 2UL;
+    static const std::size_t column_count = 1UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
     static const std::size_t readonly_column_count = 0UL;
@@ -3982,7 +4025,6 @@ namespace odb
     static const char persist_statement[];
     static const char* const find_statements[depth];
     static const std::size_t find_column_counts[depth];
-    static const char update_statement[];
     static const char erase_statement[];
     static const char query_statement[];
     static const char erase_query_statement[];

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -2713,18 +2713,6 @@ namespace odb
     error_fix_type_;
 
     static const error_fix_type_ error_fix;
-
-    // field
-    //
-    typedef
-    sqlite::query_column<
-      sqlite::value_traits<
-        ::std::string,
-        sqlite::id_text >::query_type,
-      sqlite::id_text >
-    field_type_;
-
-    static const field_type_ field;
   };
 
   template <typename A>
@@ -2736,11 +2724,6 @@ namespace odb
   const typename query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::error_fix_type_
   query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::
   error_fix (A::table_name, "\"error_fix\"", 0);
-
-  template <typename A>
-  const typename query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::field_type_
-  query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::
-  field (A::table_name, "\"field\"", 0);
 
   template <typename A>
   struct pointer_query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >:
@@ -2774,12 +2757,6 @@ namespace odb
       //
       long long error_fix_value;
       bool error_fix_null;
-
-      // field
-      //
-      details::buffer field_value;
-      std::size_t field_size;
-      bool field_null;
 
       std::size_t version;
     };
@@ -2833,10 +2810,10 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 3UL;
+    static const std::size_t column_count = 2UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 1UL;
+    static const std::size_t readonly_column_count = 0UL;
     static const std::size_t managed_optimistic_column_count = 0UL;
 
     static const std::size_t separate_load_column_count = 0UL;
@@ -3936,18 +3913,6 @@ namespace odb
     error_fix_type_;
 
     static const error_fix_type_ error_fix;
-
-    // field
-    //
-    typedef
-    sqlite::query_column<
-      sqlite::value_traits<
-        ::std::string,
-        sqlite::id_text >::query_type,
-      sqlite::id_text >
-    field_type_;
-
-    static const field_type_ field;
   };
 
   template <typename A>
@@ -3959,11 +3924,6 @@ namespace odb
   const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::error_fix_type_
   query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
   error_fix (A::table_name, "\"error_fix\"", 0);
-
-  template <typename A>
-  const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::field_type_
-  query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
-  field (A::table_name, "\"field\"", 0);
 
   template <typename A>
   struct pointer_query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >:
@@ -3997,12 +3957,6 @@ namespace odb
       //
       long long error_fix_value;
       bool error_fix_null;
-
-      // field
-      //
-      details::buffer field_value;
-      std::size_t field_size;
-      bool field_null;
 
       std::size_t version;
     };
@@ -4056,10 +4010,10 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 3UL;
+    static const std::size_t column_count = 2UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 1UL;
+    static const std::size_t readonly_column_count = 0UL;
     static const std::size_t managed_optimistic_column_count = 0UL;
 
     static const std::size_t separate_load_column_count = 0UL;

--- a/inc/vcf/error-odb.hpp
+++ b/inc/vcf/error-odb.hpp
@@ -2701,12 +2701,29 @@ namespace odb
     id_type_;
 
     static const id_type_ id;
+
+    // field
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    field_type_;
+
+    static const field_type_ field;
   };
 
   template <typename A>
   const typename query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::id_type_
   query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >::
+  field (A::table_name, "\"field\"", 0);
 
   template <typename A>
   struct pointer_query_columns< ::ebi::vcf::IdBodyError, id_sqlite, A >:
@@ -2735,6 +2752,12 @@ namespace odb
       //
       long long id_value;
       bool id_null;
+
+      // field
+      //
+      details::buffer field_value;
+      std::size_t field_size;
+      bool field_null;
 
       std::size_t version;
     };
@@ -2788,7 +2811,7 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 1UL;
+    static const std::size_t column_count = 2UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
     static const std::size_t readonly_column_count = 0UL;
@@ -2802,6 +2825,7 @@ namespace odb
     static const char persist_statement[];
     static const char* const find_statements[depth];
     static const std::size_t find_column_counts[depth];
+    static const char update_statement[];
     static const char erase_statement[];
     static const char query_statement[];
     static const char erase_query_statement[];
@@ -3409,183 +3433,6 @@ namespace odb
     id_type_;
 
     static const id_type_ id;
-  };
-
-  template <typename A>
-  const typename query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::id_type_
-  query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::
-  id (A::table_name, "\"id\"", 0);
-
-  template <typename A>
-  struct pointer_query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >:
-    query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >
-  {
-  };
-
-  template <>
-  class access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >:
-    public access::object_traits< ::ebi::vcf::FilterBodyError >
-  {
-    public:
-    typedef polymorphic_entry<object_type, id_sqlite> entry_type;
-    typedef object_traits_impl<root_type, id_sqlite> root_traits;
-    typedef object_traits_impl<base_type, id_sqlite> base_traits;
-
-    typedef root_traits::id_image_type id_image_type;
-
-    static const info_type info;
-
-    struct image_type
-    {
-      base_traits::image_type* base;
-
-      // id_
-      //
-      long long id_value;
-      bool id_null;
-
-      std::size_t version;
-    };
-
-    struct extra_statement_cache_type;
-
-    using object_traits<object_type>::id;
-
-    static bool
-    grow (image_type&,
-          bool*,
-          std::size_t = depth);
-
-    static void
-    bind (sqlite::bind*,
-          const sqlite::bind* id,
-          std::size_t id_size,
-          image_type&,
-          sqlite::statement_kind);
-
-    static void
-    bind (sqlite::bind*, id_image_type&);
-
-    static bool
-    init (image_type&,
-          const object_type&,
-          sqlite::statement_kind);
-
-    static void
-    init (object_type&,
-          const image_type&,
-          database*,
-          std::size_t = depth);
-
-    static void
-    init (id_image_type&, const id_type&);
-
-    static bool
-    check_version (const std::size_t*, const image_type&);
-
-    static void
-    update_version (std::size_t*, const image_type&, sqlite::binding*);
-
-    typedef
-    sqlite::polymorphic_derived_object_statements<object_type>
-    statements_type;
-
-    typedef
-    sqlite::polymorphic_root_object_statements<root_type>
-    root_statements_type;
-
-    typedef sqlite::query_base query_base_type;
-
-    static const std::size_t column_count = 1UL;
-    static const std::size_t id_column_count = 1UL;
-    static const std::size_t inverse_column_count = 0UL;
-    static const std::size_t readonly_column_count = 0UL;
-    static const std::size_t managed_optimistic_column_count = 0UL;
-
-    static const std::size_t separate_load_column_count = 0UL;
-    static const std::size_t separate_update_column_count = 0UL;
-
-    static const bool versioned = false;
-
-    static const char persist_statement[];
-    static const char* const find_statements[depth];
-    static const std::size_t find_column_counts[depth];
-    static const char erase_statement[];
-    static const char query_statement[];
-    static const char erase_query_statement[];
-
-    static const char table_name[];
-
-    static void
-    persist (database&, object_type&, bool top = true, bool dyn = true);
-
-    static pointer_type
-    find (database&, const id_type&);
-
-    static bool
-    find (database&, const id_type&, object_type&, bool dyn = true);
-
-    static bool
-    reload (database&, object_type&, bool dyn = true);
-
-    static void
-    update (database&, const object_type&, bool top = true, bool dyn = true);
-
-    static void
-    erase (database&, const id_type&, bool top = true, bool dyn = true);
-
-    static void
-    erase (database&, const object_type&, bool top = true, bool dyn = true);
-
-    static result<object_type>
-    query (database&, const query_base_type&);
-
-    static unsigned long long
-    erase_query (database&, const query_base_type&);
-
-    public:
-    static bool
-    find_ (statements_type&,
-           const id_type*,
-           std::size_t = depth);
-
-    static void
-    load_ (statements_type&,
-           object_type&,
-           bool reload,
-           std::size_t = depth);
-
-    static void
-    load_ (database&, root_type&, std::size_t);
-  };
-
-  template <>
-  class access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_common >:
-    public access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >
-  {
-  };
-
-  // InfoBodyError
-  //
-  template <typename A>
-  struct query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >:
-    query_columns< ::ebi::vcf::BodySectionError, id_sqlite, typename A::base_traits >
-  {
-    // BodySectionError
-    //
-    typedef query_columns< ::ebi::vcf::BodySectionError, id_sqlite, typename A::base_traits > BodySectionError;
-
-    // id
-    //
-    typedef
-    sqlite::query_column<
-      sqlite::value_traits<
-        long unsigned int,
-        sqlite::id_integer >::query_type,
-      sqlite::id_integer >
-    id_type_;
-
-    static const id_type_ id;
 
     // field
     //
@@ -3601,24 +3448,24 @@ namespace odb
   };
 
   template <typename A>
-  const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::id_type_
-  query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::
+  const typename query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::id_type_
+  query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
 
   template <typename A>
-  const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::field_type_
-  query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::
+  const typename query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >::
   field (A::table_name, "\"field\"", 0);
 
   template <typename A>
-  struct pointer_query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >:
-    query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >
+  struct pointer_query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::FilterBodyError, id_sqlite, A >
   {
   };
 
   template <>
-  class access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >:
-    public access::object_traits< ::ebi::vcf::InfoBodyError >
+  class access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >:
+    public access::object_traits< ::ebi::vcf::FilterBodyError >
   {
     public:
     typedef polymorphic_entry<object_type, id_sqlite> entry_type;
@@ -3761,15 +3608,15 @@ namespace odb
   };
 
   template <>
-  class access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_common >:
-    public access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >
+  class access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_common >:
+    public access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >
   {
   };
 
-  // FormatBodyError
+  // InfoBodyError
   //
   template <typename A>
-  struct query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >:
+  struct query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >:
     query_columns< ::ebi::vcf::BodySectionError, id_sqlite, typename A::base_traits >
   {
     // BodySectionError
@@ -3787,22 +3634,56 @@ namespace odb
     id_type_;
 
     static const id_type_ id;
+
+    // field
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    field_type_;
+
+    static const field_type_ field;
+
+    // expected_value
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    expected_value_type_;
+
+    static const expected_value_type_ expected_value;
   };
 
   template <typename A>
-  const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::id_type_
-  query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
+  const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::id_type_
+  query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::
   id (A::table_name, "\"id\"", 0);
 
   template <typename A>
-  struct pointer_query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >:
-    query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >
+  const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::
+  field (A::table_name, "\"field\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::expected_value_type_
+  query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >::
+  expected_value (A::table_name, "\"expected_value\"", 0);
+
+  template <typename A>
+  struct pointer_query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::InfoBodyError, id_sqlite, A >
   {
   };
 
   template <>
-  class access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >:
-    public access::object_traits< ::ebi::vcf::FormatBodyError >
+  class access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >:
+    public access::object_traits< ::ebi::vcf::InfoBodyError >
   {
     public:
     typedef polymorphic_entry<object_type, id_sqlite> entry_type;
@@ -3821,6 +3702,18 @@ namespace odb
       //
       long long id_value;
       bool id_null;
+
+      // field
+      //
+      details::buffer field_value;
+      std::size_t field_size;
+      bool field_null;
+
+      // expected_value
+      //
+      details::buffer expected_value_value;
+      std::size_t expected_value_size;
+      bool expected_value_null;
 
       std::size_t version;
     };
@@ -3874,7 +3767,7 @@ namespace odb
 
     typedef sqlite::query_base query_base_type;
 
-    static const std::size_t column_count = 1UL;
+    static const std::size_t column_count = 3UL;
     static const std::size_t id_column_count = 1UL;
     static const std::size_t inverse_column_count = 0UL;
     static const std::size_t readonly_column_count = 0UL;
@@ -3888,6 +3781,208 @@ namespace odb
     static const char persist_statement[];
     static const char* const find_statements[depth];
     static const std::size_t find_column_counts[depth];
+    static const char update_statement[];
+    static const char erase_statement[];
+    static const char query_statement[];
+    static const char erase_query_statement[];
+
+    static const char table_name[];
+
+    static void
+    persist (database&, object_type&, bool top = true, bool dyn = true);
+
+    static pointer_type
+    find (database&, const id_type&);
+
+    static bool
+    find (database&, const id_type&, object_type&, bool dyn = true);
+
+    static bool
+    reload (database&, object_type&, bool dyn = true);
+
+    static void
+    update (database&, const object_type&, bool top = true, bool dyn = true);
+
+    static void
+    erase (database&, const id_type&, bool top = true, bool dyn = true);
+
+    static void
+    erase (database&, const object_type&, bool top = true, bool dyn = true);
+
+    static result<object_type>
+    query (database&, const query_base_type&);
+
+    static unsigned long long
+    erase_query (database&, const query_base_type&);
+
+    public:
+    static bool
+    find_ (statements_type&,
+           const id_type*,
+           std::size_t = depth);
+
+    static void
+    load_ (statements_type&,
+           object_type&,
+           bool reload,
+           std::size_t = depth);
+
+    static void
+    load_ (database&, root_type&, std::size_t);
+  };
+
+  template <>
+  class access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_common >:
+    public access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >
+  {
+  };
+
+  // FormatBodyError
+  //
+  template <typename A>
+  struct query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::BodySectionError, id_sqlite, typename A::base_traits >
+  {
+    // BodySectionError
+    //
+    typedef query_columns< ::ebi::vcf::BodySectionError, id_sqlite, typename A::base_traits > BodySectionError;
+
+    // id
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        long unsigned int,
+        sqlite::id_integer >::query_type,
+      sqlite::id_integer >
+    id_type_;
+
+    static const id_type_ id;
+
+    // field
+    //
+    typedef
+    sqlite::query_column<
+      sqlite::value_traits<
+        ::std::string,
+        sqlite::id_text >::query_type,
+      sqlite::id_text >
+    field_type_;
+
+    static const field_type_ field;
+  };
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::id_type_
+  query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
+  id (A::table_name, "\"id\"", 0);
+
+  template <typename A>
+  const typename query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::field_type_
+  query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >::
+  field (A::table_name, "\"field\"", 0);
+
+  template <typename A>
+  struct pointer_query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >:
+    query_columns< ::ebi::vcf::FormatBodyError, id_sqlite, A >
+  {
+  };
+
+  template <>
+  class access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >:
+    public access::object_traits< ::ebi::vcf::FormatBodyError >
+  {
+    public:
+    typedef polymorphic_entry<object_type, id_sqlite> entry_type;
+    typedef object_traits_impl<root_type, id_sqlite> root_traits;
+    typedef object_traits_impl<base_type, id_sqlite> base_traits;
+
+    typedef root_traits::id_image_type id_image_type;
+
+    static const info_type info;
+
+    struct image_type
+    {
+      base_traits::image_type* base;
+
+      // id_
+      //
+      long long id_value;
+      bool id_null;
+
+      // field
+      //
+      details::buffer field_value;
+      std::size_t field_size;
+      bool field_null;
+
+      std::size_t version;
+    };
+
+    struct extra_statement_cache_type;
+
+    using object_traits<object_type>::id;
+
+    static bool
+    grow (image_type&,
+          bool*,
+          std::size_t = depth);
+
+    static void
+    bind (sqlite::bind*,
+          const sqlite::bind* id,
+          std::size_t id_size,
+          image_type&,
+          sqlite::statement_kind);
+
+    static void
+    bind (sqlite::bind*, id_image_type&);
+
+    static bool
+    init (image_type&,
+          const object_type&,
+          sqlite::statement_kind);
+
+    static void
+    init (object_type&,
+          const image_type&,
+          database*,
+          std::size_t = depth);
+
+    static void
+    init (id_image_type&, const id_type&);
+
+    static bool
+    check_version (const std::size_t*, const image_type&);
+
+    static void
+    update_version (std::size_t*, const image_type&, sqlite::binding*);
+
+    typedef
+    sqlite::polymorphic_derived_object_statements<object_type>
+    statements_type;
+
+    typedef
+    sqlite::polymorphic_root_object_statements<root_type>
+    root_statements_type;
+
+    typedef sqlite::query_base query_base_type;
+
+    static const std::size_t column_count = 2UL;
+    static const std::size_t id_column_count = 1UL;
+    static const std::size_t inverse_column_count = 0UL;
+    static const std::size_t readonly_column_count = 0UL;
+    static const std::size_t managed_optimistic_column_count = 0UL;
+
+    static const std::size_t separate_load_column_count = 0UL;
+    static const std::size_t separate_update_column_count = 0UL;
+
+    static const bool versioned = false;
+
+    static const char persist_statement[];
+    static const char* const find_statements[depth];
+    static const std::size_t find_column_counts[depth];
+    static const char update_statement[];
     static const char erase_statement[];
     static const char query_statement[];
     static const char erase_query_statement[];

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -293,7 +293,7 @@ namespace ebi
                       const std::string &field = "",
                       const std::string &expected_value = "")
                 : BodySectionError{line, message}, error_fix{error_fix}, field{field}, expected_value{expected_value} {
-                    if (error_fix == ErrorFix::RECOVERABLE_VALUE && expected_value == "") {
+                    if (error_fix == ErrorFix::RECOVERABLE_VALUE && expected_value.empty()) {
                         throw std::invalid_argument{"An error with recoverable value must provide a non-empty expected value"};
                     }
                 }
@@ -307,11 +307,16 @@ namespace ebi
     #pragma db object
     struct FormatBodyError : public BodySectionError
     {
-        using BodySectionError::BodySectionError;
-        FormatBodyError() : FormatBodyError{0} {}
-        FormatBodyError(size_t line) : FormatBodyError{line, "Format is not a colon-separated list of alphanumeric strings"} { }
+        FormatBodyError(size_t line = 0,
+                        const std::string &message = "Format is not a colon-separated list of alphanumeric strings",
+                        ErrorFix error_fix = ErrorFix::IRRECOVERABLE_VALUE,
+                        const std::string &field = "")
+                : BodySectionError{line, message}, error_fix{error_fix}, field{field} { }
         virtual ~FormatBodyError() override { }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
+
+        ErrorFix error_fix;
+        const std::string field;
     };
     #pragma db object
     struct SamplesBodyError : public BodySectionError

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -234,14 +234,12 @@ namespace ebi
     {
         IdBodyError(size_t line = 0,
                     const std::string &message = "ID is not a single dot or a list of strings without semicolons or whitespaces",
-                    ErrorFix error_fix = ErrorFix::IRRECOVERABLE_VALUE,
-                    const std::string &field = "")
-                : BodySectionError{line, message}, error_fix{error_fix}, field{field} { }
+                    ErrorFix error_fix = ErrorFix::IRRECOVERABLE_VALUE)
+                : BodySectionError{line, message}, error_fix{error_fix} { }
         virtual ~IdBodyError() override { }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 
         ErrorFix error_fix;
-        const std::string field;
     };
     #pragma db object
     struct ReferenceAlleleBodyError : public BodySectionError
@@ -309,14 +307,12 @@ namespace ebi
     {
         FormatBodyError(size_t line = 0,
                         const std::string &message = "Format is not a colon-separated list of alphanumeric strings",
-                        ErrorFix error_fix = ErrorFix::IRRECOVERABLE_VALUE,
-                        const std::string &field = "")
-                : BodySectionError{line, message}, error_fix{error_fix}, field{field} { }
+                        ErrorFix error_fix = ErrorFix::IRRECOVERABLE_VALUE)
+                : BodySectionError{line, message}, error_fix{error_fix} { }
         virtual ~FormatBodyError() override { }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 
         ErrorFix error_fix;
-        const std::string field;
     };
     #pragma db object
     struct SamplesBodyError : public BodySectionError

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -292,7 +292,7 @@ namespace ebi
                       const std::string &expected_value = "")
                 : BodySectionError{line, message}, error_fix{error_fix}, field{field}, expected_value{expected_value} {
                     if (error_fix == ErrorFix::RECOVERABLE_VALUE && expected_value.empty()) {
-                        throw std::invalid_argument{"An error with recoverable value must provide a non-empty expected value"};
+                        throw std::invalid_argument{"The program had an internal error: An error with recoverable value must provide a non-empty expected value"};
                     }
                 }
         virtual ~InfoBodyError() override { }

--- a/inc/vcf/error.hpp
+++ b/inc/vcf/error.hpp
@@ -233,11 +233,14 @@ namespace ebi
     #pragma db object
     struct IdBodyError : public BodySectionError
     {
-        using BodySectionError::BodySectionError;
-        IdBodyError() : IdBodyError{0} {}
-        IdBodyError(size_t line) : IdBodyError{line, "ID is not a single dot or a list of strings without semicolons or whitespaces"} { }
+        IdBodyError(size_t line = 0,
+                    const std::string &message = "ID is not a single dot or a list of strings without semicolons or whitespaces",
+                    const std::string &field = "")
+                : BodySectionError{line, message}, field{field} { }
         virtual ~IdBodyError() override { }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
+
+        std::string field;
     };
     #pragma db object
     struct ReferenceAlleleBodyError : public BodySectionError
@@ -269,32 +272,40 @@ namespace ebi
     #pragma db object
     struct FilterBodyError : public BodySectionError
     {
-        using BodySectionError::BodySectionError;
-        FilterBodyError() : FilterBodyError{0} {}
-        FilterBodyError(size_t line) : FilterBodyError{line, "Filter is not a single dot or a semicolon-separated list of strings"} { }
+        FilterBodyError(size_t line = 0,
+                        const std::string &message = "Filter is not a single dot or a semicolon-separated list of strings",
+                        const std::string &field = "")
+                : BodySectionError{line, message}, field{field} { }
         virtual ~FilterBodyError() override { }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
+
+        std::string field;
     };
     #pragma db object
     struct InfoBodyError : public BodySectionError
     {
         InfoBodyError(size_t line = 0,
                       const std::string &message = "Error in info column, in body section",
-                      const std::string &field = "")
-                : BodySectionError{line, message}, field{field} {}
+                      const std::string &field = "",
+                      const std::string &expected_value = "")
+                : BodySectionError{line, message}, field{field}, expected_value{expected_value} { }
         virtual ~InfoBodyError() override { }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
 
         std::string field;
+        std::string expected_value;    // a few INFO fields expect exact values in a few cases, this would contain that value
     };
     #pragma db object
     struct FormatBodyError : public BodySectionError
     {
-        using BodySectionError::BodySectionError;
-        FormatBodyError() : FormatBodyError{0} {}
-        FormatBodyError(size_t line) : FormatBodyError{line, "Format is not a colon-separated list of alphanumeric strings"} { }
+        FormatBodyError(size_t line = 0,
+                        const std::string &message = "Format is not a colon-separated list of alphanumeric strings",
+                        const std::string &field = "")
+                : BodySectionError{line, message}, field{field} { }
         virtual ~FormatBodyError() override { }
         virtual void apply_visitor(ErrorVisitor &visitor) override { visitor.visit(*this); }
+
+        std::string field;
     };
     #pragma db object
     struct SamplesBodyError : public BodySectionError

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -46,6 +46,8 @@ namespace ebi
         std::ostream &output;
         size_t ignored_errors;
 
+        void ignore_error();
+
         virtual void visit(Error &error) override;
         virtual void visit(MetaSectionError &error) override;
         virtual void visit(HeaderSectionError &error) override;

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -126,6 +126,7 @@ namespace ebi
         size_t remove_column(const std::string &line,
                              const std::string &separator,
                              const std::string &empty_column,
+                             std::string corrected_column,
                              std::function<bool(std::string &column, size_t index)> condition_to_remove);
 
         /**

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -18,6 +18,7 @@
 #define VCF_FIXER_HPP
 
 #include <vector>
+#include <set>
 #include <iostream>
 #include <algorithm>
 
@@ -145,7 +146,19 @@ namespace ebi
          * @return the number of duplicate format fields (with corresponding samples if present) removed
          */
         size_t remove_duplicate_format_sample_pairs(const std::string &string_line);
-        
+
+        /*
+         * returns all the fields to remove from the FORMAT column and corresponding ones in sample columns, for duplicate values error
+         * @param map containing unique FORMAT fields with their indices in the FORMAT column
+         * @param iterator to the first sample column
+         * @param iterator past the last sample column
+         * @param a set of fields to remove
+         */
+        void get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields,
+                                  std::vector<std::string>::iterator first,
+                                  std::vector<std::string>::iterator last,
+                                  std::set<std::string> &fields_to_remove);
+
         /**
          * puts the genotype as missing. if the error.cardinality is known, it uses the proper ploidy
          * @param first iterator to the FORMAT column string

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -58,7 +58,8 @@ namespace ebi
         virtual void visit(PositionBodyError &error) override;
 
         /**
-         * fix: remove duplicate ids - keep the first one and remove consequent ones
+         * fix: 
+         * - remove duplicate IDs, keep the first one and remove consequent ones
          */
         virtual void visit(IdBodyError &error) override;
         virtual void visit(ReferenceAlleleBodyError &error) override;
@@ -67,18 +68,18 @@ namespace ebi
 
         /**
          * fix:
-         * - if any filter string is 0, remove it
-         * - remove duplicate filter strings - keep the first and remove consequent ones
+         * - if any FILTER string is 0, remove it
+         * - remove duplicate FILTER strings - keep the first and remove consequent ones
          */
         virtual void visit(FilterBodyError &error) override;
 
         /**
          * fix:
-         * - fix duplicates in info field :
-         *     - if even one value differs, remove all the duplicate key fields
-         *     - else, keep one duplicate field and remove all the others
-         * - if the error is recoverable, i.e., it expected an exact value, then replace the error causing info field with the correct value
-         * - if the error is irrecoverable, remove the info field that caused the error
+         * - fix duplicates in INFO field :
+         *     - if even a single value differs, remove all the duplicate key fields
+         *     - else if the duplicate key has the same value, keep the first one and remove all the others
+         * - if the error is recoverable, i.e., it expected an exact value, then replace the error causing INFO field with the correct value
+         * - if the error is irrecoverable, remove the INFO field that caused the error
          */
         virtual void visit(InfoBodyError &error) override;
         virtual void visit(FormatBodyError &error) override;
@@ -120,9 +121,10 @@ namespace ebi
                                         const std::string &separator);
 
         /**
-         * remove any duplicate key value pairs from a column
-         * the fix is to remove all fields for a duplicate key if the corresponding values differ
-         * else if all the values are the same for that key, keep one pair & remove the rest
+         * removes any duplicate key value pairs from a column
+         * explanation of the fix:
+         * - remove all fields for a duplicate key if the corresponding values differ
+         * - else if all the values are the same for that key, keep one pair & remove the rest
          * @param the column string
          * @param the separator used for splitting the column
          * @param the separator used to split the key value pair
@@ -135,16 +137,17 @@ namespace ebi
                                                 const std::string &empty_value);
 
         /**
-         * removes duplicate format and samples
-         * the fix is to remove all format fields for which one or more of the samples contain duplicate values (within the sample field itself)
-         * else if all the values match in a sample, and this happens for all the samples, keep the first occurrence in each sample and discard the rest
+         * removes duplicate FORMAT and samples
+         * explanation of the fix:
+         * - remove all FORMAT fields for which one or more of the samples contain duplicate values (within the sample field itself)
+         * - else if all the values match in a sample, and this happens for all the samples, keep the first occurrence in each sample and discard the rest
          * @param the complete error string
          * @return the number of duplicate format fields (with corresponding samples if present) removed
          */
         size_t remove_duplicate_format_sample_pairs(const std::string &string_line);
         
         /**
-         * puts the genotype as missing. if the error.cardinality is know, it uses the proper ploidy
+         * puts the genotype as missing. if the error.cardinality is known, it uses the proper ploidy
          * @param first iterator to the FORMAT column string
          * @param last iterator past the last sample column
          * @param error needed for the field (that must be "GT") the cardinality, and the line number
@@ -181,7 +184,7 @@ namespace ebi
 
         /**
          * write to output the `expected_field` in place of the erroneous one
-         * @param line: its incorrect columns will be replaced by the correct one
+         * @param line: its incorrect column will be replaced by the correct one
          * @param separators to be used to split `line`
          * @param expected_field to replace the incorrect one
          * @param condition_to_replace return true if the column is to be replaced with the `expected_field`

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -131,6 +131,16 @@ namespace ebi
                                                 const std::string &separator,
                                                 const std::string &key_value_separator,
                                                 const std::string &empty_value);
+
+        /**
+         * removes duplicate format and samples
+         * the fix is to remove all format fields for which one or more of the samples contain duplicate values (within the sample field itself)
+         * else if all the values match in a sample, and this happens for all the samples, keep the first occurrence in each sample and discard the rest
+         * @param the complete error string
+         * @return the number of duplicate format fields (with corresponding samples if present) removed
+         */
+        size_t remove_duplicate_format_sample_pairs(const std::string &string_line);
+        
         /**
          * puts the genotype as missing. if the error.cardinality is know, it uses the proper ploidy
          * @param first iterator to the FORMAT column string

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -75,12 +75,13 @@ namespace ebi
         virtual void visit(FilterBodyError &error) override;
 
         /**
-         * fix:
-         * - fix duplicates in INFO field :
-         *     - if even a single value differs, remove all the duplicate key fields
-         *     - else if the duplicate key has the same value, keep the first one and remove all the others
-         * - if the error is recoverable, i.e., it expected an exact value, then replace the error causing INFO field with the correct value
-         * - if the error is irrecoverable, remove the INFO field that caused the error
+         * Fixes duplicates in INFO field.
+         *     - If even a single value differs, remove all the duplicate key fields
+         *     - Else if all the duplicate keys have the same value, keep only the first occurrence
+         *
+         * If the error is recoverable, i.e. it expected an exact value, then replace the error causing
+         * INFO field with the correct value. If the error is irrecoverable, remove the INFO field that
+         * caused the error
          */
         virtual void visit(InfoBodyError &error) override;
         virtual void visit(FormatBodyError &error) override;
@@ -152,12 +153,11 @@ namespace ebi
          * @param map containing unique FORMAT fields with their indices in the FORMAT column
          * @param iterator to the first sample column
          * @param iterator past the last sample column
-         * @param a set of fields to remove
+         * @return a set of fields to remove
          */
-        void get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
-                                  std::vector<std::string>::iterator first,
-                                  std::vector<std::string>::iterator last,
-                                  std::set<std::string> &fields_to_remove);
+        std::set<std::string> get_format_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
+                                                          std::vector<std::string>::iterator first,
+                                                          std::vector<std::string>::iterator last);
 
         /**
          * puts the genotype as missing. if the error.cardinality is known, it uses the proper ploidy

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -154,7 +154,7 @@ namespace ebi
          * @param iterator past the last sample column
          * @param a set of fields to remove
          */
-        void get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields,
+        void get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
                                   std::vector<std::string>::iterator first,
                                   std::vector<std::string>::iterator last,
                                   std::set<std::string> &fields_to_remove);

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -151,14 +151,10 @@ namespace ebi
         /*
          * returns all the fields to remove from the FORMAT column and corresponding ones in sample columns, for duplicate values error
          * @param map containing unique FORMAT fields with their indices in the FORMAT column
-         * @param iterator to the first sample column
-         * @param iterator past the last sample column
          * @param a vector of sample columns, where each column is stored as a vector of split sample subfields
          * @return a set of fields to remove
          */
         std::set<std::string> get_format_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
-                                                          std::vector<std::string>::iterator first,
-                                                          std::vector<std::string>::iterator last,
                                                           std::vector<std::vector<std::string>> &samples);
 
         /**

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -150,7 +150,7 @@ namespace ebi
                            std::vector<std::string>::iterator last,
                            SamplesFieldBodyError &error);
 
-        size_t remove_column(const std::string &line,
+        size_t remove_fields(const std::string &line,
                              const std::string &separators,
                              std::function<bool(const std::string &column, size_t index)> condition_to_remove);
 
@@ -162,7 +162,7 @@ namespace ebi
          * @param condition_to_remove return true if the column has to be removed. can decide using the column and its index
          * @return amount of columns removed
          */
-        size_t remove_column(const std::string &line,
+        size_t remove_fields(const std::string &line,
                              const std::string &separators,
                              const std::string &empty_column,
                              std::function<bool(const std::string &column, size_t index)> condition_to_remove);
@@ -174,10 +174,10 @@ namespace ebi
          * @param expected_field to replace the incorrect one
          * @param condition_to_replace return true if the column is to be replaced with the `expected_field`
          */
-        size_t replace_column(const std::string &line,
-                            const std::string &separators,
-                            const std::string &expected_field,
-                            std::function<bool(const std::string &column, size_t index)> condition_to_replace);
+        size_t replace_fields(const std::string &line,
+                              const std::string &separators,
+                              const std::string &expected_field,
+                              std::function<bool(const std::string &column, size_t index)> condition_to_replace);
 
         /**
          * returns an index (NOT an iterator) to the column in `line` (split by `separator`) where `value` is found. Or `line.npos`

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -112,9 +112,10 @@ namespace ebi
          * removes any duplicate fields in a column
          * @param the column string
          * @param the separator used for splitting the column
+         * @return the number of duplicate fields removed
          */
-        void remove_duplicate_strings(const std::string &column,
-                                      const std::string &separator);
+        size_t remove_duplicate_strings(const std::string &column,
+                                        const std::string &separator);
 
         /**
          * remove any duplicate key value pairs from a column
@@ -124,11 +125,12 @@ namespace ebi
          * @param the separator used for splitting the column
          * @param the separator used to split the key value pair
          * @param the empty value to be used if we end up removing all pairs
+         * @return the number of duplicate fields removed
          */
-        void remove_duplicate_key_value_pairs(const std::string &column,
-                                              const std::string &separator,
-                                              const std::string &key_value_separator,
-                                              const std::string &empty_value);
+        size_t remove_duplicate_key_value_pairs(const std::string &column,
+                                                const std::string &separator,
+                                                const std::string &key_value_separator,
+                                                const std::string &empty_value);
         /**
          * puts the genotype as missing. if the error.cardinality is know, it uses the proper ploidy
          * @param first iterator to the FORMAT column string

--- a/inc/vcf/fixer.hpp
+++ b/inc/vcf/fixer.hpp
@@ -153,11 +153,13 @@ namespace ebi
          * @param map containing unique FORMAT fields with their indices in the FORMAT column
          * @param iterator to the first sample column
          * @param iterator past the last sample column
+         * @param a vector of sample columns, where each column is stored as a vector of split sample subfields
          * @return a set of fields to remove
          */
         std::set<std::string> get_format_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
                                                           std::vector<std::string>::iterator first,
-                                                          std::vector<std::string>::iterator last);
+                                                          std::vector<std::string>::iterator last,
+                                                          std::vector<std::vector<std::string>> &samples);
 
         /**
          * puts the genotype as missing. if the error.cardinality is known, it uses the proper ploidy

--- a/src/vcf/error-odb.cpp
+++ b/src/vcf/error-odb.cpp
@@ -6317,13 +6317,17 @@ namespace odb
     //
     if (--d != 0)
     {
-      if (base_traits::grow (*i.base, t + 1UL, d))
+      if (base_traits::grow (*i.base, t + 2UL, d))
         i.base->version++;
     }
 
+    // error_fix
+    //
+    t[0UL] = false;
+
     // field
     //
-    if (t[0UL])
+    if (t[1UL])
     {
       i.field_value.capacity (i.field_size);
       grew = true;
@@ -6354,16 +6358,26 @@ namespace odb
       n += id_size;
     }
 
+    // error_fix
+    //
+    b[n].type = sqlite::bind::integer;
+    b[n].buffer = &i.error_fix_value;
+    b[n].is_null = &i.error_fix_null;
+    n++;
+
     // field
     //
-    b[n].type = sqlite::image_traits<
-      ::std::string,
-      sqlite::id_text>::bind_value;
-    b[n].buffer = i.field_value.data ();
-    b[n].size = &i.field_size;
-    b[n].capacity = i.field_value.capacity ();
-    b[n].is_null = &i.field_null;
-    n++;
+    if (sk != statement_update)
+    {
+      b[n].type = sqlite::image_traits<
+        ::std::string,
+        sqlite::id_text>::bind_value;
+      b[n].buffer = i.field_value.data ();
+      b[n].size = &i.field_size;
+      b[n].capacity = i.field_value.capacity ();
+      b[n].is_null = &i.field_null;
+      n++;
+    }
 
     // id_
     //
@@ -6393,8 +6407,25 @@ namespace odb
 
     bool grew (false);
 
+    // error_fix
+    //
+    {
+      ::ebi::vcf::ErrorFix const& v =
+        o.error_fix;
+
+      bool is_null (false);
+      sqlite::value_traits<
+          ::ebi::vcf::ErrorFix,
+          sqlite::id_integer >::set_image (
+        i.error_fix_value,
+        is_null,
+        v);
+      i.error_fix_null = is_null;
+    }
+
     // field
     //
+    if (sk == statement_insert)
     {
       ::std::string const& v =
         o.field;
@@ -6430,11 +6461,26 @@ namespace odb
     if (--d != 0)
       base_traits::init (o, *i.base, db, d);
 
+    // error_fix
+    //
+    {
+      ::ebi::vcf::ErrorFix& v =
+        o.error_fix;
+
+      sqlite::value_traits<
+          ::ebi::vcf::ErrorFix,
+          sqlite::id_integer >::set_value (
+        v,
+        i.error_fix_value,
+        i.error_fix_null);
+    }
+
     // field
     //
     {
       ::std::string& v =
-        o.field;
+        const_cast< ::std::string& > (
+        o.field);
 
       sqlite::value_traits<
           ::std::string,
@@ -6462,13 +6508,15 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::persist_statement[] =
   "INSERT INTO \"IdBodyError\" "
   "(\"id\", "
+  "\"error_fix\", "
   "\"field\") "
   "VALUES "
-  "(?, ?)";
+  "(?, ?, ?)";
 
   const char* const access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::find_statements[] =
   {
     "SELECT "
+    "\"IdBodyError\".\"error_fix\", "
     "\"IdBodyError\".\"field\", "
     "\"Error\".\"line\", "
     "\"Error\".\"message\", "
@@ -6480,11 +6528,13 @@ namespace odb
     "WHERE \"IdBodyError\".\"id\"=?",
 
     "SELECT "
+    "\"IdBodyError\".\"error_fix\", "
     "\"IdBodyError\".\"field\" "
     "FROM \"IdBodyError\" "
     "WHERE \"IdBodyError\".\"id\"=?",
 
     "SELECT "
+    "\"IdBodyError\".\"error_fix\", "
     "\"IdBodyError\".\"field\" "
     "FROM \"IdBodyError\" "
     "WHERE \"IdBodyError\".\"id\"=?"
@@ -6492,15 +6542,15 @@ namespace odb
 
   const std::size_t access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::find_column_counts[] =
   {
-    6UL,
-    1UL,
-    1UL
+    7UL,
+    2UL,
+    2UL
   };
 
   const char access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::update_statement[] =
   "UPDATE \"IdBodyError\" "
   "SET "
-  "\"field\"=? "
+  "\"error_fix\"=? "
   "WHERE \"id\"=?";
 
   const char access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::erase_statement[] =
@@ -6509,6 +6559,7 @@ namespace odb
 
   const char access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::query_statement[] =
   "SELECT\n"
+  "\"IdBodyError\".\"error_fix\",\n"
   "\"IdBodyError\".\"field\",\n"
   "\"Error\".\"line\",\n"
   "\"Error\".\"message\",\n"
@@ -9106,13 +9157,17 @@ namespace odb
     //
     if (--d != 0)
     {
-      if (base_traits::grow (*i.base, t + 1UL, d))
+      if (base_traits::grow (*i.base, t + 2UL, d))
         i.base->version++;
     }
 
+    // error_fix
+    //
+    t[0UL] = false;
+
     // field
     //
-    if (t[0UL])
+    if (t[1UL])
     {
       i.field_value.capacity (i.field_size);
       grew = true;
@@ -9143,16 +9198,26 @@ namespace odb
       n += id_size;
     }
 
+    // error_fix
+    //
+    b[n].type = sqlite::bind::integer;
+    b[n].buffer = &i.error_fix_value;
+    b[n].is_null = &i.error_fix_null;
+    n++;
+
     // field
     //
-    b[n].type = sqlite::image_traits<
-      ::std::string,
-      sqlite::id_text>::bind_value;
-    b[n].buffer = i.field_value.data ();
-    b[n].size = &i.field_size;
-    b[n].capacity = i.field_value.capacity ();
-    b[n].is_null = &i.field_null;
-    n++;
+    if (sk != statement_update)
+    {
+      b[n].type = sqlite::image_traits<
+        ::std::string,
+        sqlite::id_text>::bind_value;
+      b[n].buffer = i.field_value.data ();
+      b[n].size = &i.field_size;
+      b[n].capacity = i.field_value.capacity ();
+      b[n].is_null = &i.field_null;
+      n++;
+    }
 
     // id_
     //
@@ -9182,8 +9247,25 @@ namespace odb
 
     bool grew (false);
 
+    // error_fix
+    //
+    {
+      ::ebi::vcf::ErrorFix const& v =
+        o.error_fix;
+
+      bool is_null (false);
+      sqlite::value_traits<
+          ::ebi::vcf::ErrorFix,
+          sqlite::id_integer >::set_image (
+        i.error_fix_value,
+        is_null,
+        v);
+      i.error_fix_null = is_null;
+    }
+
     // field
     //
+    if (sk == statement_insert)
     {
       ::std::string const& v =
         o.field;
@@ -9219,11 +9301,26 @@ namespace odb
     if (--d != 0)
       base_traits::init (o, *i.base, db, d);
 
+    // error_fix
+    //
+    {
+      ::ebi::vcf::ErrorFix& v =
+        o.error_fix;
+
+      sqlite::value_traits<
+          ::ebi::vcf::ErrorFix,
+          sqlite::id_integer >::set_value (
+        v,
+        i.error_fix_value,
+        i.error_fix_null);
+    }
+
     // field
     //
     {
       ::std::string& v =
-        o.field;
+        const_cast< ::std::string& > (
+        o.field);
 
       sqlite::value_traits<
           ::std::string,
@@ -9251,13 +9348,15 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >::persist_statement[] =
   "INSERT INTO \"FilterBodyError\" "
   "(\"id\", "
+  "\"error_fix\", "
   "\"field\") "
   "VALUES "
-  "(?, ?)";
+  "(?, ?, ?)";
 
   const char* const access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >::find_statements[] =
   {
     "SELECT "
+    "\"FilterBodyError\".\"error_fix\", "
     "\"FilterBodyError\".\"field\", "
     "\"Error\".\"line\", "
     "\"Error\".\"message\", "
@@ -9269,11 +9368,13 @@ namespace odb
     "WHERE \"FilterBodyError\".\"id\"=?",
 
     "SELECT "
+    "\"FilterBodyError\".\"error_fix\", "
     "\"FilterBodyError\".\"field\" "
     "FROM \"FilterBodyError\" "
     "WHERE \"FilterBodyError\".\"id\"=?",
 
     "SELECT "
+    "\"FilterBodyError\".\"error_fix\", "
     "\"FilterBodyError\".\"field\" "
     "FROM \"FilterBodyError\" "
     "WHERE \"FilterBodyError\".\"id\"=?"
@@ -9281,15 +9382,15 @@ namespace odb
 
   const std::size_t access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >::find_column_counts[] =
   {
-    6UL,
-    1UL,
-    1UL
+    7UL,
+    2UL,
+    2UL
   };
 
   const char access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >::update_statement[] =
   "UPDATE \"FilterBodyError\" "
   "SET "
-  "\"field\"=? "
+  "\"error_fix\"=? "
   "WHERE \"id\"=?";
 
   const char access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >::erase_statement[] =
@@ -9298,6 +9399,7 @@ namespace odb
 
   const char access::object_traits_impl< ::ebi::vcf::FilterBodyError, id_sqlite >::query_statement[] =
   "SELECT\n"
+  "\"FilterBodyError\".\"error_fix\",\n"
   "\"FilterBodyError\".\"field\",\n"
   "\"Error\".\"line\",\n"
   "\"Error\".\"message\",\n"
@@ -9870,13 +9972,17 @@ namespace odb
     //
     if (--d != 0)
     {
-      if (base_traits::grow (*i.base, t + 2UL, d))
+      if (base_traits::grow (*i.base, t + 3UL, d))
         i.base->version++;
     }
 
+    // error_fix
+    //
+    t[0UL] = false;
+
     // field
     //
-    if (t[0UL])
+    if (t[1UL])
     {
       i.field_value.capacity (i.field_size);
       grew = true;
@@ -9884,7 +9990,7 @@ namespace odb
 
     // expected_value
     //
-    if (t[1UL])
+    if (t[2UL])
     {
       i.expected_value_value.capacity (i.expected_value_size);
       grew = true;
@@ -9915,27 +10021,40 @@ namespace odb
       n += id_size;
     }
 
+    // error_fix
+    //
+    b[n].type = sqlite::bind::integer;
+    b[n].buffer = &i.error_fix_value;
+    b[n].is_null = &i.error_fix_null;
+    n++;
+
     // field
     //
-    b[n].type = sqlite::image_traits<
-      ::std::string,
-      sqlite::id_text>::bind_value;
-    b[n].buffer = i.field_value.data ();
-    b[n].size = &i.field_size;
-    b[n].capacity = i.field_value.capacity ();
-    b[n].is_null = &i.field_null;
-    n++;
+    if (sk != statement_update)
+    {
+      b[n].type = sqlite::image_traits<
+        ::std::string,
+        sqlite::id_text>::bind_value;
+      b[n].buffer = i.field_value.data ();
+      b[n].size = &i.field_size;
+      b[n].capacity = i.field_value.capacity ();
+      b[n].is_null = &i.field_null;
+      n++;
+    }
 
     // expected_value
     //
-    b[n].type = sqlite::image_traits<
-      ::std::string,
-      sqlite::id_text>::bind_value;
-    b[n].buffer = i.expected_value_value.data ();
-    b[n].size = &i.expected_value_size;
-    b[n].capacity = i.expected_value_value.capacity ();
-    b[n].is_null = &i.expected_value_null;
-    n++;
+    if (sk != statement_update)
+    {
+      b[n].type = sqlite::image_traits<
+        ::std::string,
+        sqlite::id_text>::bind_value;
+      b[n].buffer = i.expected_value_value.data ();
+      b[n].size = &i.expected_value_size;
+      b[n].capacity = i.expected_value_value.capacity ();
+      b[n].is_null = &i.expected_value_null;
+      n++;
+    }
 
     // id_
     //
@@ -9965,8 +10084,25 @@ namespace odb
 
     bool grew (false);
 
+    // error_fix
+    //
+    {
+      ::ebi::vcf::ErrorFix const& v =
+        o.error_fix;
+
+      bool is_null (false);
+      sqlite::value_traits<
+          ::ebi::vcf::ErrorFix,
+          sqlite::id_integer >::set_image (
+        i.error_fix_value,
+        is_null,
+        v);
+      i.error_fix_null = is_null;
+    }
+
     // field
     //
+    if (sk == statement_insert)
     {
       ::std::string const& v =
         o.field;
@@ -9986,6 +10122,7 @@ namespace odb
 
     // expected_value
     //
+    if (sk == statement_insert)
     {
       ::std::string const& v =
         o.expected_value;
@@ -10021,11 +10158,26 @@ namespace odb
     if (--d != 0)
       base_traits::init (o, *i.base, db, d);
 
+    // error_fix
+    //
+    {
+      ::ebi::vcf::ErrorFix& v =
+        o.error_fix;
+
+      sqlite::value_traits<
+          ::ebi::vcf::ErrorFix,
+          sqlite::id_integer >::set_value (
+        v,
+        i.error_fix_value,
+        i.error_fix_null);
+    }
+
     // field
     //
     {
       ::std::string& v =
-        o.field;
+        const_cast< ::std::string& > (
+        o.field);
 
       sqlite::value_traits<
           ::std::string,
@@ -10040,7 +10192,8 @@ namespace odb
     //
     {
       ::std::string& v =
-        o.expected_value;
+        const_cast< ::std::string& > (
+        o.expected_value);
 
       sqlite::value_traits<
           ::std::string,
@@ -10068,14 +10221,16 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >::persist_statement[] =
   "INSERT INTO \"InfoBodyError\" "
   "(\"id\", "
+  "\"error_fix\", "
   "\"field\", "
   "\"expected_value\") "
   "VALUES "
-  "(?, ?, ?)";
+  "(?, ?, ?, ?)";
 
   const char* const access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >::find_statements[] =
   {
     "SELECT "
+    "\"InfoBodyError\".\"error_fix\", "
     "\"InfoBodyError\".\"field\", "
     "\"InfoBodyError\".\"expected_value\", "
     "\"Error\".\"line\", "
@@ -10088,12 +10243,14 @@ namespace odb
     "WHERE \"InfoBodyError\".\"id\"=?",
 
     "SELECT "
+    "\"InfoBodyError\".\"error_fix\", "
     "\"InfoBodyError\".\"field\", "
     "\"InfoBodyError\".\"expected_value\" "
     "FROM \"InfoBodyError\" "
     "WHERE \"InfoBodyError\".\"id\"=?",
 
     "SELECT "
+    "\"InfoBodyError\".\"error_fix\", "
     "\"InfoBodyError\".\"field\", "
     "\"InfoBodyError\".\"expected_value\" "
     "FROM \"InfoBodyError\" "
@@ -10102,16 +10259,15 @@ namespace odb
 
   const std::size_t access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >::find_column_counts[] =
   {
-    7UL,
-    2UL,
-    2UL
+    8UL,
+    3UL,
+    3UL
   };
 
   const char access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >::update_statement[] =
   "UPDATE \"InfoBodyError\" "
   "SET "
-  "\"field\"=?, "
-  "\"expected_value\"=? "
+  "\"error_fix\"=? "
   "WHERE \"id\"=?";
 
   const char access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >::erase_statement[] =
@@ -10120,6 +10276,7 @@ namespace odb
 
   const char access::object_traits_impl< ::ebi::vcf::InfoBodyError, id_sqlite >::query_statement[] =
   "SELECT\n"
+  "\"InfoBodyError\".\"error_fix\",\n"
   "\"InfoBodyError\".\"field\",\n"
   "\"InfoBodyError\".\"expected_value\",\n"
   "\"Error\".\"line\",\n"
@@ -10693,16 +10850,8 @@ namespace odb
     //
     if (--d != 0)
     {
-      if (base_traits::grow (*i.base, t + 1UL, d))
+      if (base_traits::grow (*i.base, t + 0UL, d))
         i.base->version++;
-    }
-
-    // field
-    //
-    if (t[0UL])
-    {
-      i.field_value.capacity (i.field_size);
-      grew = true;
     }
 
     return grew;
@@ -10729,17 +10878,6 @@ namespace odb
         std::memcpy (&b[n], id, id_size * sizeof (id[0]));
       n += id_size;
     }
-
-    // field
-    //
-    b[n].type = sqlite::image_traits<
-      ::std::string,
-      sqlite::id_text>::bind_value;
-    b[n].buffer = i.field_value.data ();
-    b[n].size = &i.field_size;
-    b[n].capacity = i.field_value.capacity ();
-    b[n].is_null = &i.field_null;
-    n++;
 
     // id_
     //
@@ -10769,25 +10907,6 @@ namespace odb
 
     bool grew (false);
 
-    // field
-    //
-    {
-      ::std::string const& v =
-        o.field;
-
-      bool is_null (false);
-      std::size_t cap (i.field_value.capacity ());
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_image (
-        i.field_value,
-        i.field_size,
-        is_null,
-        v);
-      i.field_null = is_null;
-      grew = grew || (cap != i.field_value.capacity ());
-    }
-
     return grew;
   }
 
@@ -10805,21 +10924,6 @@ namespace odb
     //
     if (--d != 0)
       base_traits::init (o, *i.base, db, d);
-
-    // field
-    //
-    {
-      ::std::string& v =
-        o.field;
-
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_value (
-        v,
-        i.field_value,
-        i.field_size,
-        i.field_null);
-    }
   }
 
   const access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::info_type
@@ -10837,15 +10941,13 @@ namespace odb
 
   const char access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::persist_statement[] =
   "INSERT INTO \"FormatBodyError\" "
-  "(\"id\", "
-  "\"field\") "
+  "(\"id\") "
   "VALUES "
-  "(?, ?)";
+  "(?)";
 
   const char* const access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::find_statements[] =
   {
     "SELECT "
-    "\"FormatBodyError\".\"field\", "
     "\"Error\".\"line\", "
     "\"Error\".\"message\", "
     "\"Error\".\"severity\", "
@@ -10855,29 +10957,17 @@ namespace odb
     "LEFT JOIN \"Error\" ON \"Error\".\"id\"=\"FormatBodyError\".\"id\" "
     "WHERE \"FormatBodyError\".\"id\"=?",
 
-    "SELECT "
-    "\"FormatBodyError\".\"field\" "
-    "FROM \"FormatBodyError\" "
-    "WHERE \"FormatBodyError\".\"id\"=?",
+    "",
 
-    "SELECT "
-    "\"FormatBodyError\".\"field\" "
-    "FROM \"FormatBodyError\" "
-    "WHERE \"FormatBodyError\".\"id\"=?"
+    ""
   };
 
   const std::size_t access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::find_column_counts[] =
   {
-    6UL,
-    1UL,
-    1UL
+    5UL,
+    0UL,
+    0UL
   };
-
-  const char access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::update_statement[] =
-  "UPDATE \"FormatBodyError\" "
-  "SET "
-  "\"field\"=? "
-  "WHERE \"id\"=?";
 
   const char access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::erase_statement[] =
   "DELETE FROM \"FormatBodyError\" "
@@ -10885,7 +10975,6 @@ namespace odb
 
   const char access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::query_statement[] =
   "SELECT\n"
-  "\"FormatBodyError\".\"field\",\n"
   "\"Error\".\"line\",\n"
   "\"Error\".\"message\",\n"
   "\"Error\".\"severity\",\n"
@@ -10984,32 +11073,7 @@ namespace odb
     if (top)
       callback (db, obj, callback_event::pre_update);
 
-    sqlite::transaction& tr (sqlite::transaction::current ());
-    sqlite::connection& conn (tr.connection ());
-    statements_type& sts (
-      conn.statement_cache ().find_object<object_type> ());
-
     base_traits::update (db, obj, false, false);
-
-    image_type& im (sts.image ());
-    if (init (im, obj, statement_update))
-      im.version++;
-
-    const binding& idb (sts.id_image_binding ());
-    binding& imb (sts.update_image_binding ());
-    if (idb.version != sts.update_id_binding_version () ||
-        im.version != sts.update_image_version () ||
-        imb.version == 0)
-    {
-      bind (imb.bind, idb.bind, idb.count, im, statement_update);
-      sts.update_id_binding_version (idb.version);
-      sts.update_image_version (im.version);
-      imb.version++;
-    }
-
-    update_statement& st (sts.update_statement ());
-    if (st.execute () == 0)
-      throw object_not_persistent ();
 
     if (top)
     {
@@ -11342,13 +11406,17 @@ namespace odb
 
     d = depth - d;
 
-    if (!find_ (sts, 0, d))
-      throw object_not_persistent ();
+    if (d > 2UL)
+    {
+      if (!find_ (sts, 0, d))
+        throw object_not_persistent ();
 
-    select_statement& st (sts.find_statement (d));
-    ODB_POTENTIALLY_UNUSED (st);
+      select_statement& st (sts.find_statement (d));
+      ODB_POTENTIALLY_UNUSED (st);
 
-    init (obj, sts.image (), &db, d);
+      init (obj, sts.image (), &db, d);
+    }
+
     load_ (sts, obj, false, d);
   }
 
@@ -14368,6 +14436,7 @@ namespace odb
                       "    ON DELETE CASCADE)");
           db.execute ("CREATE TABLE \"IdBodyError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
+                      "  \"error_fix\" INTEGER NOT NULL,\n"
                       "  \"field\" TEXT NOT NULL,\n"
                       "  CONSTRAINT \"id_fk\"\n"
                       "    FOREIGN KEY (\"id\")\n"
@@ -14393,6 +14462,7 @@ namespace odb
                       "    ON DELETE CASCADE)");
           db.execute ("CREATE TABLE \"FilterBodyError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
+                      "  \"error_fix\" INTEGER NOT NULL,\n"
                       "  \"field\" TEXT NOT NULL,\n"
                       "  CONSTRAINT \"id_fk\"\n"
                       "    FOREIGN KEY (\"id\")\n"
@@ -14400,6 +14470,7 @@ namespace odb
                       "    ON DELETE CASCADE)");
           db.execute ("CREATE TABLE \"InfoBodyError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
+                      "  \"error_fix\" INTEGER NOT NULL,\n"
                       "  \"field\" TEXT NOT NULL,\n"
                       "  \"expected_value\" TEXT NOT NULL,\n"
                       "  CONSTRAINT \"id_fk\"\n"
@@ -14408,7 +14479,6 @@ namespace odb
                       "    ON DELETE CASCADE)");
           db.execute ("CREATE TABLE \"FormatBodyError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
-                      "  \"field\" TEXT NOT NULL,\n"
                       "  CONSTRAINT \"id_fk\"\n"
                       "    FOREIGN KEY (\"id\")\n"
                       "    REFERENCES \"BodySectionError\" (\"id\")\n"

--- a/src/vcf/error-odb.cpp
+++ b/src/vcf/error-odb.cpp
@@ -6317,21 +6317,13 @@ namespace odb
     //
     if (--d != 0)
     {
-      if (base_traits::grow (*i.base, t + 2UL, d))
+      if (base_traits::grow (*i.base, t + 1UL, d))
         i.base->version++;
     }
 
     // error_fix
     //
     t[0UL] = false;
-
-    // field
-    //
-    if (t[1UL])
-    {
-      i.field_value.capacity (i.field_size);
-      grew = true;
-    }
 
     return grew;
   }
@@ -6364,20 +6356,6 @@ namespace odb
     b[n].buffer = &i.error_fix_value;
     b[n].is_null = &i.error_fix_null;
     n++;
-
-    // field
-    //
-    if (sk != statement_update)
-    {
-      b[n].type = sqlite::image_traits<
-        ::std::string,
-        sqlite::id_text>::bind_value;
-      b[n].buffer = i.field_value.data ();
-      b[n].size = &i.field_size;
-      b[n].capacity = i.field_value.capacity ();
-      b[n].is_null = &i.field_null;
-      n++;
-    }
 
     // id_
     //
@@ -6423,26 +6401,6 @@ namespace odb
       i.error_fix_null = is_null;
     }
 
-    // field
-    //
-    if (sk == statement_insert)
-    {
-      ::std::string const& v =
-        o.field;
-
-      bool is_null (false);
-      std::size_t cap (i.field_value.capacity ());
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_image (
-        i.field_value,
-        i.field_size,
-        is_null,
-        v);
-      i.field_null = is_null;
-      grew = grew || (cap != i.field_value.capacity ());
-    }
-
     return grew;
   }
 
@@ -6474,22 +6432,6 @@ namespace odb
         i.error_fix_value,
         i.error_fix_null);
     }
-
-    // field
-    //
-    {
-      ::std::string& v =
-        const_cast< ::std::string& > (
-        o.field);
-
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_value (
-        v,
-        i.field_value,
-        i.field_size,
-        i.field_null);
-    }
   }
 
   const access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::info_type
@@ -6508,16 +6450,14 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::persist_statement[] =
   "INSERT INTO \"IdBodyError\" "
   "(\"id\", "
-  "\"error_fix\", "
-  "\"field\") "
+  "\"error_fix\") "
   "VALUES "
-  "(?, ?, ?)";
+  "(?, ?)";
 
   const char* const access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::find_statements[] =
   {
     "SELECT "
     "\"IdBodyError\".\"error_fix\", "
-    "\"IdBodyError\".\"field\", "
     "\"Error\".\"line\", "
     "\"Error\".\"message\", "
     "\"Error\".\"severity\", "
@@ -6528,23 +6468,21 @@ namespace odb
     "WHERE \"IdBodyError\".\"id\"=?",
 
     "SELECT "
-    "\"IdBodyError\".\"error_fix\", "
-    "\"IdBodyError\".\"field\" "
+    "\"IdBodyError\".\"error_fix\" "
     "FROM \"IdBodyError\" "
     "WHERE \"IdBodyError\".\"id\"=?",
 
     "SELECT "
-    "\"IdBodyError\".\"error_fix\", "
-    "\"IdBodyError\".\"field\" "
+    "\"IdBodyError\".\"error_fix\" "
     "FROM \"IdBodyError\" "
     "WHERE \"IdBodyError\".\"id\"=?"
   };
 
   const std::size_t access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::find_column_counts[] =
   {
-    7UL,
-    2UL,
-    2UL
+    6UL,
+    1UL,
+    1UL
   };
 
   const char access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::update_statement[] =
@@ -6560,7 +6498,6 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::IdBodyError, id_sqlite >::query_statement[] =
   "SELECT\n"
   "\"IdBodyError\".\"error_fix\",\n"
-  "\"IdBodyError\".\"field\",\n"
   "\"Error\".\"line\",\n"
   "\"Error\".\"message\",\n"
   "\"Error\".\"severity\",\n"
@@ -10850,21 +10787,13 @@ namespace odb
     //
     if (--d != 0)
     {
-      if (base_traits::grow (*i.base, t + 2UL, d))
+      if (base_traits::grow (*i.base, t + 1UL, d))
         i.base->version++;
     }
 
     // error_fix
     //
     t[0UL] = false;
-
-    // field
-    //
-    if (t[1UL])
-    {
-      i.field_value.capacity (i.field_size);
-      grew = true;
-    }
 
     return grew;
   }
@@ -10897,20 +10826,6 @@ namespace odb
     b[n].buffer = &i.error_fix_value;
     b[n].is_null = &i.error_fix_null;
     n++;
-
-    // field
-    //
-    if (sk != statement_update)
-    {
-      b[n].type = sqlite::image_traits<
-        ::std::string,
-        sqlite::id_text>::bind_value;
-      b[n].buffer = i.field_value.data ();
-      b[n].size = &i.field_size;
-      b[n].capacity = i.field_value.capacity ();
-      b[n].is_null = &i.field_null;
-      n++;
-    }
 
     // id_
     //
@@ -10956,26 +10871,6 @@ namespace odb
       i.error_fix_null = is_null;
     }
 
-    // field
-    //
-    if (sk == statement_insert)
-    {
-      ::std::string const& v =
-        o.field;
-
-      bool is_null (false);
-      std::size_t cap (i.field_value.capacity ());
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_image (
-        i.field_value,
-        i.field_size,
-        is_null,
-        v);
-      i.field_null = is_null;
-      grew = grew || (cap != i.field_value.capacity ());
-    }
-
     return grew;
   }
 
@@ -11007,22 +10902,6 @@ namespace odb
         i.error_fix_value,
         i.error_fix_null);
     }
-
-    // field
-    //
-    {
-      ::std::string& v =
-        const_cast< ::std::string& > (
-        o.field);
-
-      sqlite::value_traits<
-          ::std::string,
-          sqlite::id_text >::set_value (
-        v,
-        i.field_value,
-        i.field_size,
-        i.field_null);
-    }
   }
 
   const access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::info_type
@@ -11041,16 +10920,14 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::persist_statement[] =
   "INSERT INTO \"FormatBodyError\" "
   "(\"id\", "
-  "\"error_fix\", "
-  "\"field\") "
+  "\"error_fix\") "
   "VALUES "
-  "(?, ?, ?)";
+  "(?, ?)";
 
   const char* const access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::find_statements[] =
   {
     "SELECT "
     "\"FormatBodyError\".\"error_fix\", "
-    "\"FormatBodyError\".\"field\", "
     "\"Error\".\"line\", "
     "\"Error\".\"message\", "
     "\"Error\".\"severity\", "
@@ -11061,23 +10938,21 @@ namespace odb
     "WHERE \"FormatBodyError\".\"id\"=?",
 
     "SELECT "
-    "\"FormatBodyError\".\"error_fix\", "
-    "\"FormatBodyError\".\"field\" "
+    "\"FormatBodyError\".\"error_fix\" "
     "FROM \"FormatBodyError\" "
     "WHERE \"FormatBodyError\".\"id\"=?",
 
     "SELECT "
-    "\"FormatBodyError\".\"error_fix\", "
-    "\"FormatBodyError\".\"field\" "
+    "\"FormatBodyError\".\"error_fix\" "
     "FROM \"FormatBodyError\" "
     "WHERE \"FormatBodyError\".\"id\"=?"
   };
 
   const std::size_t access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::find_column_counts[] =
   {
-    7UL,
-    2UL,
-    2UL
+    6UL,
+    1UL,
+    1UL
   };
 
   const char access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::update_statement[] =
@@ -11093,7 +10968,6 @@ namespace odb
   const char access::object_traits_impl< ::ebi::vcf::FormatBodyError, id_sqlite >::query_statement[] =
   "SELECT\n"
   "\"FormatBodyError\".\"error_fix\",\n"
-  "\"FormatBodyError\".\"field\",\n"
   "\"Error\".\"line\",\n"
   "\"Error\".\"message\",\n"
   "\"Error\".\"severity\",\n"
@@ -14577,7 +14451,6 @@ namespace odb
           db.execute ("CREATE TABLE \"IdBodyError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
                       "  \"error_fix\" INTEGER NOT NULL,\n"
-                      "  \"field\" TEXT NOT NULL,\n"
                       "  CONSTRAINT \"id_fk\"\n"
                       "    FOREIGN KEY (\"id\")\n"
                       "    REFERENCES \"BodySectionError\" (\"id\")\n"
@@ -14620,7 +14493,6 @@ namespace odb
           db.execute ("CREATE TABLE \"FormatBodyError\" (\n"
                       "  \"id\" INTEGER NOT NULL PRIMARY KEY,\n"
                       "  \"error_fix\" INTEGER NOT NULL,\n"
-                      "  \"field\" TEXT NOT NULL,\n"
                       "  CONSTRAINT \"id_fk\"\n"
                       "    FOREIGN KEY (\"id\")\n"
                       "    REFERENCES \"BodySectionError\" (\"id\")\n"

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <set>
-
 #include "vcf/fixer.hpp"
 #include "vcf/string_constants.hpp"
 
@@ -313,22 +311,7 @@ namespace ebi
                 }
 
                 std::set<std::string> fields_to_remove;
-
-                for (auto it = first + 1; it != last; it++) {
-                    std::vector<std::string> sample_fields;
-                    util::string_split(*it, ":", sample_fields);
-                    for (auto & format_field : format_fields) {
-                        if (format_field.second.size() > 1) {
-                            for (auto & format_field_index : format_field.second) {
-                                if (sample_fields.size() > format_field_index && sample_fields[format_field_index] != sample_fields[format_field.second[0]]) {
-                                    fields_to_remove.insert(format_field.first);
-                                    it = last - 1;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
+                get_fields_to_remove(format_fields, first, last, fields_to_remove);
 
                 std::vector<std::string> fixed_format;
                 for (auto & ordered_field : ordered_fields) {
@@ -367,6 +350,28 @@ namespace ebi
             });
 
             return num_removed_duplicates;
+        }
+
+        void Fixer::get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields,
+                                         std::vector<std::string>::iterator first, 
+                                         std::vector<std::string>::iterator last,
+                                         std::set<std::string> &fields_to_remove)
+        {
+            for (auto it = first + 1; it != last; it++) {
+                std::vector<std::string> sample_fields;
+                util::string_split(*it, ":", sample_fields);
+                for (auto & format_field : format_fields) {
+                    if (format_field.second.size() > 1) {
+                        for (auto & format_field_index : format_field.second) {
+                            if (sample_fields.size() > format_field_index && sample_fields[format_field_index] != sample_fields[format_field.second[0]]) {
+                                fields_to_remove.insert(format_field.first);
+                                it = last - 1;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         void Fixer::fix_format_gt(std::vector<std::string>::iterator first,

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -77,8 +77,7 @@ namespace ebi
 
     void Fixer::visit(NoMetaDefinitionError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(FileformatError &error)

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -261,7 +261,7 @@ namespace ebi
                                                        const std::string &empty_value)
         {
             std::map<std::string, std::string> values;
-            std::vector<std::string> ordered_values;
+            std::vector<std::string> ordered_keys;
             std::set<std::string> fields_to_remove;
 
             std::vector<std::string> fields;
@@ -272,7 +272,7 @@ namespace ebi
                 util::string_split(field, key_value_separator.c_str(), subfields);
                 auto iterator = values.find(subfields[0]);
                 if (iterator == values.end()) {
-                    ordered_values.push_back(subfields[0]);
+                    ordered_keys.push_back(subfields[0]);
                     values[subfields[0]] = subfields[1];
                 } else if (values[subfields[0]] != subfields[1]) {
                     fields_to_remove.insert(subfields[0]);
@@ -281,9 +281,9 @@ namespace ebi
 
             std::string fixed_column;
             size_t num_removed_duplicates = 0;
-            for (auto & ordered_value : ordered_values) {
-                if (fields_to_remove.find(ordered_value) == fields_to_remove.end()) {
-                    fixed_column += ordered_value + key_value_separator + values[ordered_value] + separator;
+            for (auto & ordered_key : ordered_keys) {
+                if (fields_to_remove.find(ordered_key) == fields_to_remove.end()) {
+                    fixed_column += ordered_key + key_value_separator + values[ordered_key] + separator;
                 } else {
                     num_removed_duplicates++;
                 }
@@ -354,7 +354,7 @@ namespace ebi
                 }
     
                 if (fixed_format.empty()) {
-                    throw std::runtime_error("Could not fix FORMAT duplicate fields, all fields had to be removed, but missing value not permitted");
+                    throw std::runtime_error("Could not fix FORMAT duplicate fields: All fields had to be removed, but missing value is not permitted");
                 } else {
                     fixed_format.pop_back();              // remove trailing colon
                 }
@@ -497,11 +497,11 @@ namespace ebi
             size_t num_replaced_columns = 0;
 
             for (size_t j = 0; j < columns.size(); ++j) {
-                if (not condition_to_replace(columns[j], j)) {
-                    output << columns[j];
-                } else {
+                if (condition_to_replace(columns[j], j)) {
                     num_replaced_columns++;
                     output << expected_field;
+                } else {
+                    output << columns[j];
                 }
                 if (j < columns.size() - 1) {
                     output << separators;

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -298,20 +298,20 @@ namespace ebi
 
             using iter = std::vector<std::string>::iterator;
             fix_columns(format_column_index, -1, string_line, "\t", [&](iter first, iter last) {
-                std::map<std::string, std::vector<size_t>> format_fields;
+                std::map<std::string, std::vector<size_t>> format_fields_indexes;
                 std::vector<std::string> ordered_fields;
                 std::vector<std::string> format_keys;
                 util::string_split(*first, ":", format_keys);
 
                 for (size_t i = 0; i < format_keys.size(); i++) {
-                    format_fields[format_keys[i]].push_back(i);
-                    if (format_fields[format_keys[i]].size() == 1) {
+                    format_fields_indexes[format_keys[i]].push_back(i);
+                    if (format_fields_indexes[format_keys[i]].size() == 1) {
                         ordered_fields.push_back(format_keys[i]);
                     }
                 }
 
                 std::set<std::string> fields_to_remove;
-                get_fields_to_remove(format_fields, first, last, fields_to_remove);
+                get_fields_to_remove(format_fields_indexes, first, last, fields_to_remove);
 
                 std::vector<std::string> fixed_format;
                 for (auto & ordered_field : ordered_fields) {
@@ -335,8 +335,8 @@ namespace ebi
                     for (auto & ordered_field : ordered_fields) {
                         if (fields_to_remove.find(ordered_field) == fields_to_remove.end()) {
                             // keep first occurrence, discard the rest if present
-                            if (sample_fields.size() > format_fields[ordered_field][0]) {
-                                fixed_sample.push_back(sample_fields[format_fields[ordered_field][0]]);
+                            if (sample_fields.size() > format_fields_indexes[ordered_field][0]) {
+                                fixed_sample.push_back(sample_fields[format_fields_indexes[ordered_field][0]]);
                             }
                         }
                     }
@@ -352,7 +352,7 @@ namespace ebi
             return num_removed_duplicates;
         }
 
-        void Fixer::get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields,
+        void Fixer::get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
                                          std::vector<std::string>::iterator first, 
                                          std::vector<std::string>::iterator last,
                                          std::set<std::string> &fields_to_remove)
@@ -360,7 +360,7 @@ namespace ebi
             for (auto it = first + 1; it != last; it++) {
                 std::vector<std::string> sample_fields;
                 util::string_split(*it, ":", sample_fields);
-                for (auto & format_field : format_fields) {
+                for (auto & format_field : format_fields_indexes) {
                     if (format_field.second.size() > 1) {
                         for (auto & format_field_index : format_field.second) {
                             if (sample_fields.size() > format_field_index && sample_fields[format_field_index] != sample_fields[format_field.second[0]]) {

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -145,12 +145,12 @@ namespace ebi
             fix_column(filter_column_index, string_line, "\t", [&](std::string &filter_column) {
                 if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE && error.field == "0") {
                     std::cerr << "DEBUG: line " << error.line << ": fixing invalid FILTER field " << error.field << std::endl;
-                    const std::string empty_filter_column = ".";
+                    const std::string empty_filter_column = MISSING_VALUE;
                     auto condition_to_remove_filter_field = [&](const std::string &filter_subfield, size_t index) -> bool {
                         return filter_subfield == error.field;
                     };
 
-                    remove_column(filter_column, ";", empty_filter_column, condition_to_remove_filter_field);
+                    remove_fields(filter_column, ";", empty_filter_column, condition_to_remove_filter_field);
                 } else if (error.error_fix == ErrorFix::DUPLICATE_VALUES) {
                     std::cerr << "DEBUG: line " << error.line << ": fixing duplicate FILTER fields" << std::endl;
                     remove_duplicate_strings(filter_column, ";");
@@ -255,7 +255,7 @@ namespace ebi
                 bool first_appearance = already_present.insert(value).second;
                 return not first_appearance;
             };
-            return remove_column(column, separator, is_value_duplicated);
+            return remove_fields(column, separator, is_value_duplicated);
         }
 
         size_t Fixer::remove_duplicate_key_value_pairs(const std::string &column,
@@ -342,7 +342,7 @@ namespace ebi
             // remove from FORMAT column
             const std::string field_separator = ":";
             size_t field_index;
-            size_t removed = remove_column(*first, field_separator, [&](const std::string &field, size_t index) {
+            size_t removed = remove_fields(*first, field_separator, [&](const std::string &field, size_t index) {
                 if (field == error.field) {
                     field_index = index;
                     return field == error.field;
@@ -361,7 +361,7 @@ namespace ebi
             // remove from the samples columns
             for (++first; first != last; ++first) {
                 output << "\t";
-                removed = remove_column(*first, field_separator, [&](const std::string &field, size_t index) {
+                removed = remove_fields(*first, field_separator, [&](const std::string &field, size_t index) {
                     return index == field_index;
                 });
                 if (removed == 0) {
@@ -379,7 +379,7 @@ namespace ebi
                              const std::string &separators,
                              std::function<bool(const std::string &column, size_t index)> condition_to_remove)
         {
-            return remove_column(line, separators, "", condition_to_remove);
+            return remove_fields(line, separators, "", condition_to_remove);
         }
 
         size_t Fixer::remove_fields(const std::string &line,

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -276,6 +276,7 @@ namespace ebi
 
             std::vector<std::string> fixed_column;
             size_t num_removed_duplicates = 0;
+
             for (auto & ordered_key : ordered_keys) {
                 if (fields_to_remove.find(ordered_key) == fields_to_remove.end()) {
                     fixed_column.push_back(ordered_key + key_value_separator + first_key_occurrence[ordered_key]);
@@ -283,6 +284,7 @@ namespace ebi
                     num_removed_duplicates++;
                 }
             }
+
             if (fixed_column.size() == 0) {       // all the fields were removed
                 output << empty_value;
             } else {
@@ -310,8 +312,7 @@ namespace ebi
                     }
                 }
 
-                std::set<std::string> fields_to_remove;
-                get_fields_to_remove(format_fields_indexes, first, last, fields_to_remove);
+                std::set<std::string> fields_to_remove = get_format_fields_to_remove(format_fields_indexes, first, last);
 
                 std::vector<std::string> fixed_format;
                 for (auto & ordered_field : ordered_fields) {
@@ -352,11 +353,12 @@ namespace ebi
             return num_removed_duplicates;
         }
 
-        void Fixer::get_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
-                                         std::vector<std::string>::iterator first, 
-                                         std::vector<std::string>::iterator last,
-                                         std::set<std::string> &fields_to_remove)
+        std::set<std::string> Fixer::get_format_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
+                                                                 std::vector<std::string>::iterator first,
+                                                                 std::vector<std::string>::iterator last)
         {
+            std::set<std::string> fields_to_remove;
+
             for (auto it = first + 1; it != last; it++) {
                 std::vector<std::string> sample_fields;
                 util::string_split(*it, ":", sample_fields);
@@ -372,6 +374,8 @@ namespace ebi
                     }
                 }
             }
+
+            return fields_to_remove;
         }
 
         void Fixer::fix_format_gt(std::vector<std::string>::iterator first,

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -97,6 +97,12 @@ namespace ebi
 
         void Fixer::visit(IdBodyError &error)
         {
+            if (error.field == "") {
+                util::writeline(output, *line);
+                ignored_errors++;
+                return;
+            }
+
             std::cerr << "DEBUG: line " << error.line << ": fixing invalid ID field " << error.field << std::endl;
             const size_t id_column_index = 2;
             const std::string empty_id_column = ".";
@@ -131,6 +137,12 @@ namespace ebi
 
         void Fixer::visit(FilterBodyError &error)
         {
+            if (error.field == "") {
+                util::writeline(output, *line);
+                ignored_errors++;
+                return;
+            }
+
             std::cerr << "DEBUG: line " << error.line << ": fixing invalid FILTER field " << error.field << std::endl;
             const size_t filter_column_index = 6;
             const std::string empty_filter_column = ".";

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -365,7 +365,7 @@ namespace ebi
             }
 
             if (fixed_format.empty()) {
-                fixed_format = MISSING_VALUE;         // all format fields were removed, so use missing value
+                throw std::runtime_error("Could not fix FORMAT duplicate fields, all fields had to be removed, but missing value not permitted");
             } else {
                 fixed_format.pop_back();              // remove trailing colon
             }
@@ -373,7 +373,7 @@ namespace ebi
 
             for (auto & fixed_sample : fixed_samples) {
                 if (fixed_sample.empty()) {
-                    fixed_sample = MISSING_VALUE;      // all sample fields were removed
+                    fixed_sample = MISSING_VALUE;      // all sample fields were removed, so set to MISSING_VALUE
                 } else {
                     fixed_sample.pop_back();           // remove trailing colon
                 }

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -314,11 +314,11 @@ namespace ebi
 
                 std::set<std::string> fields_to_remove;
 
-                for (auto & format_field : format_fields) {
-                    if (format_field.second.size() > 1) {
-                        for (auto it = first + 1; it != last; it++) {
-                            std::vector<std::string> sample_fields;
-                            util::string_split(*it, ":", sample_fields);
+                for (auto it = first + 1; it != last; it++) {
+                    std::vector<std::string> sample_fields;
+                    util::string_split(*it, ":", sample_fields);
+                    for (auto & format_field : format_fields) {
+                        if (format_field.second.size() > 1) {
                             for (auto & format_field_index : format_field.second) {
                                 if (sample_fields.size() > format_field_index && sample_fields[format_field_index] != sample_fields[format_field.second[0]]) {
                                     fields_to_remove.insert(format_field.first);

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -21,26 +21,26 @@
 
 namespace ebi
 {
-    namespace vcf
+  namespace vcf
+  {
+    void Fixer::fix(size_t line_number, std::vector<char> &line, Error &error)
     {
-        void Fixer::fix(size_t line_number, std::vector<char> &line, Error &error)
-        {
-            this->line_number = line_number;
-            this->line = &line; // this will be valid until this function returns
-            error.apply_visitor(*this);
-            this->line = nullptr;
-        }
+        this->line_number = line_number;
+        this->line = &line; // this will be valid until this function returns
+        error.apply_visitor(*this);
+        this->line = nullptr;
+    }
 
-        size_t Fixer::get_ignored_errors()
-        {
-            return ignored_errors;
-        }
+    size_t Fixer::get_ignored_errors()
+    {
+        return ignored_errors;
+    }
 
-        void Fixer::visit(Error &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(Error &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
         void Fixer::visit(MetaSectionError &error)
         {
@@ -61,463 +61,463 @@ namespace ebi
             }
         }
 
-        void Fixer::visit(HeaderSectionError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(HeaderSectionError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
-        void Fixer::visit(BodySectionError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(BodySectionError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
-        void Fixer::visit(NoMetaDefinitionError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(NoMetaDefinitionError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
-        void Fixer::visit(FileformatError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(FileformatError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
-        void Fixer::visit(ChromosomeBodyError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(ChromosomeBodyError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
-        void Fixer::visit(PositionBodyError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(PositionBodyError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
-        void Fixer::visit(IdBodyError &error)
-        {
-            if (error.error_fix == ErrorFix::DUPLICATE_VALUES) {
-                std::cerr << "DEBUG: line " << error.line << ": fixing duplicate ID fields" << std::endl;
-                const size_t id_column_index = 2;
-                std::string string_line = {line->begin(), line->end()};
-
-                fix_column(id_column_index, string_line, "\t", [&](std::string &id_column) {
-                    remove_duplicate_strings(id_column, ";");
-                });
-            } else if (error.field == "") {
-                util::writeline(output, *line);
-                ignored_errors++;
-            }
-        }
-
-        void Fixer::visit(ReferenceAlleleBodyError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
-
-        void Fixer::visit(AlternateAllelesBodyError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
-
-        void Fixer::visit(QualityBodyError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
-
-        void Fixer::visit(FilterBodyError &error)
-        {
-            if (error.field == "" && error.error_fix != ErrorFix::DUPLICATE_VALUES) {
-                util::writeline(output, *line);
-                ignored_errors++;
-                return;
-            }
-
-            const size_t filter_column_index = 6;
+    void Fixer::visit(IdBodyError &error)
+    {
+        if (error.error_fix == ErrorFix::DUPLICATE_VALUES) {
+            std::cerr << "DEBUG: line " << error.line << ": fixing duplicate ID fields" << std::endl;
+            const size_t id_column_index = 2;
             std::string string_line = {line->begin(), line->end()};
 
-            fix_column(filter_column_index, string_line, "\t", [&](std::string &filter_column) {
-                if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE && error.field == "0") {
-                    std::cerr << "DEBUG: line " << error.line << ": fixing invalid FILTER field " << error.field << std::endl;
-                    const std::string empty_filter_column = MISSING_VALUE;
-                    auto condition_to_remove_filter_field = [&](const std::string &filter_subfield, size_t index) -> bool {
-                        return filter_subfield == error.field;
-                    };
-
-                    remove_fields(filter_column, ";", empty_filter_column, condition_to_remove_filter_field);
-                } else if (error.error_fix == ErrorFix::DUPLICATE_VALUES) {
-                    std::cerr << "DEBUG: line " << error.line << ": fixing duplicate FILTER fields" << std::endl;
-                    remove_duplicate_strings(filter_column, ";");
-                }
+            fix_column(id_column_index, string_line, "\t", [&](std::string &id_column) {
+                remove_duplicate_strings(id_column, ";");
             });
+        } else if (error.field == "") {
+            util::writeline(output, *line);
+            ignored_errors++;
+        }
+    }
+
+    void Fixer::visit(ReferenceAlleleBodyError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
+
+    void Fixer::visit(AlternateAllelesBodyError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
+
+    void Fixer::visit(QualityBodyError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
+
+    void Fixer::visit(FilterBodyError &error)
+    {
+        if (error.field == "" && error.error_fix != ErrorFix::DUPLICATE_VALUES) {
+            util::writeline(output, *line);
+            ignored_errors++;
+            return;
         }
 
-        void Fixer::visit(InfoBodyError &error)
-        {
-            // TODO better log system, if any
-            const size_t info_column_index = 7;
+        const size_t filter_column_index = 6;
+        std::string string_line = {line->begin(), line->end()};
 
-            std::string string_line = {line->begin(), line->end()};
-
-            fix_column(info_column_index, string_line, "\t", [&](std::string &info_column) {
-                const std::string empty_info_column = MISSING_VALUE;
-
-                auto condition_to_modify_info_field = [&](const std::string &info_subfield, size_t index) -> bool {
-                    std::vector<std::string> key_value;
-                    util::string_split(info_subfield, "=", key_value);
-                    return key_value[0] == error.field;
+        fix_column(filter_column_index, string_line, "\t", [&](std::string &filter_column) {
+            if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE && error.field == "0") {
+                std::cerr << "DEBUG: line " << error.line << ": fixing invalid FILTER field " << error.field << std::endl;
+                const std::string empty_filter_column = MISSING_VALUE;
+                auto condition_to_remove_filter_field = [&](const std::string &filter_subfield, size_t index) -> bool {
+                    return filter_subfield == error.field;
                 };
 
-                if (error.error_fix == ErrorFix::DUPLICATE_VALUES) {
-                    std::cerr << "DEBUG: line " << error.field << ": fixing duplicate INFO fields" << std::endl;
-                    remove_duplicate_key_value_pairs(info_column, ";", "=", empty_info_column);
-                } else if (error.error_fix == ErrorFix::RECOVERABLE_VALUE) {
-                    std::cerr << "DEBUG: line " << error.field << ": fixing invalid INFO field " << error.field << std::endl;
-                    replace_fields(info_column, ";", error.field + "=" + error.expected_value, condition_to_modify_info_field);
-                } else if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE) {
-                    std::cerr << "DEBUG: line " << error.field << ": removing invalid INFO field " << error.field << std::endl;
-                    remove_fields(info_column, ";", empty_info_column, condition_to_modify_info_field);
+                remove_fields(filter_column, ";", empty_filter_column, condition_to_remove_filter_field);
+            } else if (error.error_fix == ErrorFix::DUPLICATE_VALUES) {
+                std::cerr << "DEBUG: line " << error.line << ": fixing duplicate FILTER fields" << std::endl;
+                remove_duplicate_strings(filter_column, ";");
+            }
+        });
+    }
+
+    void Fixer::visit(InfoBodyError &error)
+    {
+        // TODO better log system, if any
+        const size_t info_column_index = 7;
+
+        std::string string_line = {line->begin(), line->end()};
+
+        fix_column(info_column_index, string_line, "\t", [&](std::string &info_column) {
+            const std::string empty_info_column = MISSING_VALUE;
+
+            auto condition_to_modify_info_field = [&](const std::string &info_subfield, size_t index) -> bool {
+                std::vector<std::string> key_value;
+                util::string_split(info_subfield, "=", key_value);
+                return key_value[0] == error.field;
+            };
+
+            if (error.error_fix == ErrorFix::DUPLICATE_VALUES) {
+                std::cerr << "DEBUG: line " << error.field << ": fixing duplicate INFO fields" << std::endl;
+                remove_duplicate_key_value_pairs(info_column, ";", "=", empty_info_column);
+            } else if (error.error_fix == ErrorFix::RECOVERABLE_VALUE) {
+                std::cerr << "DEBUG: line " << error.field << ": fixing invalid INFO field " << error.field << std::endl;
+                replace_fields(info_column, ";", error.field + "=" + error.expected_value, condition_to_modify_info_field);
+            } else if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE) {
+                std::cerr << "DEBUG: line " << error.field << ": removing invalid INFO field " << error.field << std::endl;
+                remove_fields(info_column, ";", empty_info_column, condition_to_modify_info_field);
+            }
+        });
+    }
+
+    void Fixer::visit(FormatBodyError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
+
+    void Fixer::visit(SamplesBodyError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
+
+    void Fixer::visit(SamplesFieldBodyError &error)
+    {
+        std::cerr << "DEBUG: line " << error.line << ": fixing invalid sample field " << error.field
+                  << std::endl;
+
+        const size_t format_column_index = 8;
+        // size_t first_samples_column_index = 9;
+        std::string string_line = {line->begin(), line->end()};
+
+        size_t fixed_samples;
+        std::string message;
+        try {
+            using iter = std::vector<std::string>::iterator;
+            fixed_samples = fix_columns(format_column_index, -1, string_line, "\t", [&](iter first, iter last) {
+                if (error.field == GT) {
+                    fix_format_gt(first, last, error);
+                } else {
+                    remove_format(first, last, error);
                 }
             });
+        } catch (std::out_of_range bad_range) {
+            // there were not enough columns. maybe an aggregate vcf without genotypes?
+            fixed_samples = 0;
+            message = bad_range.what();
         }
 
-        void Fixer::visit(FormatBodyError &error)
-        {
+        if (fixed_samples <= 1) {   // 1 because we started counting since the FORMAT column
+            std::cerr << "WARNING: line " << error.line << ": tried to fix field " << error.field
+                      << " in the samples column, but sample columns are not present. " << message << std::endl;
             util::writeline(output, *line);
             ignored_errors++;
+            return;
         }
+    }
 
-        void Fixer::visit(SamplesBodyError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
+    void Fixer::visit(NormalizationError &error)
+    {
+        util::writeline(output, *line);
+        ignored_errors++;
+    }
 
-        void Fixer::visit(SamplesFieldBodyError &error)
-        {
-            std::cerr << "DEBUG: line " << error.line << ": fixing invalid sample field " << error.field
-                      << std::endl;
+    void Fixer::visit(DuplicationError &error)
+    {
+        // TODO better log system, if any
+        std::cerr << "DEBUG: line " << line_number << ": fixing duplicate: removing variant: "
+        << std::string{line->begin(), line->end()} << std::endl;
+    }
 
-            const size_t format_column_index = 8;
-            // size_t first_samples_column_index = 9;
-            std::string string_line = {line->begin(), line->end()};
+    size_t Fixer::remove_duplicate_strings(const std::string &column,
+                                           const std::string &separator)
+    {
+        std::set<std::string> already_present;
+        auto is_value_duplicated = [&](const std::string &value, size_t index) -> bool {
+            bool first_appearance = already_present.insert(value).second;
+            return not first_appearance;
+        };
+        return remove_fields(column, separator, is_value_duplicated);
+    }
 
-            size_t fixed_samples;
-            std::string message;
-            try {
-                using iter = std::vector<std::string>::iterator;
-                fixed_samples = fix_columns(format_column_index, -1, string_line, "\t", [&](iter first, iter last) {
-                    if (error.field == GT) {
-                        fix_format_gt(first, last, error);
-                    } else {
-                        remove_format(first, last, error);
-                    }
-                });
-            } catch (std::out_of_range bad_range) {
-                // there were not enough columns. maybe an aggregate vcf without genotypes?
-                fixed_samples = 0;
-                message = bad_range.what();
+    size_t Fixer::remove_duplicate_key_value_pairs(const std::string &column,
+                                                   const std::string &separator,
+                                                   const std::string &key_value_separator,
+                                                   const std::string &empty_value)
+    {
+        std::map<std::string, std::string> values;
+        std::set<std::string> fields_to_remove;
+
+        std::vector<std::string> fields;
+        util::string_split(column, separator.c_str(), fields);
+
+        for (auto & field : fields) {
+            std::vector<std::string> subfields;
+            util::string_split(field, key_value_separator.c_str(), subfields);
+            auto iterator = values.find(subfields[0]);
+            if (iterator == values.end()) {
+                values[subfields[0]] = subfields[1];
+            } else if (values[subfields[0]] != subfields[1]) {
+                fields_to_remove.insert(subfields[0]);
             }
-
-            if (fixed_samples <= 1) {   // 1 because we started counting since the FORMAT column
-                std::cerr << "WARNING: line " << error.line << ": tried to fix field " << error.field
-                          << " in the samples column, but sample columns are not present. " << message << std::endl;
-                util::writeline(output, *line);
-                ignored_errors++;
-                return;
-            }
         }
 
-        void Fixer::visit(NormalizationError &error)
-        {
-            util::writeline(output, *line);
-            ignored_errors++;
-        }
-
-        void Fixer::visit(DuplicationError &error)
-        {
-            // TODO better log system, if any
-            std::cerr << "DEBUG: line " << line_number << ": fixing duplicate: removing variant: "
-            << std::string{line->begin(), line->end()} << std::endl;
-        }
-
-        size_t Fixer::remove_duplicate_strings(const std::string &column,
-                                               const std::string &separator)
-        {
-            std::set<std::string> already_present;
-            auto is_value_duplicated = [&](const std::string &value, size_t index) -> bool {
-                bool first_appearance = already_present.insert(value).second;
-                return not first_appearance;
-            };
-            return remove_fields(column, separator, is_value_duplicated);
-        }
-
-        size_t Fixer::remove_duplicate_key_value_pairs(const std::string &column,
-                                                       const std::string &separator,
-                                                       const std::string &key_value_separator,
-                                                       const std::string &empty_value)
-        {
-            std::map<std::string, std::string> values;
-            std::set<std::string> fields_to_remove;
-
-            std::vector<std::string> fields;
-            util::string_split(column, separator.c_str(), fields);
-
-            for (auto & field : fields) {
-                std::vector<std::string> subfields;
-                util::string_split(field, key_value_separator.c_str(), subfields);
-                auto iterator = values.find(subfields[0]);
-                if (iterator == values.end()) {
-                    values[subfields[0]] = subfields[1];
-                } else if (values[subfields[0]] != subfields[1]) {
-                    fields_to_remove.insert(subfields[0]);
-                }
-            }
-
-            std::string fixed_column;
-            size_t num_removed_duplicates = 0;
-            for (auto & value : values) {
-                if (fields_to_remove.find(value.first) == fields_to_remove.end()) {
-                    fixed_column += value.first + key_value_separator + value.second + separator;
-                } else {
-                    num_removed_duplicates++;
-                }
-            }
-            if (fixed_column.size() == 0) {       // all the fields were removed
-                fixed_column = empty_value;
+        std::string fixed_column;
+        size_t num_removed_duplicates = 0;
+        for (auto & value : values) {
+            if (fields_to_remove.find(value.first) == fields_to_remove.end()) {
+                fixed_column += value.first + key_value_separator + value.second + separator;
             } else {
-                fixed_column.pop_back();          // remove trailing separator (its length is always 1)
-            }
-
-            output << fixed_column;
-            return num_removed_duplicates;
-        }
-
-        void Fixer::fix_format_gt(std::vector<std::string>::iterator first,
-                           std::vector<std::string>::iterator last,
-                           SamplesFieldBodyError &error)
-        {
-            const std::string field_separator = ":";
-            size_t gt_column_index = 0;
-            // if the field is GT, the values must use "/", as in "./."
-            const std::string subfield_separator = "/";
-            const char empty_subfield = '.';
-
-            // check that GT is present and is the first field
-            size_t subfield_index = split_and_find(*first, field_separator, error.field);
-            if (subfield_index != gt_column_index) {
-                std::cerr << "WARNING: line " << error.line << ": tried to fix field \"" << error.field
-                          << "\" but it was not present in the FORMAT column \"" + *first + "\"" << std::endl;
-                ignored_errors++;
-                util::print_container(output, std::vector<std::string>{first, last}, "", "\t", "");
-                return;
-            }
-
-            // write the FORMAT column
-            output << *first;
-
-            // `cardinality` should be -1 if the cardinality is unknown, and any positive number otherwise
-            // so, if unknown, put 1, so that a single "." is written
-            size_t repeat = error.field_cardinality <= -1 ? 1 : static_cast<size_t>(error.field_cardinality);
-
-            // now `it` will point to each SAMPLE column
-            for (auto it = ++first; it != last; ++it) {
-                output << "\t";
-                fix_column(gt_column_index, *it, field_separator, [&](std::string wrong_subfield) {
-                    util::print_container(output, std::string(repeat, empty_subfield), "", subfield_separator, "");
-                });
+                num_removed_duplicates++;
             }
         }
+        if (fixed_column.size() == 0) {       // all the fields were removed
+            fixed_column = empty_value;
+        } else {
+            fixed_column.pop_back();          // remove trailing separator (its length is always 1)
+        }
 
-        void Fixer::remove_format(std::vector<std::string>::iterator first,
-                           std::vector<std::string>::iterator last,
-                           SamplesFieldBodyError &error)
-        {
-            // remove from FORMAT column
-            const std::string field_separator = ":";
-            size_t field_index;
-            size_t removed = remove_fields(*first, field_separator, [&](const std::string &field, size_t index) {
-                if (field == error.field) {
-                    field_index = index;
-                    return field == error.field;
-                } else {
-                    return false;
-                }
+        output << fixed_column;
+        return num_removed_duplicates;
+    }
+
+    void Fixer::fix_format_gt(std::vector<std::string>::iterator first,
+                              std::vector<std::string>::iterator last,
+                              SamplesFieldBodyError &error)
+    {
+        const std::string field_separator = ":";
+        size_t gt_column_index = 0;
+        // if the field is GT, the values must use "/", as in "./."
+        const std::string subfield_separator = "/";
+        const char empty_subfield = '.';
+
+        // check that GT is present and is the first field
+        size_t subfield_index = split_and_find(*first, field_separator, error.field);
+        if (subfield_index != gt_column_index) {
+            std::cerr << "WARNING: line " << error.line << ": tried to fix field \"" << error.field
+                      << "\" but it was not present in the FORMAT column \"" + *first + "\"" << std::endl;
+            ignored_errors++;
+            util::print_container(output, std::vector<std::string>{first, last}, "", "\t", "");
+            return;
+        }
+
+        // write the FORMAT column
+        output << *first;
+
+        // `cardinality` should be -1 if the cardinality is unknown, and any positive number otherwise
+        // so, if unknown, put 1, so that a single "." is written
+        size_t repeat = error.field_cardinality <= -1 ? 1 : static_cast<size_t>(error.field_cardinality);
+
+        // now `it` will point to each SAMPLE column
+        for (auto it = ++first; it != last; ++it) {
+            output << "\t";
+            fix_column(gt_column_index, *it, field_separator, [&](std::string wrong_subfield) {
+                util::print_container(output, std::string(repeat, empty_subfield), "", subfield_separator, "");
+            });
+        }
+    }
+
+    void Fixer::remove_format(std::vector<std::string>::iterator first,
+                              std::vector<std::string>::iterator last,
+                              SamplesFieldBodyError &error)
+    {
+        // remove from FORMAT column
+        const std::string field_separator = ":";
+        size_t field_index;
+        size_t removed = remove_fields(*first, field_separator, [&](const std::string &field, size_t index) {
+            if (field == error.field) {
+                field_index = index;
+                return field == error.field;
+            } else {
+                return false;
+            }
+        });
+        if (removed == 0) {
+            std::cerr << "WARNING: line " << error.line << ": tried to fix field \"" << error.field
+                      << "\" but it was not present in the FORMAT column \"" + *first + "\"" << std::endl;
+            ignored_errors++;
+            util::print_container(output, std::vector<std::string>{++first, last}, "\t", "\t", "");
+            return;
+        }
+
+        // remove from the samples columns
+        for (++first; first != last; ++first) {
+            output << "\t";
+            removed = remove_fields(*first, field_separator, [&](const std::string &field, size_t index) {
+                return index == field_index;
             });
             if (removed == 0) {
-                std::cerr << "WARNING: line " << error.line << ": tried to fix field \"" << error.field
-                          << "\" but it was not present in the FORMAT column \"" + *first + "\"" << std::endl;
+                std::cerr << "WARNING: tried to remove field with index " << field_index << " in \"" << *first
+                          << "\" but couldn't do it, this is likely to happen in all samples" << std::endl;
                 ignored_errors++;
+                // copy the rest of samples, as we already copied one and don't want to repeat the log for everyone
                 util::print_container(output, std::vector<std::string>{++first, last}, "\t", "\t", "");
                 return;
             }
+        }
+    }
 
-            // remove from the samples columns
-            for (++first; first != last; ++first) {
-                output << "\t";
-                removed = remove_fields(*first, field_separator, [&](const std::string &field, size_t index) {
-                    return index == field_index;
-                });
-                if (removed == 0) {
-                    std::cerr << "WARNING: tried to remove field with index " << field_index << " in \"" << *first
-                              << "\" but couldn't do it, this is likely to happen in all samples" << std::endl;
-                    ignored_errors++;
-                    // copy the rest of samples, as we already copied one and don't want to repeat the log for everyone
-                    util::print_container(output, std::vector<std::string>{++first, last}, "\t", "\t", "");
-                    return;
-                }
+    size_t Fixer::remove_fields(const std::string &line,
+                                const std::string &separators,
+                                std::function<bool(const std::string &column, size_t index)> condition_to_remove)
+    {
+        return remove_fields(line, separators, "", condition_to_remove);
+    }
+
+    size_t Fixer::remove_fields(const std::string &line,
+                                const std::string &separators,
+                                const std::string &empty_column,
+                                std::function<bool(const std::string &column, size_t index)> condition_to_remove)
+    {
+        std::vector<std::string> columns;
+        util::string_split(line, separators.c_str(), columns);
+        size_t written = 0;
+
+        if (columns.size() > 0) {
+            size_t j = 0;
+            if (not condition_to_remove(columns[j], j)) {
+                written++;
+                output << columns[j];
             }
-        }
-
-        size_t Fixer::remove_fields(const std::string &line,
-                             const std::string &separators,
-                             std::function<bool(const std::string &column, size_t index)> condition_to_remove)
-        {
-            return remove_fields(line, separators, "", condition_to_remove);
-        }
-
-        size_t Fixer::remove_fields(const std::string &line,
-                             const std::string &separators,
-                             const std::string &empty_column,
-                             std::function<bool(const std::string &column, size_t index)> condition_to_remove)
-        {
-            std::vector<std::string> columns;
-            util::string_split(line, separators.c_str(), columns);
-            size_t written = 0;
-
-            if (columns.size() > 0) {
-                size_t j = 0;
+            for (j = 1; j < columns.size(); ++j) {
                 if (not condition_to_remove(columns[j], j)) {
+                    if (written > 0) {
+                        output << separators;
+                    }
                     written++;
                     output << columns[j];
                 }
-                for (j = 1; j < columns.size(); ++j) {
-                    if (not condition_to_remove(columns[j], j)) {
-                        if (written > 0) {
-                            output << separators;
-                        }
-                        written++;
-                        output << columns[j];
-                    }
-                }
             }
-            if (written == 0) {
-                output << empty_column;
-            }
-            return columns.size() - written;
         }
-
-        size_t Fixer::replace_fields(const std::string &line,
-                                     const std::string &separators,
-                                     const std::string &expected_field,
-                                     std::function<bool(const std::string &column, size_t index)> condition_to_replace)
-        {
-            std::vector<std::string> columns;
-            util::string_split(line, separators.c_str(), columns);
-            size_t num_replaced_columns = 0;
-
-            for (size_t j = 0; j < columns.size(); ++j) {
-                if (not condition_to_replace(columns[j], j)) {
-                    output << columns[j];
-                } else {
-                    num_replaced_columns++;
-                    output << expected_field;
-                }
-                if (j < columns.size() - 1) {
-                    output << separators;
-                }
-            }
-
-            return num_replaced_columns;
+        if (written == 0) {
+            output << empty_column;
         }
-
-        size_t Fixer::split_and_find(const std::string &line, const std::string &separator, const std::string &value)
-        {
-            std::vector<std::string> columns;
-            util::string_split(line, separator.c_str(), columns);
-            auto found = std::find(columns.begin(), columns.end(), value);
-            return found == columns.end()? line.npos : found - columns.begin();
-        }
-
-        size_t Fixer::fix_column(size_t column_index,
-                        const std::string &line,
-                        const std::string &separator,
-                        std::function<void(std::string &column)> fix_function)
-        {
-            using iter = std::vector<std::string>::iterator;
-            return fix_columns(column_index, column_index + 1, line, separator, [fix_function](iter first, iter last) {
-                for (auto it = first; it != last; ++it) {
-                    fix_function(*it);
-                }
-            });
-        }
-
-        size_t Fixer::fix_foreach_column(size_t column_index,
-                        long column_index_last,
-                        const std::string &line,
-                        const std::string &separator,
-                        std::function<void(std::string &column)> fix_function)
-        {
-            using iter = std::vector<std::string>::iterator;
-            return fix_columns(column_index, column_index_last, line, separator, [fix_function](iter first, iter last) {
-                fix_function(*first);
-            });
-        }
-
-        size_t Fixer::fix_columns(size_t column_index,
-                        long column_index_last,
-                        const std::string &line,
-                        const std::string &separator,
-                        std::function<void(std::vector<std::string>::iterator begin,
-                                           std::vector<std::string>::iterator end)> fix_function)
-        {
-            std::vector<std::string> columns;
-            util::string_split(line, separator.c_str(), columns);
-
-            //remove (and add it later) the newline so that the `fix_function` doesn't have to deal with it.
-            std::string eol = util::remove_end_of_line(columns.back());
-
-            // check ranges. don't allow an empty range, the fix_function should be called at least once
-            size_t column_index_last_unsigned;
-            if (column_index_last < 0) {
-                column_index_last_unsigned = columns.size();
-            } else {
-                column_index_last_unsigned = static_cast<size_t>(column_index_last);
-            }
-
-            if (column_index >= columns.size()) {
-                std::string message{"fix_columns requires a non-empty range: asked to fix columns["};
-                message += std::to_string(column_index) + "] (0-based index) but there are only "
-                        + std::to_string(columns.size()) + " columns: \"" + line + "\"";
-                throw std::out_of_range{message};
-            }
-            if (column_index_last_unsigned > columns.size()) {
-                std::string message{"fix_columns: asked to fix until past-the end, until (non-including) columns["};
-                message += std::to_string(column_index_last_unsigned) + "] (0-based index) but there are only "
-                        + std::to_string(columns.size()) + " columns: \"" + line + "\"";
-                throw std::out_of_range{message};
-            }
-
-            // write before, call fix_function, write after
-            for (size_t i = 0; i < column_index; ++i) {
-                output << columns[i] << separator;
-            }
-
-            fix_function(columns.begin() + column_index, columns.begin() + column_index_last_unsigned);
-
-            for (size_t i = column_index_last_unsigned; i < columns.size(); ++i) {
-                output << separator << columns[i];
-            }
-
-            output << eol;
-
-            return column_index_last_unsigned - column_index;
-        }
+        return columns.size() - written;
     }
+
+    size_t Fixer::replace_fields(const std::string &line,
+                                 const std::string &separators,
+                                 const std::string &expected_field,
+                                 std::function<bool(const std::string &column, size_t index)> condition_to_replace)
+    {
+        std::vector<std::string> columns;
+        util::string_split(line, separators.c_str(), columns);
+        size_t num_replaced_columns = 0;
+
+        for (size_t j = 0; j < columns.size(); ++j) {
+            if (not condition_to_replace(columns[j], j)) {
+                output << columns[j];
+            } else {
+                num_replaced_columns++;
+                output << expected_field;
+            }
+            if (j < columns.size() - 1) {
+                output << separators;
+            }
+        }
+
+        return num_replaced_columns;
+    }
+
+    size_t Fixer::split_and_find(const std::string &line, const std::string &separator, const std::string &value)
+    {
+        std::vector<std::string> columns;
+        util::string_split(line, separator.c_str(), columns);
+        auto found = std::find(columns.begin(), columns.end(), value);
+        return found == columns.end()? line.npos : found - columns.begin();
+    }
+
+    size_t Fixer::fix_column(size_t column_index,
+                             const std::string &line,
+                             const std::string &separator,
+                             std::function<void(std::string &column)> fix_function)
+    {
+        using iter = std::vector<std::string>::iterator;
+        return fix_columns(column_index, column_index + 1, line, separator, [fix_function](iter first, iter last) {
+            for (auto it = first; it != last; ++it) {
+                fix_function(*it);
+            }
+        });
+    }
+
+    size_t Fixer::fix_foreach_column(size_t column_index,
+                                     long column_index_last,
+                                     const std::string &line,
+                                     const std::string &separator,
+                                     std::function<void(std::string &column)> fix_function)
+    {
+        using iter = std::vector<std::string>::iterator;
+        return fix_columns(column_index, column_index_last, line, separator, [fix_function](iter first, iter last) {
+            fix_function(*first);
+        });
+    }
+
+    size_t Fixer::fix_columns(size_t column_index,
+                              long column_index_last,
+                              const std::string &line,
+                              const std::string &separator,
+                              std::function<void(std::vector<std::string>::iterator begin,
+                                                 std::vector<std::string>::iterator end)> fix_function)
+    {
+        std::vector<std::string> columns;
+        util::string_split(line, separator.c_str(), columns);
+
+        //remove (and add it later) the newline so that the `fix_function` doesn't have to deal with it.
+        std::string eol = util::remove_end_of_line(columns.back());
+
+        // check ranges. don't allow an empty range, the fix_function should be called at least once
+        size_t column_index_last_unsigned;
+        if (column_index_last < 0) {
+            column_index_last_unsigned = columns.size();
+        } else {
+            column_index_last_unsigned = static_cast<size_t>(column_index_last);
+        }
+
+        if (column_index >= columns.size()) {
+            std::string message{"fix_columns requires a non-empty range: asked to fix columns["};
+            message += std::to_string(column_index) + "] (0-based index) but there are only "
+                    + std::to_string(columns.size()) + " columns: \"" + line + "\"";
+            throw std::out_of_range{message};
+        }
+        if (column_index_last_unsigned > columns.size()) {
+            std::string message{"fix_columns: asked to fix until past-the end, until (non-including) columns["};
+            message += std::to_string(column_index_last_unsigned) + "] (0-based index) but there are only "
+                    + std::to_string(columns.size()) + " columns: \"" + line + "\"";
+            throw std::out_of_range{message};
+        }
+
+        // write before, call fix_function, write after
+        for (size_t i = 0; i < column_index; ++i) {
+            output << columns[i] << separator;
+        }
+
+        fix_function(columns.begin() + column_index, columns.begin() + column_index_last_unsigned);
+
+        for (size_t i = column_index_last_unsigned; i < columns.size(); ++i) {
+            output << separator << columns[i];
+        }
+
+        output << eol;
+
+        return column_index_last_unsigned - column_index;
+    }
+  }
 }

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -312,7 +312,7 @@ namespace ebi
                     }
                 }
 
-                std::set<std::string> fields_to_remove = get_format_fields_to_remove(format_fields_indexes, first, last);
+                std::set<std::string> fields_to_remove = get_format_fields_to_remove(format_fields_indexes, first + 1, last);
 
                 std::vector<std::string> fixed_format;
                 for (auto & ordered_field : ordered_fields) {
@@ -359,7 +359,7 @@ namespace ebi
         {
             std::set<std::string> fields_to_remove;
 
-            for (auto it = first + 1; it != last; it++) {
+            for (auto it = first; it != last; it++) {
                 std::vector<std::string> sample_fields;
                 util::string_split(*it, ":", sample_fields);
                 for (auto & format_field : format_fields_indexes) {

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -319,7 +319,7 @@ namespace ebi
                     samples.push_back(sample_fields);
                 }
 
-                std::set<std::string> fields_to_remove = get_format_fields_to_remove(format_fields_indexes, first + 1, last, samples);
+                std::set<std::string> fields_to_remove = get_format_fields_to_remove(format_fields_indexes, samples);
 
                 std::vector<std::string> fixed_format;
                 for (auto & ordered_field : ordered_fields) {
@@ -359,8 +359,6 @@ namespace ebi
         }
 
         std::set<std::string> Fixer::get_format_fields_to_remove(std::map<std::string, std::vector<size_t>> &format_fields_indexes,
-                                                                 std::vector<std::string>::iterator first,
-                                                                 std::vector<std::string>::iterator last,
                                                                  std::vector<std::vector<std::string>> &samples)
         {
             std::set<std::string> fields_to_remove;

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -42,24 +42,24 @@ namespace ebi
         ignored_errors++;
     }
 
-        void Fixer::visit(MetaSectionError &error)
-        {
-            if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE) {
-                util::writeline(output, *line);
-                ignored_errors++;
-            } else if (error.error_fix == ErrorFix::RECOVERABLE_VALUE) {
-                std::string string_line = {line->begin(), line->end()};
+    void Fixer::visit(MetaSectionError &error)
+    {
+        if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE) {
+            util::writeline(output, *line);
+            ignored_errors++;
+        } else if (error.error_fix == ErrorFix::RECOVERABLE_VALUE) {
+            std::string string_line = {line->begin(), line->end()};
 
-                // fixing meta header definition of INFO and FORMAT, the error.value is either Type or Number
-                size_t meta_error_field_start_index = string_line.find(error.value + "=");
-                size_t meta_error_field_end_index = string_line.find(",", meta_error_field_start_index);     // exclusive
+            // fixing meta header definition of INFO and FORMAT, the error.value is either Type or Number
+            size_t meta_error_field_start_index = string_line.find(error.value + "=");
+            size_t meta_error_field_end_index = string_line.find(",", meta_error_field_start_index);     // exclusive
 
-                std::cerr << "DEBUG: line " << error.line << ": fixing incorrect predefined tag meta definition " << error.value << std::endl;
+            std::cerr << "DEBUG: line " << error.line << ": fixing incorrect predefined tag meta definition " << error.value << std::endl;
 
-                std::string fixed_meta_header_line = string_line.substr(0, meta_error_field_start_index) + error.value + "=" + error.expected_value + string_line.substr(meta_error_field_end_index);
-                util::writeline(output, fixed_meta_header_line);
-            }
+            std::string fixed_meta_header_line = string_line.substr(0, meta_error_field_start_index) + error.value + "=" + error.expected_value + string_line.substr(meta_error_field_end_index);
+            util::writeline(output, fixed_meta_header_line);
         }
+    }
 
     void Fixer::visit(HeaderSectionError &error)
     {
@@ -107,7 +107,7 @@ namespace ebi
             fix_column(id_column_index, string_line, "\t", [&](std::string &id_column) {
                 remove_duplicate_strings(id_column, ";");
             });
-        } else if (error.field == "") {
+        } else {
             util::writeline(output, *line);
             ignored_errors++;
         }

--- a/src/vcf/fixer.cpp
+++ b/src/vcf/fixer.cpp
@@ -36,17 +36,21 @@ namespace ebi
         return ignored_errors;
     }
 
-    void Fixer::visit(Error &error)
+    void Fixer::ignore_error()
     {
         util::writeline(output, *line);
-        ignored_errors++;
+        ignored_errors++;        
+    }
+
+    void Fixer::visit(Error &error)
+    {
+        ignore_error();
     }
 
     void Fixer::visit(MetaSectionError &error)
     {
         if (error.error_fix == ErrorFix::IRRECOVERABLE_VALUE) {
-            util::writeline(output, *line);
-            ignored_errors++;
+            ignore_error();
         } else if (error.error_fix == ErrorFix::RECOVERABLE_VALUE) {
             std::string string_line = {line->begin(), line->end()};
 
@@ -63,14 +67,12 @@ namespace ebi
 
     void Fixer::visit(HeaderSectionError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(BodySectionError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(NoMetaDefinitionError &error)
@@ -81,20 +83,17 @@ namespace ebi
 
     void Fixer::visit(FileformatError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(ChromosomeBodyError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(PositionBodyError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(IdBodyError &error)
@@ -108,34 +107,29 @@ namespace ebi
                 remove_duplicate_strings(id_column, ";");
             });
         } else {
-            util::writeline(output, *line);
-            ignored_errors++;
+            ignore_error();
         }
     }
 
     void Fixer::visit(ReferenceAlleleBodyError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(AlternateAllelesBodyError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(QualityBodyError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(FilterBodyError &error)
     {
         if (error.field == "" && error.error_fix != ErrorFix::DUPLICATE_VALUES) {
-            util::writeline(output, *line);
-            ignored_errors++;
+            ignore_error();
             return;
         }
 
@@ -189,8 +183,7 @@ namespace ebi
     void Fixer::visit(FormatBodyError &error)
     {
         if (error.error_fix != ErrorFix::DUPLICATE_VALUES) {
-            util::writeline(output, *line);
-            ignored_errors++;
+            ignore_error();
             return;
         }
         
@@ -203,8 +196,7 @@ namespace ebi
 
     void Fixer::visit(SamplesBodyError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(SamplesFieldBodyError &error)
@@ -236,16 +228,14 @@ namespace ebi
         if (fixed_samples <= 1) {   // 1 because we started counting since the FORMAT column
             std::cerr << "WARNING: line " << error.line << ": tried to fix field " << error.field
                       << " in the samples column, but sample columns are not present. " << message << std::endl;
-            util::writeline(output, *line);
-            ignored_errors++;
+            ignore_error();
             return;
         }
     }
 
     void Fixer::visit(NormalizationError &error)
     {
-        util::writeline(output, *line);
-        ignored_errors++;
+        ignore_error();
     }
 
     void Fixer::visit(DuplicationError &error)

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -143,7 +143,7 @@ namespace ebi
             try {
                 check_no_duplicates(ids);
             } catch (const std::invalid_argument &ex) {
-                throw new IdBodyError{line, "ID must not have duplicate values"};
+                throw new IdBodyError{line, "ID must not have duplicate values", ex.what()};
             }
         }
     }
@@ -221,7 +221,7 @@ namespace ebi
             try {
                 check_no_duplicates(filters);
             } catch (const std::invalid_argument &ex) {
-                throw new FilterBodyError{line, "FILTER must not have duplicate filters"};
+                throw new FilterBodyError{line, "FILTER must not have duplicate filters", ex.what()};
             }
         }
     }
@@ -230,7 +230,7 @@ namespace ebi
     {
         for (auto & filter : filters) {
             if (filter == "0") {
-                throw new FilterBodyError{line, "FILTER string must not be 0 (reserved value)"};
+                throw new FilterBodyError{line, "FILTER string must not be 0 (reserved value)", filter};
             }
         }
     }
@@ -288,7 +288,7 @@ namespace ebi
         if (source->version == Version::v43 && info.size() > 1) {
             for (auto & in : info) {
                 if (info.count(in.first) > 1) {
-                    throw new InfoBodyError{line, "INFO must not have duplicate keys"};
+                    throw new InfoBodyError{line, "INFO must not have duplicate keys", in.first};
                 }
             }
         }
@@ -317,7 +317,7 @@ namespace ebi
             try {
                 check_no_duplicates(format);
             } catch (const std::invalid_argument &ex) {
-                throw new FormatBodyError{line, "FORMAT must not have duplicate fields"};
+                throw new FormatBodyError{line, "FORMAT must not have duplicate fields", ex.what()};
             }
         }
     }
@@ -366,7 +366,7 @@ namespace ebi
             if (it != info.end() && it->second == "0") {
                 auto expected = std::to_string(position + reference_allele.length() - 1);
                 if (field_value != expected) {
-                    throw new InfoBodyError{line, "INFO END=" + field_value + " value must be equal to \"POS + length of REF - 1\" for a precise variant (where IMPRECISE is set to 0), expected " + expected, field_key};
+                    throw new InfoBodyError{line, "INFO END=" + field_value + " value must be equal to \"POS + length of REF - 1\" for a precise variant (where IMPRECISE is set to 0), expected " + expected, field_key, expected};
                 }
             }
         } else if (field_key == SVLEN && values.size() == alternate_alleles.size()) {
@@ -374,17 +374,17 @@ namespace ebi
                 if (check_alt_not_symbolic(i)) {
                     std::string expected = std::to_string(alternate_alleles[i].size() - reference_allele.size());
                     if (values[i] != expected) {
-                        throw new InfoBodyError{line, "INFO SVLEN=" + field_value + " must be equal to \"length of ALT - length of REF\" for non-symbolic alternate alleles (expected " + expected + ", found " + values[i] + ")"};
+                        throw new InfoBodyError{line, "INFO SVLEN=" + field_value + " must be equal to \"length of ALT - length of REF\" for non-symbolic alternate alleles (expected " + expected + ", found " + values[i] + ")", field_key, expected};
                     }
                 } else {
                     std::string first_field = alternate_alleles[i].substr(0, 4);
                     if (first_field == "<" + INS || first_field == "<" + DUP) {
                         if (std::stoi(values[i]) < 0) {
-                            throw new InfoBodyError{line, "SVLEN=" + field_value + " must be a positive integer for longer ALT alleles like " + first_field.substr(1,3)};
+                            throw new InfoBodyError{line, "SVLEN=" + field_value + " must be a positive integer for longer ALT alleles like " + first_field.substr(1,3), field_key};
                         }
                     } else if (first_field == "<" + DEL) {
                         if (std::stoi(values[i]) > 0) {
-                            throw new InfoBodyError{line, "SVLEN=" + field_value + " must be a negative integer for shorter ALT alleles like " + first_field.substr(1,3)};
+                            throw new InfoBodyError{line, "SVLEN=" + field_value + " must be a negative integer for shorter ALT alleles like " + first_field.substr(1,3), field_key};
                         }
                     }
                 }
@@ -573,7 +573,7 @@ namespace ebi
             for (auto & value : values) {
                 counter[value]++;
                 if (counter[value] >= 2) {
-                    throw std::invalid_argument("Duplicates not allowed");
+                    throw std::invalid_argument(value);
                 }
             }
         }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -317,7 +317,7 @@ namespace ebi
             try {
                 check_no_duplicates(format);
             } catch (const std::invalid_argument &ex) {
-                throw new FormatBodyError{line, "FORMAT must not have duplicate fields"};
+                throw new FormatBodyError{line, "FORMAT must not have duplicate fields", ErrorFix::DUPLICATE_VALUES};
             }
         }
     }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -372,7 +372,7 @@ namespace ebi
         } else if (field_key == SVLEN && values.size() == alternate_alleles.size()) {
             for (size_t i = 0; i < alternate_alleles.size(); i++) {
                 if (check_alt_not_symbolic(i)) {
-                    std::string expected = std::to_string(alternate_alleles[i].size() - reference_allele.size());
+                    std::string expected = std::to_string(static_cast<long>(alternate_alleles[i].size()) - static_cast<long>(reference_allele.size()));
                     if (values[i] != expected) {
                         throw new InfoBodyError{line, "INFO SVLEN=" + field_value + " must be equal to \"length of ALT - length of REF\" for non-symbolic alternate alleles (expected " + expected + ", found " + values[i] + ")", field_key, expected};
                     }

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -569,12 +569,9 @@ namespace ebi
     void Record::check_no_duplicates(std::vector<std::string> const & values) const
     {
         if (values.size() > 1) {
-            std::map<std::string, int> counter;
-            for (auto & value : values) {
-                counter[value]++;
-                if (counter[value] >= 2) {
-                    throw std::invalid_argument(value);
-                }
+            std::set<std::string> counter(values.begin(), values.end());
+            if (values.size() > counter.size()) {
+                throw std::invalid_argument("Duplicate fields");
             }
         }
     }

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -314,23 +314,6 @@ namespace ebi
           util::string_split(output.str(), "\t", columns);
           CHECK(columns[8] == "GT:GH");
       }
-      SECTION("Fix FORMAT duplicate field with 1 sample, different values for all")
-      {
-          size_t line_number = 8;
-          std::string message{"error message mock: Duplicate format fields"};
-          ebi::vcf::FormatBodyError test_error{line_number, message, ebi::vcf::ErrorFix::DUPLICATE_VALUES};
-
-          std::string string_line = "chr\tpos\tid\tref\talt\tqual\tfilter\tinfo\tGT:GH:GT:GH\t1:2:3:4";
-          std::vector<char> line{string_line.begin(), string_line.end()};
-
-          std::stringstream output;
-          vcf::Fixer{output}.fix(line_number, line, test_error);
-
-          std::vector<std::string> columns;
-          util::string_split(output.str(), "\t", columns);
-          CHECK(columns[8] == ebi::vcf::MISSING_VALUE);
-          CHECK(columns[9] == ebi::vcf::MISSING_VALUE);
-      }
       SECTION("Fix FORMAT duplicate fields with 1 sample, same values for some")
       {
           size_t line_number = 8;
@@ -405,7 +388,7 @@ namespace ebi
           std::string message{"error message mock: Duplicate format fields"};
           ebi::vcf::FormatBodyError test_error{line_number, message, ebi::vcf::ErrorFix::DUPLICATE_VALUES};
 
-          std::string string_line = "chr\tpos\tid\tref\talt\tqual\tfilter\tinfo\tGT:GT\t1:1\t3:4";
+          std::string string_line = "chr\tpos\tid\tref\talt\tqual\tfilter\tinfo\tGT:GT:GP\t1:1\t3:4";
           std::vector<char> line{string_line.begin(), string_line.end()};
 
           std::stringstream output;
@@ -413,7 +396,7 @@ namespace ebi
 
           std::vector<std::string> columns;
           util::string_split(output.str(), "\t", columns);
-          CHECK(columns[8] == ebi::vcf::MISSING_VALUE);
+          CHECK(columns[8] == "GP");
           CHECK(columns[9] == ebi::vcf::MISSING_VALUE);
           CHECK(columns[10] == ebi::vcf::MISSING_VALUE);
       }

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -314,6 +314,18 @@ namespace ebi
           util::string_split(output.str(), "\t", columns);
           CHECK(columns[8] == "GT:GH");
       }
+      SECTION("Fix FORMAT duplicate field, throw exception if format column gets empty (because of different values)")
+      {
+          size_t line_number = 8;
+          std::string message{"error message mock: Duplicate format fields"};
+          ebi::vcf::FormatBodyError test_error{line_number, message, ebi::vcf::ErrorFix::DUPLICATE_VALUES};
+
+          std::string string_line = "chr\tpos\tid\tref\talt\tqual\tfilter\tinfo\tGT:GH:GT:GH\t1:2:3:4";
+          std::vector<char> line{string_line.begin(), string_line.end()};
+
+          std::stringstream output;
+          CHECK_THROWS_AS(vcf::Fixer{output}.fix(line_number, line, test_error), std::runtime_error);
+      }
       SECTION("Fix FORMAT duplicate fields with 1 sample, same values for some")
       {
           size_t line_number = 8;

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -124,7 +124,7 @@ namespace ebi
 
           std::vector<std::string> columns;
           util::string_split(output.str(), "\t", columns);
-          CHECK(columns[6] == ".");
+          CHECK(columns[6] == ebi::vcf::MISSING_VALUE);
       }
       SECTION("Fix FILTER duplicates")
       {
@@ -193,7 +193,7 @@ namespace ebi
 
           std::vector<std::string> columns;
           util::string_split(output.str(), "\t", columns);
-          CHECK(columns[7] == ".");
+          CHECK(columns[7] == ebi::vcf::MISSING_VALUE);
       }
       SECTION("Fix INFO duplicate key with varying values")
       {
@@ -245,7 +245,7 @@ namespace ebi
 
           std::vector<std::string> columns;
           util::string_split(output.str(), "\t", columns);
-          CHECK(columns[7] == ".");
+          CHECK(columns[7] == ebi::vcf::MISSING_VALUE);
       }
       SECTION("Fix INFO SVLEN for non-symbolic alternate alleles")
       {

--- a/test/vcf/debugulator_test.cpp
+++ b/test/vcf/debugulator_test.cpp
@@ -230,6 +230,7 @@ namespace ebi
           util::string_split(columns[7], ";", info_fields);
           CHECK(info_fields.size() == 2);
           CHECK(info_fields[0] == "dupkey=x");
+          CHECK(info_fields[1] == "info=y");
       }
       SECTION("Fix INFO with duplicates of unique key")
       {

--- a/test/vcf/predefined_info_tags_test.cpp
+++ b/test/vcf/predefined_info_tags_test.cpp
@@ -740,6 +740,35 @@ namespace ebi
                             source}),
                         vcf::InfoBodyError*);
 
+            CHECK_NOTHROW( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "ACTGNGCN",
+                            { "ATC" },
+                            1.0,
+                            { "PASS" },
+                            { {"SVLEN", "-5"} },
+                            { "GT" },
+                            { "0|1" },
+                            source} ) );
+
+            CHECK_THROWS_AS( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "ACTGNGCN",
+                            { "ATC" },
+                            1.0,
+                            { "PASS" },
+                            { {"SVLEN", "-4"} },
+                            { "GT" },
+                            { "0|1" },
+                            source}),
+                        vcf::InfoBodyError*);
+
             CHECK_THROWS_AS( (vcf::Record{
                             1,
                             "chr1",

--- a/test/vcf/predefined_info_tags_test.cpp
+++ b/test/vcf/predefined_info_tags_test.cpp
@@ -748,9 +748,9 @@ namespace ebi
                             "ACTGNGCN",
                             { "ATC" },
                             1.0,
-                            { "PASS" },
-                            { {"SVLEN", "-5"} },
-                            { "GT" },
+                            { vcf::PASS },
+                            { {vcf::SVLEN, "-5"} },
+                            { vcf::GT },
                             { "0|1" },
                             source} ) );
 
@@ -762,9 +762,9 @@ namespace ebi
                             "ACTGNGCN",
                             { "ATC" },
                             1.0,
-                            { "PASS" },
-                            { {"SVLEN", "-4"} },
-                            { "GT" },
+                            { vcf::PASS },
+                            { {vcf::SVLEN, "-4"} },
+                            { vcf::GT },
                             { "0|1" },
                             source}),
                         vcf::InfoBodyError*);

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -410,6 +410,154 @@ namespace ebi
 //                                source}),
 //                            vcf::SamplesFieldBodyError*);
         }
+
+        SECTION("Duplicate IDs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123", "id123" },
+                                "A",
+                                { "AC", "AT" },
+                                1.0,
+                                { vcf::PASS },
+                                { {vcf::AN, "12"}, {vcf::AF, "0.5,0.3"} },
+                                { vcf::GT, vcf::DP },
+                                { "0|1" },
+                                source}) );
+        }
+
+        SECTION("Duplicate FILTERs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123" },
+                                "A",
+                                { "AC" },
+                                1.0,
+                                { "q10", "q10" },
+                                { {vcf::AN, "12"} },
+                                { vcf::GT },
+                                { "0|1" },
+                                source}) );
+        }
+
+        SECTION("Duplicate INFOs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123", "id456" },
+                                "A",
+                                { "T", "C" },
+                                1.0,
+                                { vcf::PASS },
+                                { {vcf::AN, "12"}, {vcf::AN, "15"} },
+                                { vcf::DP },
+                                { "12" },
+                                source}) );
+        }
+
+        SECTION("Duplicate FORMATs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123", "id456" },
+                                "A",
+                                { "T", "C" },
+                                1.0,
+                                { vcf::PASS },
+                                { {vcf::AN, "12"}, {vcf::AF, "0.5,0.3"} },
+                                { vcf::DP, vcf::DP },
+                                { "12:13" },
+                                source}) );
+        }
+    }
+
+    TEST_CASE("Record constructor v42", "[constructor]")
+    {
+        std::shared_ptr<vcf::Source> source{
+            new vcf::Source{
+                "Example VCF source",
+                vcf::InputFormat::VCF_FILE_VCF | vcf::InputFormat::VCF_FILE_BGZIP,
+                vcf::Version::v42,
+                vcf::Ploidy{2, {{"Y", 1}}},
+                {},
+                { "Sample1" }}};
+
+        SECTION("Duplicate IDs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123", "id123" },
+                                "A",
+                                { "AC", "AT" },
+                                1.0,
+                                { vcf::PASS },
+                                { {vcf::AN, "12"}, {vcf::AF, "0.5,0.3"} },
+                                { vcf::GT, vcf::DP },
+                                { "0|1" },
+                                source}) );
+        }
+
+        SECTION("Duplicate FILTERs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123" },
+                                "A",
+                                { "AC" },
+                                1.0,
+                                { "q10", "q10" },
+                                { {vcf::AN, "12"} },
+                                { vcf::GT },
+                                { "0|1" },
+                                source}) );
+        }
+
+        SECTION("Duplicate INFOs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123", "id456" },
+                                "A",
+                                { "T", "C" },
+                                1.0,
+                                { vcf::PASS },
+                                { {vcf::AN, "12"}, {vcf::AN, "15"} },
+                                { vcf::DP },
+                                { "12" },
+                                source}) );
+        }
+
+        SECTION("Duplicate FORMATs")
+        {
+            CHECK_NOTHROW( (vcf::Record{
+                                1,
+                                "chr1",
+                                123456,
+                                { "id123", "id456" },
+                                "A",
+                                { "T", "C" },
+                                1.0,
+                                { vcf::PASS },
+                                { {vcf::AN, "12"}, {vcf::AF, "0.5,0.3"} },
+                                { vcf::DP, vcf::DP },
+                                { "12:13" },
+                                source}) );
+        }
     }
 
     TEST_CASE("Record constructor v43", "[constructor]")


### PR DESCRIPTION
The fixes added are :

- #### Fix SVLEN value for non-symbolic ALTs
If the alternate allele in the variant is not symbolic, & SVLEN is integral but not equal to `len(ALT) - len(REF)`, set it to this value.

- #### Fix END value for precise variants
If a variant is flagged as precise (using IMPRECISE=0), & END is an integer nut not equal to `POS + len(REF) - 1`, set it to this value.

- #### Removal of duplicates in ID
The fix is to keep the first duplicated ID, and remove all consequent ones.

- #### Removal of duplicates or `0`'s in FILTER
The fix is to remove all 0's (if present) and keep the first duplicate filter, & remove the consequent ones.

- #### Removal of duplicates in INFO
The fix here is :
i) remove all the duplicate fields, if there are different values for the same key (we cannot give preference to any particular field)
ii) keep first and remove all consequent occurrences of a field if for the key, all the duplicate fields have the same value

- #### Removal of duplicates in FORMAT
The fix is: 
i) remove all duplicate fields from the format and sample(s) columns, if there are different values in one or more of the samples
ii) keep first and remove all consequent occurrences of a field from format and sample(s) if each sample has the same value for that field