### PR TITLE
adds newer version of gcc to the travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,24 @@ matrix:
             - libboost-log1.55-dev
             - ninja-build
 
+    # GCC 6
+    - compiler: gcc
+      env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6
+      addons:
+        apt:
+          sources:
+            - boost-latest
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - g++-6
+            - libboost1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-regex1.55-dev
+            - libboost-log1.55-dev
+            - ninja-build
+
 before_script:
   - ./install_dependencies.sh
   - export PATH=$PATH:$PWD/odb/odb-2.4.0-x86_64-linux-gnu/bin/


### PR DESCRIPTION
This PR adds newer version of GCC to Travis file. In reference to the issue #106 