### PR TITLE
Fields PL and GL now depend on the ploidy of GT

### DIFF
--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -167,7 +167,7 @@ namespace ebi
             { DP, { INTEGER, "1" } },
             { EC, { INTEGER, A } },
             { FT, { STRING, "1" } },
-            { GL, { FLOAT, G } },
+            { GL, { FLOAT, UNKNOWN_CARDINALITY } },
             { GLE, { STRING, G } },
             { GP, { FLOAT, G } },
             { GQ, { INTEGER, "1" } },
@@ -176,7 +176,7 @@ namespace ebi
             { HQ, { INTEGER, "2" } },
             { MQ, { INTEGER, "1" } },
             { NQ, { INTEGER, "1" } },
-            { PL, { INTEGER, G } },
+            { PL, { INTEGER, UNKNOWN_CARDINALITY } },
             { PQ, { INTEGER, "1" } },
             { PS, { INTEGER, "1" } }
     };
@@ -193,7 +193,7 @@ namespace ebi
             { DP, { INTEGER, "1" } },
             { EC, { INTEGER, A } },
             { FT, { STRING, "1" } },
-            { GL, { FLOAT, G } },
+            { GL, { FLOAT, UNKNOWN_CARDINALITY } },
             { GP, { FLOAT, G } },
             { GQ, { INTEGER, "1" } },
             { GT, { STRING, "1" } },
@@ -201,7 +201,7 @@ namespace ebi
             { HQ, { INTEGER, "2" } },
             { MQ, { INTEGER, "1" } },
             { NQ, { INTEGER, "1" } },
-            { PL, { INTEGER, G } },
+            { PL, { INTEGER, UNKNOWN_CARDINALITY } },
             { PQ, { INTEGER, "1" } },
             { PS, { INTEGER, "1" } }
     };
@@ -480,6 +480,11 @@ namespace ebi
          * Returns a vector of MetaEntry objects in the same order as they are displayed in the samples
          */
         std::vector<MetaEntry> get_meta_entry_objects() const;
+
+        /**
+         * Returns the ploidy of GT
+         */
+        long get_ploidy_from_GT(std::string const & sample) const;
 
         /**
          * Checks the sample contents and accordance to the meta section

--- a/inc/vcf/file_structure.hpp
+++ b/inc/vcf/file_structure.hpp
@@ -167,7 +167,7 @@ namespace ebi
             { DP, { INTEGER, "1" } },
             { EC, { INTEGER, A } },
             { FT, { STRING, "1" } },
-            { GL, { FLOAT, UNKNOWN_CARDINALITY } },
+            { GL, { FLOAT, G } },
             { GLE, { STRING, G } },
             { GP, { FLOAT, G } },
             { GQ, { INTEGER, "1" } },
@@ -193,7 +193,7 @@ namespace ebi
             { DP, { INTEGER, "1" } },
             { EC, { INTEGER, A } },
             { FT, { STRING, "1" } },
-            { GL, { FLOAT, UNKNOWN_CARDINALITY } },
+            { GL, { FLOAT, G } },
             { GP, { FLOAT, G } },
             { GQ, { INTEGER, "1" } },
             { GT, { STRING, "1" } },
@@ -201,7 +201,7 @@ namespace ebi
             { HQ, { INTEGER, "2" } },
             { MQ, { INTEGER, "1" } },
             { NQ, { INTEGER, "1" } },
-            { PL, { INTEGER, UNKNOWN_CARDINALITY } },
+            { PL, { INTEGER, G } },
             { PQ, { INTEGER, "1" } },
             { PS, { INTEGER, "1" } }
     };
@@ -484,7 +484,7 @@ namespace ebi
         /**
          * Returns the ploidy of GT
          */
