### PR TITLE
break if file is not written

### DIFF
--- a/inc/vcf/report_writer.hpp
+++ b/inc/vcf/report_writer.hpp
@@ -44,7 +44,9 @@ namespace ebi
             FileReportWriter(std::string filename) : file_name(filename)
             {
                 file.open(filename, std::ios::out);
-                if(!file) throw std::runtime_error{"Unable to write output file " + file_name};
+                if(!file) {
+                    throw std::runtime_error{"Unable to write output file " + file_name};
+                }
             }
 
             ~FileReportWriter()

--- a/inc/vcf/report_writer.hpp
+++ b/inc/vcf/report_writer.hpp
@@ -44,6 +44,7 @@ namespace ebi
             FileReportWriter(std::string filename) : file_name(filename)
             {
                 file.open(filename, std::ios::out);
+                if(!file) throw std::runtime_error{"Unable to write output file " + file_name};
             }
 
             ~FileReportWriter()

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -70,6 +70,7 @@ namespace ebi
         SummaryReportWriter(std::string filename) : file_name(filename)
         {
             file.open(filename, std::ios::out);
+            if(!file) throw std::runtime_error{"Unable to write output file " + file_name};
         }
 
         ~SummaryReportWriter()

--- a/inc/vcf/summary_report_writer.hpp
+++ b/inc/vcf/summary_report_writer.hpp
@@ -70,7 +70,9 @@ namespace ebi
         SummaryReportWriter(std::string filename) : file_name(filename)
         {
             file.open(filename, std::ios::out);
-            if(!file) throw std::runtime_error{"Unable to write output file " + file_name};
+            if(!file) {
+                throw std::runtime_error{"Unable to write output file " + file_name};
+            }
         }
 
         ~SummaryReportWriter()


### PR DESCRIPTION
this PR closes the issue #142 
now the vcf_validator will throw runtime error is it is unable to write the output file.

```
srb@srb-pc:~$ ./vcf_validator -i /data/my_vcf.vcf.gz
[error] The validation could not be completed: Unable to write output file stdin.errors_summary.1529587453100.txt
```