### PR TITLE
Display type of report written

### DIFF
--- a/inc/vcf/odb_report.hpp
+++ b/inc/vcf/odb_report.hpp
@@ -53,6 +53,7 @@ namespace ebi
         virtual void for_each_error(std::function<void(std::shared_ptr<Error>)> user_function) override;
 
         virtual std::string get_filename() override;
+        virtual std::string get_type() override;
 
       private:
         std::string db_name;

--- a/inc/vcf/odb_report.hpp
+++ b/inc/vcf/odb_report.hpp
@@ -52,8 +52,7 @@ namespace ebi
         virtual size_t count_errors() override;
         virtual void for_each_error(std::function<void(std::shared_ptr<Error>)> user_function) override;
 
-        virtual std::string get_filename() override;
-        virtual std::string get_type() override;
+        virtual std::string get_report_message() override;
 
       private:
         std::string db_name;

--- a/inc/vcf/report_writer.hpp
+++ b/inc/vcf/report_writer.hpp
@@ -35,8 +35,7 @@ namespace ebi
             virtual void write_warning(Error &error) = 0;
             virtual void write_message(const std::string &report_result) = 0;
 
-            virtual std::string get_filename() = 0;
-            virtual std::string get_type() = 0;
+            virtual std::string get_report_message() = 0;
     };
 
     class FileReportWriter : public ReportWriter
@@ -67,14 +66,9 @@ namespace ebi
                 file << report_result << std::endl;
             }
 
-            virtual std::string get_filename() override
+            virtual std::string get_report_message() override
             {
-                return file_name;
-            }
-
-            virtual std::string get_type() override
-            {
-                return "Text";
+                return "Text report written to : " + file_name;
             }
 
         private:

--- a/inc/vcf/report_writer.hpp
+++ b/inc/vcf/report_writer.hpp
@@ -36,6 +36,7 @@ namespace ebi
             virtual void write_message(const std::string &report_result) = 0;
 
             virtual std::string get_filename() = 0;
+            virtual std::string get_type() = 0;
     };
 
     class FileReportWriter : public ReportWriter
@@ -69,6 +70,11 @@ namespace ebi
             virtual std::string get_filename() override
             {
                 return file_name;
+            }
+
+            virtual std::string get_type() override
+            {
+                return "Text";
             }
 
         private:

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -93,14 +93,9 @@ namespace ebi
             this->report_result = report_result;
         }
 
-        virtual std::string get_filename() override
+        virtual std::string get_report_message() override
         {
-            return file_name;
-        }
-
-        virtual std::string get_type() override
-        {
-            return "Summary";
+            return "Summary report written to : " + file_name;
         }
 
       private:

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -98,6 +98,11 @@ namespace ebi
             return file_name;
         }
 
+        virtual std::string get_type() override
+        {
+            return "Summary";
+        }
+
       private:
         SummaryTracker summary;
         std::string report_result;

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
 
         std::string report_result = "According to the VCF specification, the input file is " + std::string(is_valid ? "" : "not ") + "valid";
         for (auto & output : outputs) {
-            BOOST_LOG_TRIVIAL(info) << output->get_type() << " report written to : " << output->get_filename();
+            BOOST_LOG_TRIVIAL(info) << output->get_report_message();
             output->write_message(report_result);
         }
         BOOST_LOG_TRIVIAL(info) << report_result;

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
 
         std::string report_result = "According to the VCF specification, the input file is " + std::string(is_valid ? "" : "not ") + "valid";
         for (auto & output : outputs) {
-            BOOST_LOG_TRIVIAL(info) << "Report written to : " << output->get_filename();
+            BOOST_LOG_TRIVIAL(info) << output->get_type() << " report written to : " << output->get_filename();
             output->write_message(report_result);
         }
         BOOST_LOG_TRIVIAL(info) << report_result;

--- a/src/vcf/odb_report.cpp
+++ b/src/vcf/odb_report.cpp
@@ -164,14 +164,9 @@ namespace ebi
         }
     }
 
-    std::string OdbReportRW::get_filename()
+    std::string OdbReportRW::get_report_message()
     {
-        return db_name;
-    }
-
-    std::string OdbReportRW::get_type()
-    {
-        return "Database";
+        return "Database report written to : " + db_name;
     }
   }
 }

--- a/src/vcf/odb_report.cpp
+++ b/src/vcf/odb_report.cpp
@@ -168,5 +168,10 @@ namespace ebi
     {
         return db_name;
     }
+
+    std::string OdbReportRW::get_type()
+    {
+        return "Database";
+    }
   }
 }


### PR DESCRIPTION
The log message being displayed was not very descriptive.
i.e. it didn't provide any description about type of report being written.
Now it will also display the type of report
```
[info] Reading from input file...
[info] Summary report written to : passed_meta_sample.vcf.errors_summary.1521316784807.txt
[info] Text report written to : passed_meta_sample.vcf.errors.1521316784807.txt
[info] According to the VCF specification, the input file is valid

```