-        long get_ploidy_from_GT(std::string const & sample) const;
+        size_t get_ploidy_from_GT(std::string const & sample) const;
 
         /**
          * Checks the sample contents and accordance to the meta section
@@ -553,29 +553,46 @@ namespace ebi
          *  (e.g. with 1 reference, 2 alternate alleles (3 total alleles) and ploidy 2, it's 3 + 2 -1 choose 2, which is 6: 00, 01, 11, 02, 12, 22)
          *  - "." means unknown number of elements
          *  - number is a positive number [0, +inf)
-         * @param ploidy is the number of sets of chromosomes, so a given position in a chromosome needs `ploidy` bases to be completely specified
+         * @param alternate_allele_number the number of alternate alleles
          * @param cardinality return by reference [0, +inf) for valid numbers. -1 if unknown number. 
+         * @param ploidy is the number of sets of chromosomes, so a given position in a chromosome needs `ploidy` bases to be completely specifie 
          * @throw std::invalid_argument if it's not a number
          * @throw std::out_of_range if it's out of range.
          * @return bool: whether the number was valid or not
          */
-        bool is_valid_cardinality(std::string const & number, size_t alternate_allele_number, long & cardinality) const;
+        bool is_valid_cardinality(std::string const & number, size_t alternate_allele_number, long & cardinality, size_t ploidy) const;
 
         /**
          * Checks that the values match either their type specified in the meta or the VCF specification for predefined tags not in meta
          */
         void check_value_type(std::string const & type, std::string const & value, std::string & message) const;
 
+        /**
+         * Checks that every field in info column matches the Number specification in the meta
+         * Or if it is not present in the meta and is a predefined tag, check that it matches the VCF specification
+         * 
+         * @throw std::invalid_argument
+         */
+        void check_field_cardinality(std::string const & field, std::vector<std::string> const & values, std::string const & number) const;
 
+        /**
+         * Checks that every field in format column matches the Number specification in the meta
+         * Or if it is not present in the meta and is a predefined tag, check that it matches the VCF specification
+         * 
+         * @throw std::invalid_argument
+         */
+        void check_field_cardinality(bool & valid, std::string const & field, std::vector<std::string> const & values,
+                                     std::string const & number, long & cardinality) const;
+ 
         /**
          * Checks that every field in a sample matches the Number specification in the meta
          * Or if it is not present in the meta and is a predefined tag, check that it matches the VCF specification
          * 
          * @throw std::invalid_argument
          */
