### PR TITLE
Simplify build for OS X users (docker based)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+.dockerignore
+.travis.yml
+build
+docker*
+README.md
+LICENSE*
+install_dependencies.sh

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ vcf_debugulator -i /path/to/file.vcf -e /path/to/write/report/vcf.errors.timesta
 
 The easiest way to build vcf-validator is using the Docker image provided with the source code. This will create an executable that can be run in any Linux machine.
 
-**Note:** If you are a Windows/OS-X user, you may follow a different set of steps for building a static docker based binary. Head over to section [Alternative way to build (for Windows and Mac OS-X)](https://github.com/Anishka0107/vcf-validator/tree/docker_extend#alternative-way-to-build-for-windows-and-mac-os-x).
+**Note:** If you are a Windows/OS-X user, you may follow a different set of steps for building a static docker based binary. After completing steps 1, 2.1 and 2.2 given below, head over to section [Alternative way to build (for Windows and Mac OS-X)](https://github.com/Anishka0107/vcf-validator/tree/docker_extend#alternative-way-to-build-for-windows-and-mac-os-x).
 
 1. Install and configure Docker following [their tutorial](https://docs.docker.com/engine/getstarted/).
 2. Create the Docker image:
@@ -142,16 +142,20 @@ mv inc/vcf/error-odb.cpp src/vcf/error-odb.cpp
 
 Build the image: `docker build -t ebivariation/vcf-validator -f docker/Dockerfile.prod .`
 
-For every file you provide (vcf or database or any other external file), you have to prepend to it `\tmp\`, so that docker may mount it properly.
+To run the validator inside the image, append the validator command to `docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator`
 
 Validator example:
-`docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i /tmp/path/to/file.vcf`
+`docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i path/to/file.vcf`
+
+For the debugulator, append the debugulator command to `docker run -v ${PWD}:/tmp -t ebivaraition/vcf-validator`. If you wish to generate the debugulator log file, use `1>` or `&>` for redirecting stdout (instead of redirecting stderr to the log file using `2>`).
 
 Debugulator example:
 ```
-docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i /tmp/path/to/file.vcf -r database -o /tmp/path/to/write/report
-docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_debugulator -i /tmp/path/to/file.vcf -e /tmp/path/to/write/report/vcf.errors.timestamp.db -o /tmp/path/to/fixed.vcf
+docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i path/to/file.vcf -r database -o path/to/write/report
+docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_debugulator -i path/to/file.vcf -e path/to/write/report/vcf.errors.timestamp.db -o path/to/fixed.vcf 1>debugulator_log.txt
 ```
 
+For running tests on the validator and debugulator, append the command to `docker run -w /home/vcf-validator -t ebivariation/vcf-validator`
+
 Test suite example:
-`docker run -t ebivariation/vcf-validator test_validator`
+`docker run -w /home/vcf-validator -t ebivariation/vcf-validator test_validator`

--- a/README.md
+++ b/README.md
@@ -142,20 +142,17 @@ mv inc/vcf/error-odb.cpp src/vcf/error-odb.cpp
 
 Build the image: `docker build -t ebivariation/vcf-validator -f docker/Dockerfile.prod .`
 
-To run the validator inside the image, append the validator command to `docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator`
-
+To run the validator inside the image, append the validator command to `docker run -v ${PWD}:/tmp ebivariation/vcf-validator`.  
 Validator example:
-`docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i path/to/file.vcf`
+`docker run -v ${PWD}:/tmp ebivariation/vcf-validator vcf_validator -i path/to/file.vcf`
 
-For the debugulator, append the debugulator command to `docker run -v ${PWD}:/tmp -t ebivaraition/vcf-validator`. If you wish to generate the debugulator log file, use `1>` or `&>` for redirecting stdout (instead of redirecting stderr to the log file using `2>`).
-
+For the debugulator, append the debugulator command to `docker run -v ${PWD}:/tmp ebivaraition/vcf-validator`. If you wish to generate the debugulator log file, use `1>` or `&>` for redirecting stdout (instead of redirecting stderr to the log file using `2>`).  
 Debugulator example:
 ```
-docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i path/to/file.vcf -r database -o path/to/write/report
-docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_debugulator -i path/to/file.vcf -e path/to/write/report/vcf.errors.timestamp.db -o path/to/fixed.vcf 1>debugulator_log.txt
+docker run -v ${PWD}:/tmp ebivariation/vcf-validator vcf_validator -i path/to/file.vcf -r database -o path/to/write/report
+docker run -v ${PWD}:/tmp ebivariation/vcf-validator vcf_debugulator -i path/to/file.vcf -e path/to/write/report/vcf.errors.timestamp.db -o path/to/fixed.vcf 1>debugulator_log.txt
 ```
 
-For running tests on the validator and debugulator, append the command to `docker run -w /home/vcf-validator -t ebivariation/vcf-validator`
-
+For running tests on the validator and debugulator, append the command to `docker run -w /home/vcf-validator ebivariation/vcf-validator`.  
 Test suite example:
-`docker run -w /home/vcf-validator -t ebivariation/vcf-validator test_validator`
+`docker run -w /home/vcf-validator ebivariation/vcf-validator test_validator`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ vcf_debugulator -i /path/to/file.vcf -e /path/to/write/report/vcf.errors.timesta
 
 The easiest way to build vcf-validator is using the Docker image provided with the source code. This will create an executable that can be run in any Linux machine.
 
+**Note:** If you are a Windows/OS-X user, you may follow a different set of steps for building a static docker based binary. Head over to section [Alternative way to build (for Windows and Mac OS-X)](https://github.com/Anishka0107/vcf-validator/tree/docker_extend#alternative-way-to-build-for-windows-and-mac-os-x).
+
 1. Install and configure Docker following [their tutorial](https://docs.docker.com/engine/getstarted/).
 2. Create the Docker image:
     1. Clone this Git repository: `git clone https://github.com/EBIvariation/vcf-validator.git`
@@ -135,3 +137,21 @@ And the full ODB-based code from the classes definitions using:
 odb --include-prefix vcf --std c++11 -d sqlite --generate-query --generate-schema --hxx-suffix .hpp --ixx-suffix .ipp --cxx-suffix .cpp --output-dir inc/vcf/ inc/vcf/error.hpp
 mv inc/vcf/error-odb.cpp src/vcf/error-odb.cpp
 ```
+
+## Alternative way to build (for Windows and Mac OS-X)
+
+Build the image: `docker build -t ebivariation/vcf-validator -f docker/Dockerfile.prod .`
+
+For every file you provide (vcf or database or any other external file), you have to prepend to it `\tmp\`, so that docker may mount it properly.
+
+Validator example:
+`docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i /tmp/path/to/file.vcf`
+
+Debugulator example:
+```
+docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_validator -i /tmp/path/to/file.vcf -r database -o /tmp/path/to/write/report
+docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_debugulator -i /tmp/path/to/file.vcf -e /tmp/path/to/write/report/vcf.errors.timestamp.db -o /tmp/path/to/fixed.vcf
+```
+
+Test suite example:
+`docker run -w /home/vcf-validator -t ebivariation/vcf-validator test_validator`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ vcf_debugulator -i /path/to/file.vcf -e /path/to/write/report/vcf.errors.timesta
 
 The easiest way to build vcf-validator is using the Docker image provided with the source code. This will create an executable that can be run in any Linux machine.
 
-**Note:** If you are a Windows/OS-X user, you may follow a different set of steps for building a static docker based binary. After completing steps 1, 2.1 and 2.2 given below, head over to section [Alternative way to build (for Windows and Mac OS-X)](https://github.com/Anishka0107/vcf-validator/tree/docker_extend#alternative-way-to-build-for-windows-and-mac-os-x).
+**Note:** If you are an OS-X user, you may follow a different set of steps for building a static docker based binary. After completing steps 1, 2.1 and 2.2 given below, head over to section [Alternative way to build (for Mac OS-X)](https://github.com/Anishka0107/vcf-validator/tree/docker_extend#alternative-way-to-build-for-mac-os-x).
 
 1. Install and configure Docker following [their tutorial](https://docs.docker.com/engine/getstarted/).
 2. Create the Docker image:
@@ -138,9 +138,9 @@ odb --include-prefix vcf --std c++11 -d sqlite --generate-query --generate-schem
 mv inc/vcf/error-odb.cpp src/vcf/error-odb.cpp
 ```
 
-## Alternative way to build (for Windows and Mac OS-X)
+## Alternative way to build (for Mac OS-X)
 
-Build the image: `docker build -t ebivariation/vcf-validator -f docker/Dockerfile.prod .`
+Build the image: `docker build -t ebivariation/vcf-validator docker_mac`
 
 To run the validator inside the image, append the validator command to `docker run -v ${PWD}:/tmp ebivariation/vcf-validator`.  
 Validator example:

--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ docker run -v ${PWD}:/tmp -t ebivariation/vcf-validator vcf_debugulator -i /tmp/
 ```
 
 Test suite example:
-`docker run -w /home/vcf-validator -t ebivariation/vcf-validator test_validator`
+`docker run -t ebivariation/vcf-validator test_validator`

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,0 +1,44 @@
+FROM ubuntu:xenial
+
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
+build-essential \
+cmake \
+libboost-dev \
+libboost-filesystem-dev \
+libboost-program-options-dev \
+libboost-regex-dev \
+libsqlite3-dev \
+ragel \
+wget
+
+# Ubuntu-native ODB packages don't seem to work due to a broken ABI, see this thread: http://codesynthesis.com/pipermail/odb-users/2016-May/003277.html
+RUN wget http://www.codesynthesis.com/download/odb/2.4/odb_2.4.0-1_amd64.deb -O /opt/odb_2.4.0-1_amd64.deb
+RUN wget http://codesynthesis.com/download/odb/2.4/libodb-2.4.0.tar.bz2 -O /opt/libodb.tar.bz2
+RUN wget http://codesynthesis.com/download/odb/2.4/libodb-sqlite-2.4.0.tar.bz2 -O /opt/libodb-sqlite.tar.bz2
+
+# ODB compiler
+RUN cd /opt && tar jxvf libodb.tar.bz2 && tar jxvf libodb-sqlite.tar.bz2 && dpkg -i odb_2.4.0-1_amd64.deb
+RUN cd /opt/libodb-2.4.0 && ./configure && make && make install
+RUN cd /opt/libodb-sqlite-2.4.0 && ./configure --with-libodb=../libodb-2.4.0 && make && make install
+
+RUN NPROCS=`grep processor </proc/cpuinfo | wc -l`
+
+# Copy present working directory to home directory of docker image
+COPY ${PWD} /home/vcf-validator/
+
+# Generate last version of parser sources from Ragel descriptors
+RUN cd /home/vcf-validator && for i in 1 2 3 ; do ragel -G2 -o inc/vcf/validator_detail_v4${i}.hpp src/vcf/vcf_v4${i}.ragel ; done
+
+# Create build directory
+RUN mkdir -p /tmp/build
+
+# Build a static binary
+RUN cd /tmp/build && cmake -DBUILD_STATIC=1 /home/vcf-validator
+RUN cd /tmp/build && make -j${NPROCS}
+
+# Copy the binaries to project folder
+RUN cp -r /tmp/build /home/vcf-validator/build
+RUN rm -r /tmp/build
+
+# COPY ./docker/entrypoint_prod.sh /
+# CMD ["entrypoint_prod.sh"]

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -23,18 +23,21 @@ RUN cd /opt/libodb-sqlite-2.4.0 && ./configure --with-libodb=../libodb-2.4.0 && 
 
 RUN NPROCS=`grep processor </proc/cpuinfo | wc -l`
 
+# Set working directory for docker
+WORKDIR /home/vcf-validator
+
 # Copy present working directory to home directory of docker image
-COPY ${PWD} /home/vcf-validator
+COPY ${PWD} .
 
 # Generate last version of parser sources from Ragel descriptors
-RUN cd /home/vcf-validator && for i in 1 2 3 ; do ragel -G2 -o inc/vcf/validator_detail_v4${i}.hpp src/vcf/vcf_v4${i}.ragel ; done
+RUN for i in 1 2 3 ; do ragel -G2 -o inc/vcf/validator_detail_v4${i}.hpp src/vcf/vcf_v4${i}.ragel ; done
 
 # Create build directory
-RUN mkdir -p /home/vcf-validator/build
+RUN mkdir -p build
 
 # Build a static binary
-RUN cd /home/vcf-validator/build && cmake -DBUILD_STATIC=1 /home/vcf-validator
-RUN cd /home/vcf-validator/build && make -j${NPROCS}
+RUN cd build && cmake -DBUILD_STATIC=1 ..
+RUN cd build && make -j${NPROCS}
 
 # Set environment variable PATH to include executables
 ENV PATH $PATH:/home/vcf-validator/build/bin

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -26,7 +26,7 @@ RUN NPROCS=`grep processor </proc/cpuinfo | wc -l`
 # Set working directory for docker
 WORKDIR /home/vcf-validator
 
-# Copy present working directory to home directory of docker image
+# Copy project directory to container
 COPY ${PWD} .
 
 # Generate last version of parser sources from Ragel descriptors
@@ -42,5 +42,7 @@ RUN cd build && make -j${NPROCS}
 # Set environment variable PATH to include executables
 ENV PATH $PATH:/home/vcf-validator/build/bin
 
-# COPY ./docker/entrypoint_prod.sh /
-# CMD ["entrypoint_prod.sh"]
+# Set working directory to /tmp, for files outside the container
+WORKDIR /tmp
+
+# CMD ["/home/vcf_validator/docker/entrypoint_prod.sh"]

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -24,21 +24,20 @@ RUN cd /opt/libodb-sqlite-2.4.0 && ./configure --with-libodb=../libodb-2.4.0 && 
 RUN NPROCS=`grep processor </proc/cpuinfo | wc -l`
 
 # Copy present working directory to home directory of docker image
-COPY ${PWD} /home/vcf-validator/
+COPY ${PWD} /home/vcf-validator
 
 # Generate last version of parser sources from Ragel descriptors
 RUN cd /home/vcf-validator && for i in 1 2 3 ; do ragel -G2 -o inc/vcf/validator_detail_v4${i}.hpp src/vcf/vcf_v4${i}.ragel ; done
 
 # Create build directory
-RUN mkdir -p /tmp/build
+RUN mkdir -p /home/vcf-validator/build
 
 # Build a static binary
-RUN cd /tmp/build && cmake -DBUILD_STATIC=1 /home/vcf-validator
-RUN cd /tmp/build && make -j${NPROCS}
+RUN cd /home/vcf-validator/build && cmake -DBUILD_STATIC=1 /home/vcf-validator
+RUN cd /home/vcf-validator/build && make -j${NPROCS}
 
-# Copy the binaries to project folder
-RUN cp -r /tmp/build /home/vcf-validator/build
-RUN rm -r /tmp/build
+# Set environment variable PATH to include executables
+ENV PATH $PATH:/home/vcf-validator/build/bin
 
 # COPY ./docker/entrypoint_prod.sh /
 # CMD ["entrypoint_prod.sh"]

--- a/docker_mac/Dockerfile
+++ b/docker_mac/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /home/vcf-validator
 COPY ${PWD} .
 
 # Generate last version of parser sources from Ragel descriptors
-RUN for i in 1 2 3 ; do ragel -G2 -o inc/vcf/validator_detail_v4${i}.hpp src/vcf/vcf_v4${i}.ragel ; done
+RUN for i in 1 2 3 ; do ragel -G2 -o /home/vcf-validator/inc/vcf/validator_detail_v4${i}.hpp /home/vcf-validator/src/vcf/vcf_v4${i}.ragel ; done
 
 # Create build directory
 RUN mkdir -p build
@@ -45,4 +45,4 @@ ENV PATH $PATH:/home/vcf-validator/build/bin
 # Set working directory to /tmp, for files outside the container
 WORKDIR /tmp
 
-# CMD ["/home/vcf_validator/docker/entrypoint_prod.sh"]
+# CMD ["/home/vcf_validator/docker_mac/entrypoint.sh"]


### PR DESCRIPTION
This PR aims to simplify the build for Mac (not supported as containerized os yet) users by providing a new Dockerfile which runs the tool inside of it. It is not convenient for developers though.

TODO: windows developers/users could use Docker Toolbox to get rid of the restriction of disabling virtualbox. (Fully supports docker, hence write new dockerfile with win base image)