### PR TITLE
Improvement in functionality of reading compressed files

### DIFF
--- a/inc/vcf/validator.hpp
+++ b/inc/vcf/validator.hpp
@@ -189,12 +189,17 @@ namespace ebi
                            ValidationLevel validationLevel,
                            std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> &outputs);
 
+    bool process_vcf_stream(std::istream &input,
+                          const std::string &sourceName,
+                          ValidationLevel validationLevel,
+                          std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> &outputs);
+
     std::string get_compression_from_extension(std::string const & source);
 
     std::string get_compression_from_magic_num(const std::vector<char> &line);
 
     void create_uncompressed_stream(std::istream & input,
-                                    const std::string & sourceName,
+                                    const std::string & file_extension,
                                     boost::iostreams::filtering_istream & uncompressed_input);
 
   }


### PR DESCRIPTION
This PR is extension of #117.
In that PR functionality of reading compressed files was added. We used boost::filtering streams to read the compressed files.
Boost filtering streams delayed the output.
Using boost for compressed files was fine. but using it for normal files was just delayed the output uselessly.
So now I have used normal istream for uncompressed file and boost filtering streams for compressed ones.