-        void check_field_cardinality(std::string const & field,
-                                     std::vector<std::string> const & values,
-                                     std::string const & number) const;
+        void check_field_cardinality(bool & valid, std::string const & field, std::vector<std::string> const & values,
+                                     std::string const & number, long & cardinality, size_t & ploidy,
+                                     std::string const & sample) const;
         
         /**
          * Checks that every field in a column matches the Type specification in the meta

--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -16,6 +16,8 @@
 
 #include <functional>
 #include <unordered_set>
+
+#include "util/logger.hpp"
 #include "vcf/file_structure.hpp"
 #include "vcf/record.hpp"
 
@@ -441,7 +443,7 @@ namespace ebi
             bool found_in_header = false;
             
             for (iter current = range.first; current != range.second; ++current) {
-                auto & key_values = boost::get<std::map < std::string, std::string>>((current->second).value);
+                auto & key_values = boost::get<std::map<std::string, std::string>>((current->second).value);
 
                 if (key_values[ID] == fm) {
                     format_meta.push_back(current->second);
@@ -457,6 +459,21 @@ namespace ebi
         }
 
         return format_meta;
+    }
+
+    long Record::get_ploidy_from_GT(std::string const & sample) const
+    {
+        if (format[0] == GT) {
+            std::string::size_type pos = sample.find(':');
+            std::string GT_subfield = sample;
+            if (pos != std::string::npos) {
+                GT_subfield = sample.substr(0, pos);
+            }
+            return 1 + count_if(GT_subfield.begin(), GT_subfield.end(), [](char c) { return c == '/' || c == '|'; });
+        } else {
+            BOOST_LOG_TRIVIAL(error) << "Cannot fetch ploidy from GT as GT is not present in the FORMAT";
+            return -1;
+        }
     }
 
     void Record::check_sample(size_t i, std::vector<MetaEntry> const & format_meta) const
@@ -482,14 +499,15 @@ namespace ebi
         }
     }
 
-    void Record::check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> const & subfields, std::vector<MetaEntry> const & format_meta) const
+    void Record::check_sample_subfields_cardinality_type(size_t i, std::vector<std::string> const & subfields,
+                                                         std::vector<MetaEntry> const & format_meta) const
     {
         std::vector<std::string> values;
 
         for (size_t j = 0; j < subfields.size(); ++j) {
             MetaEntry meta = format_meta[j];
             auto & subfield = subfields[j];
-            
+
             util::string_split(subfield, ",", values);
 
             if (meta.id == "") {
@@ -535,6 +553,19 @@ namespace ebi
                 if (std::stold(value) < 0 || std::stold(value) > 1) {
                     throw new SamplesFieldBodyError{line, message + " does not lie in the interval [0,1]", "", field_key};
                 }
+            }
+        } else if (field_key == GL || field_key == PL) {
+            long expected_sample_ploidy = 2;  // diploidy is assumed
+            if (format[0] == GT) {
+                expected_sample_ploidy = get_ploidy_from_GT(samples[i]);
+            }
+            long cardinality = boost::math::binomial_coefficient<float>(alternate_alleles.size() + expected_sample_ploidy,
+                                                                        expected_sample_ploidy);
+            if (cardinality != static_cast<long>(values.size())) {
+                throw new SamplesFieldBodyError{line, message + " must derive its number of values from the ploidy of "
+                                "GT (if present), or assume a diploidy", "Contains " + std::to_string(values.size())
+                                + " value(s), expected " + std::to_string(cardinality) + " (derived from ploidy " +
+                                std::to_string(expected_sample_ploidy) + ")", field_key};
             }
         }
     }

--- a/test/input_files/v4.1/failed/failed_meta_format_012.vcf
+++ b/test/input_files/v4.1/failed/failed_meta_format_012.vcf
@@ -1,5 +1,0 @@
-##fileformat=VCFv4.1
-##CauseOfFailure=FORMAT GL Number is not G
-##FORMAT=<ID=GL,Number=A,Type=Float,Description="Genotype likelihoods">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/input_files/v4.1/failed/failed_meta_format_024.vcf
+++ b/test/input_files/v4.1/failed/failed_meta_format_024.vcf
@@ -1,5 +1,0 @@
-##fileformat=VCFv4.1
-##CauseOfFailure=FORMAT PL Number is not G
-##FORMAT=<ID=PL,Number=1,Type=Integer,Description="Phred-scaled genotype likelihoods rounded to the closest integer">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/input_files/v4.2/failed/failed_meta_format_011.vcf
+++ b/test/input_files/v4.2/failed/failed_meta_format_011.vcf
@@ -1,5 +1,0 @@
-##fileformat=VCFv4.2
-##CauseOfFailure=FORMAT GL Number is not G
-##FORMAT=<ID=GL,Number=A,Type=Float,Description="Genotype likelihoods">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/input_files/v4.2/failed/failed_meta_format_023.vcf
+++ b/test/input_files/v4.2/failed/failed_meta_format_023.vcf
@@ -1,5 +1,0 @@
-##fileformat=VCFv4.2
-##CauseOfFailure=FORMAT PL Number is not G
-##FORMAT=<ID=PL,Number=1,Type=Integer,Description="Phred-scaled genotype likelihoods rounded to the closest integer">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/input_files/v4.3/failed/failed_meta_format_017.vcf
+++ b/test/input_files/v4.3/failed/failed_meta_format_017.vcf
@@ -1,5 +1,0 @@
-##fileformat=VCFv4.3
-##CauseOfFailure=FORMAT GL Number is not G
-##FORMAT=<ID=GL,Number=A,Type=Float,Description="Genotype likelihoods">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/input_files/v4.3/failed/failed_meta_format_029.vcf
+++ b/test/input_files/v4.3/failed/failed_meta_format_029.vcf
@@ -1,5 +1,0 @@
-##fileformat=VCFv4.3
-##CauseOfFailure=FORMAT PL Number is not G
-##FORMAT=<ID=PL,Number=1,Type=Integer,Description="Phred-scaled genotype likelihoods rounded to the closest integer">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	123	.	TC	T	.	.	.

--- a/test/vcf/metaentry_test.cpp
+++ b/test/vcf/metaentry_test.cpp
@@ -581,14 +581,6 @@ namespace ebi
                             }),
                             vcf::MetaSectionError* );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {
-                                1,
-                                vcf::FORMAT,
-                                { {vcf::ID, vcf::GL}, {vcf::NUMBER, "2"}, {vcf::TYPE, vcf::FLOAT}, {vcf::DESCRIPTION, "Genotype likelihoods"} },
-                                source
-                            }),
-                            vcf::MetaSectionError* );
-
             CHECK_NOTHROW( (vcf::MetaEntry {
                                 1,
                                 vcf::FORMAT,
@@ -719,14 +711,6 @@ namespace ebi
                             }),
                             vcf::MetaSectionError* );
                                 
-            CHECK_THROWS_AS( (vcf::MetaEntry {
-                                1,
-                                vcf::FORMAT,
-                                { {vcf::ID, vcf::PL}, {vcf::NUMBER, "2"}, {vcf::TYPE, vcf::INTEGER}, {vcf::DESCRIPTION, "Phred-scaled genotype likelihoods rounded to the closest integer"} },
-                                source
-                            }),
-                            vcf::MetaSectionError* );
-
             CHECK_NOTHROW( (vcf::MetaEntry {
                                 1,
                                 vcf::FORMAT,

--- a/test/vcf/predefined_format_tags_test.cpp
+++ b/test/vcf/predefined_format_tags_test.cpp
@@ -217,7 +217,7 @@ namespace ebi
                             source}),
                         vcf::SamplesFieldBodyError*);
 
-           CHECK_THROWS_AS( (vcf::Record{
+            CHECK_THROWS_AS( (vcf::Record{
                             1,
                             "chr1",
                             123456,
@@ -231,6 +231,49 @@ namespace ebi
                             { "1.3,2.4" },
                             source}),
                         vcf::SamplesFieldBodyError*);
+
+            CHECK_THROWS_AS( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "A",
+                            { "AT" },
+                            1.0,
+                            { vcf::PASS },
+                            { {vcf::AA, "243"} },
+                            { vcf::GT, vcf::GL },
+                            { "1/0:1.3,2.4" },
+                            source}),
+                        vcf::SamplesFieldBodyError*);
+
+            CHECK_NOTHROW( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "A",
+                            { "AT" },
+                            1.0,
+                            { vcf::PASS },
+                            { {vcf::AA, "243"} },
+                            { vcf::GT, vcf::GL },
+                            { "1:1.3,2.4" },
+                            source}));
+
+            CHECK_NOTHROW( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "A",
+                            { "AT" },
+                            1.0,
+                            { vcf::PASS },
+                            { {vcf::AA, "243"} },
+                            { vcf::GL },
+                            { "1.3,2.4,2.3" },
+                            source}));
 
             CHECK_THROWS_AS( (vcf::Record{
                             1,
@@ -411,6 +454,49 @@ namespace ebi
                             { "7,5" },
                             source}),
                         vcf::SamplesFieldBodyError*);
+
+            CHECK_THROWS_AS( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "A",
+                            { "AT" },
+                            1.0,
+                            { vcf::PASS },
+                            { {vcf::AA, "243"} },
+                            { vcf::GT, vcf::PL },
+                            { "1/0:1,2" },
+                            source}),
+                        vcf::SamplesFieldBodyError*);
+
+            CHECK_NOTHROW( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "A",
+                            { "AT" },
+                            1.0,
+                            { vcf::PASS },
+                            { {vcf::AA, "243"} },
+                            { vcf::GT, vcf::PL },
+                            { "1:1,2" },
+                            source}));
+
+            CHECK_NOTHROW( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123" },
+                            "A",
+                            { "AT" },
+                            1.0,
+                            { vcf::PASS },
+                            { {vcf::AA, "243"} },
+                            { vcf::PL },
+                            { "1,2,5" },
+                            source}));
 
             CHECK_THROWS_AS( (vcf::Record{
                             1,


### PR DESCRIPTION
Fixes #101

The VCF spec defines for `GL` : "In presence of the GT field the same ploidy is expected; without GT field, diploidy is assumed."
It defines `PL` as : "The phred-scaled genotype likelihoods rounded to the closest integer, and otherwise defined precisely as the GL field."

This is probably not the case with other fields whose `Number` is `G` like `GP`, `CNL`, `CNP`, hence not implementing this for those. 