### PR TITLE
Stdout option for report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set (MOD_VCF_SOURCES
         inc/vcf/report_reader.hpp
         inc/vcf/report_writer.hpp
         inc/vcf/string_constants.hpp
+        inc/vcf/stdout_report_writer.hpp
         inc/vcf/summary_report_writer.hpp
         inc/vcf/validator_detail_v41.hpp
         inc/vcf/validator_detail_v42.hpp

--- a/inc/vcf/odb_report.hpp
+++ b/inc/vcf/odb_report.hpp
@@ -52,7 +52,7 @@ namespace ebi
         virtual size_t count_errors() override;
         virtual void for_each_error(std::function<void(std::shared_ptr<Error>)> user_function) override;
 
-        virtual std::string get_report_message() override;
+        virtual void show_report_message() override;
 
       private:
         std::string db_name;

--- a/inc/vcf/report_writer.hpp
+++ b/inc/vcf/report_writer.hpp
@@ -21,6 +21,8 @@
 #include <string>
 #include <stdexcept>
 
+#include <boost/log/trivial.hpp>
+
 #include "vcf/error.hpp"
 
 namespace ebi
@@ -35,7 +37,7 @@ namespace ebi
             virtual void write_warning(Error &error) = 0;
             virtual void write_message(const std::string &report_result) = 0;
 
-            virtual std::string get_report_message() = 0;
+            virtual void show_report_message() = 0;
     };
 
     class FileReportWriter : public ReportWriter
@@ -66,9 +68,9 @@ namespace ebi
                 file << report_result << std::endl;
             }
 
-            virtual std::string get_report_message() override
+            virtual void show_report_message() override
             {
-                return "Text report written to : " + file_name;
+                BOOST_LOG_TRIVIAL(info) << "Text report written to : " + file_name;
             }
 
         private:

--- a/inc/vcf/stdout_report_writer.hpp
+++ b/inc/vcf/stdout_report_writer.hpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VCF_STDOUT_REPORT_WRITER_HPP
+#define VCF_STDOUT_REPORT_WRITER_HPP
+
+#include <string>
+
+#include "report_writer.hpp"
+#include "vcf/error.hpp"
+
+
+namespace ebi
+{
+  namespace vcf
+  {
+    class StdoutReportWriter : public ReportWriter
+    {
+        public:
+            StdoutReportWriter() {}
+
+            ~StdoutReportWriter() {}
+
+            virtual void write_error(Error &error) override
+            {
+                std::cout << error.what() << std::endl;
+            }
+
+            virtual void write_warning(Error &error) override
+            {
+                std::cout << error.what() << " (warning)" << std::endl;
+            }
+
+            virtual void write_message(const std::string &report_result) override
+            {
+                std::cout << report_result << std::endl;
+            }
+
+            virtual void show_report_message() override
+            {
+
+            }
+    };
+  }
+}
+
+#endif // VCF_STDOUT_REPORT_WRITER_HPP

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -93,9 +93,9 @@ namespace ebi
             this->report_result = report_result;
         }
 
-        virtual std::string get_report_message() override
+        virtual void show_report_message() override
         {
-            return "Summary report written to : " + file_name;
+            BOOST_LOG_TRIVIAL(info) << "Summary report written to : " + file_name;
         }
 
       private:

--- a/src/vcf/odb_report.cpp
+++ b/src/vcf/odb_report.cpp
@@ -164,9 +164,9 @@ namespace ebi
         }
     }
 
-    std::string OdbReportRW::get_report_message()
+    void OdbReportRW::show_report_message()
     {
-        return "Database report written to : " + db_name;
+        BOOST_LOG_TRIVIAL(info) << "Database report written to : " + db_name;
     }
   }
 }


### PR DESCRIPTION
This PR is to add stdout option in report options.
This is to demonstrate the working of this new option for the issue #132


```
Usage: vcf-validator [OPTIONS] [< input_file]
Allowed options:
  -h [ --help ]                  Display this help
  -v [ --version ]               Display version of the validator
  -i [ --input ] arg (=stdin)    Path to the input VCF file, or stdin
  -l [ --level ] arg (=warning)  Validation level (error, warning, stop)
  -r [ --report ] arg (=summary) Comma separated values for types of reports 
                                 (summary, text, database, stdout)
  -o [ --outdir ] arg            Directory for the output

```

Users will be able to see reports on stdout without any need to opening file

```
user-pc~$ ./vcf_validator -i passed_meta_sample.vcf -r stdout
[info] Reading from input file...
Line 9: A valid 'reference' entry is not listed in the meta section. (warning)
Line 9: Chromosome/contig '1' is not described in a 'contig' meta description. (warning)
According to the VCF specification, the input file is valid
[info] According to the VCF specification, the input file is valid
```

```
user-pc~$ ./vcf_validator -i passed_meta_sample.vcf -r stdout,summary
[info] Reading from input file...
Line 9: A valid 'reference' entry is not listed in the meta section. (warning)
Line 9: Chromosome/contig '1' is not described in a 'contig' meta description. (warning)
According to the VCF specification, the input file is valid
[info] Summary report written to : passed_meta_sample.vcf.errors_summary.1522630855920.txt
[info] According to the VCF specification, the input file is valid
```

  