### PR TITLE
Tests for warnings in the body section

### DIFF
--- a/test/vcf/optional_policy_test.cpp
+++ b/test/vcf/optional_policy_test.cpp
@@ -22,7 +22,7 @@
 namespace ebi
 {
 
-    TEST_CASE("Record Position warnings", "[body position warnings]")
+    TEST_CASE("Record Position warnings", "[warnings]")
     {
         std::shared_ptr<vcf::Source> source{
             new vcf::Source{
@@ -96,7 +96,7 @@ namespace ebi
         }
     }
 
-    TEST_CASE("Id warnings", "[body id warnings]")
+    TEST_CASE("Id warnings", "[warnings]")
     {
         std::shared_ptr<vcf::Source> source{
             new vcf::Source{
@@ -156,7 +156,7 @@ namespace ebi
         }
     }
 
-    TEST_CASE("Record Reference Alternate matching warnings", "[body reference alternate matching warnings]")
+    TEST_CASE("Record Reference Alternate matching warnings", "[warnings]")
     {
         std::shared_ptr<vcf::Source> source{
             new vcf::Source{
@@ -244,7 +244,7 @@ namespace ebi
         }
     }
 
-    TEST_CASE("Info predefined tags warnings", "[body info warnings]")
+    TEST_CASE("Info predefined tags warnings", "[warnings]")
     {
         std::shared_ptr<vcf::Source> source{
             new vcf::Source{
@@ -518,7 +518,7 @@ namespace ebi
         }
     }
 
-    TEST_CASE("Alternate allele warnings", "[body alt warnings]")
+    TEST_CASE("Alternate allele warnings", "[warnings]")
     {
         std::vector<std::shared_ptr<vcf::Source>> sources = {
             std::shared_ptr<vcf::Source>{new vcf::Source{

--- a/test/vcf/optional_policy_test.cpp
+++ b/test/vcf/optional_policy_test.cpp
@@ -199,7 +199,7 @@ namespace ebi
 
         SECTION("Reference and alternate alleles share first nucleotide")
         {
-            vcf::Record record1(
+            CHECK_NOTHROW( (optional_policy.optional_check_body_entry(parsing_state, vcf::Record{
                                 1,
                                 "chr1",
                                 123456,
@@ -211,25 +211,23 @@ namespace ebi
                                 { { "XYZ", "1" } },
                                 { },
                                 { },
-                                source);
-            record1.types = { vcf::RecordType::INDEL };
+                                source})) );
 
-            vcf::Record record2(
+            CHECK_NOTHROW( (optional_policy.optional_check_body_entry(parsing_state, vcf::Record{
                                 1,
                                 "chr1",
                                 123456,
                                 { vcf::MISSING_VALUE },
-                                "A",
-                                { "CA" },
+                                "GT",
+                                { "AC" },
                                 1.0,
                                 { vcf::PASS },
                                 { { "XYZ", "1" } },
                                 { },
                                 { },
-                                source);
-            record2.types = { vcf::RecordType::MNV };
+                                source})) );
 
-            vcf::Record record3(
+            CHECK_THROWS_AS( (optional_policy.optional_check_body_entry(parsing_state, vcf::Record{
                                 1,
                                 "chr1",
                                 123456,
@@ -241,15 +239,8 @@ namespace ebi
                                 { { "XYZ", "1" } },
                                 { },
                                 { },
-                                source);
-            record3.types = { vcf::RecordType::INDEL };
-
-            CHECK_NOTHROW( (optional_policy.optional_check_body_entry(parsing_state, record1)) );
-
-            CHECK_NOTHROW( (optional_policy.optional_check_body_entry(parsing_state, record2)) );
-
-            CHECK_THROWS_AS( (optional_policy.optional_check_body_entry(parsing_state, record3)),
-                                                                        vcf::ReferenceAlleleBodyError*);
+                                source})),
+                            vcf::ReferenceAlleleBodyError*);
         }
     }
 
@@ -412,7 +403,7 @@ namespace ebi
 
         SECTION("Confidence Interval Tags")
         {
-            std::vector<std::string> confidence_interval_tags = { 
+            std::vector<std::string> confidence_interval_tags = {
                                                                     vcf::CICN,
                                                                     vcf::CICNADJ,
                                                                     vcf::CIEND,


### PR DESCRIPTION
This PR aims to solve issue #92 partially. 
Added tests for position, id, reference alternate matching and info imprecise.