### PR TITLE
wget not requiring valid certificates for ODB

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,9 +18,9 @@ ragel \
 # apt-get update needed again, as it was removed before
 RUN apt-get update && apt-get install -y --no-install-recommends wget bzip2 \
 # Built-in ODB packages don't seem to work due to a broken ABI, see this thread: http://codesynthesis.com/pipermail/odb-users/2016-May/003277.html
-&& wget http://www.codesynthesis.com/download/odb/2.4/odb_2.4.0-1_amd64.deb -O /opt/odb_2.4.0-1_amd64.deb \
-&& wget http://codesynthesis.com/download/odb/2.4/libodb-2.4.0.tar.bz2 -O /opt/libodb.tar.bz2 \
-&& wget http://codesynthesis.com/download/odb/2.4/libodb-sqlite-2.4.0.tar.bz2 -O /opt/libodb-sqlite.tar.bz2 \
+&& wget --no-check-certificate https://www.codesynthesis.com/download/odb/2.4/odb_2.4.0-1_amd64.deb -O /opt/odb_2.4.0-1_amd64.deb \
+&& wget --no-check-certificate https://codesynthesis.com/download/odb/2.4/libodb-2.4.0.tar.bz2 -O /opt/libodb.tar.bz2 \
+&& wget --no-check-certificate https://codesynthesis.com/download/odb/2.4/libodb-sqlite-2.4.0.tar.bz2 -O /opt/libodb-sqlite.tar.bz2 \
 # Build ODB dependencies
 && cd /opt && tar jxvf libodb.tar.bz2 && tar jxvf libodb-sqlite.tar.bz2 && dpkg -i odb_2.4.0-1_amd64.deb \
 && cd libodb-2.4.0 && ./configure && make && make install && cd .. \


### PR DESCRIPTION
The Docker build has started failing recently because ODB moved to HTTPS but the certificates are not valid. The only way to work around this is to add a flag `no-check-certificates` when retrieving the packages from their server.