### PR TITLE
demonstration of failure of vcf-validator on empty vcf file

### DIFF
--- a/src/vcf/validator.cpp
+++ b/src/vcf/validator.cpp
@@ -255,12 +255,13 @@ namespace ebi
         };
 
         /*
-         * If the first line of the VCF file has less than 5 characters,
-         * std::equal will cause a segmentation fault.
+         * If the first line of the VCF file is shorter than any magic number string (stored in the variable "types"),
+         * std::equal will cause a segmentation fault, so if the line is shorter than the longest magic number string
+         * (5 characters), then we assume there's no compression.
          */
         if (line.size() < 5) {
             if (line.size() == 0) {
-                BOOST_LOG_TRIVIAL(warning) << "Empty vcf file";
+                BOOST_LOG_TRIVIAL(warning) << "The VCF file provided is empty";
             }
             return NO_EXT;
         }

--- a/src/vcf/validator.cpp
+++ b/src/vcf/validator.cpp
@@ -259,6 +259,9 @@ namespace ebi
          * std::equal will cause a segmentation fault.
          */
         if (line.size() < 5) {
+            if (line.size() == 0) {
+                BOOST_LOG_TRIVIAL(warning) << "Empty vcf file";
+            }
             return NO_EXT;
         }
 

--- a/src/vcf/validator.cpp
+++ b/src/vcf/validator.cpp
@@ -254,12 +254,21 @@ namespace ebi
             { { 120, -100 }, ZLIB }
         };
 
-        for (auto & type : types) {
-            if (std::equal(type.first.begin(), type.first.end(), line.begin())) {
-                compressed_file_warning(type.second);
-                return type.second;
-            }
-        }
+        /*
+        * First line of vcf file is having smaller size than 5 characters
+        * which will be a problem for std::equal to check its extension
+        * It will cause a segmentation fault.
+        * According to spec first line of vcf, file can't be smaller than 5 characters.
+        */
+		if(line.size() >=5){
+			for (auto & type : types) {
+		        if (std::equal(type.first.begin(), type.first.end(), line.begin())) {
+		            compressed_file_warning(type.second);
+		            return type.second;
+		        }
+		    }
+		}
+
         return NO_EXT;
     }
 

--- a/src/vcf/validator.cpp
+++ b/src/vcf/validator.cpp
@@ -255,19 +255,17 @@ namespace ebi
         };
 
         /*
-        * First line of vcf file is having smaller size than 5 characters
-        * which will be a problem for std::equal to check its extension
-        * It will cause a segmentation fault.
-        * According to spec first line of vcf, file can't be smaller than 5 characters.
-        */
-		if(line.size() >=5){
-			for (auto & type : types) {
-		        if (std::equal(type.first.begin(), type.first.end(), line.begin())) {
-		            compressed_file_warning(type.second);
-		            return type.second;
-		        }
-		    }
-		}
+         * If the first line of the VCF file has less than 5 characters,
+         * std::equal will cause a segmentation fault.
+         */
+        if (line.size() >= 5) {
+            for (auto & type : types) {
+                if (std::equal(type.first.begin(), type.first.end(), line.begin())) {
+                    compressed_file_warning(type.second);
+                    return type.second;
+                }
+            }
+        }
 
         return NO_EXT;
     }

--- a/src/vcf/validator.cpp
+++ b/src/vcf/validator.cpp
@@ -258,12 +258,14 @@ namespace ebi
          * If the first line of the VCF file has less than 5 characters,
          * std::equal will cause a segmentation fault.
          */
-        if (line.size() >= 5) {
-            for (auto & type : types) {
-                if (std::equal(type.first.begin(), type.first.end(), line.begin())) {
-                    compressed_file_warning(type.second);
-                    return type.second;
-                }
+        if (line.size() < 5) {
+            return NO_EXT;
+        }
+
+        for (auto & type : types) {
+            if (std::equal(type.first.begin(), type.first.end(), line.begin())) {
+                compressed_file_warning(type.second);
+                return type.second;
             }
         }
 


### PR DESCRIPTION
if we try to validate some empty vcf file. the vcf-validator gives segmentation fault as mentioned in [this issue](https://github.com/EBIvariation/vcf-validator/issues/154)

the debugger log is 
```
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./vcf_validator...done.
(gdb) r < empty.vcf 
Starting program: /home/srb/Desktop/test/cpp/vcf_validator < empty.vcf
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[info] Reading from standard input...

Program received signal SIGSEGV, Segmentation fault.
0x00000000007c89b4 in __memcmp_sse4_1 ()
(gdb) backtrace
#0  0x00000000007c89b4 in __memcmp_sse4_1 ()
#1  0x000000000043aec8 in std::__equal<true>::equal<char> (__first2=0x0, __last1=<optimized out>, __first1=<optimized out>)
    at /usr/include/c++/5/bits/stl_algobase.h:830
#2  std::__equal_aux<char*, char const*> (__first2=0x0, __last1=<optimized out>, __first1=<optimized out>)
    at /usr/include/c++/5/bits/stl_algobase.h:847
#3  std::equal<__gnu_cxx::__normal_iterator<char*, std::vector<char, std::allocator<char> > >, __gnu_cxx::__normal_iterator<char const*, std::vector<char, std::allocator<char> > > > (__first2=..., __last1=..., __first1=...)
    at /usr/include/c++/5/bits/stl_algobase.h:1069
#4  ebi::vcf::get_compression_from_magic_num[abi:cxx11](std::vector<char, std::allocator<char> > const&) (line=...)
    at /home/srb/programs/gsoc/ebi/vcf-validator/src/vcf/validator.cpp:258
#5  0x000000000043b187 in ebi::vcf::get_compression (source=..., line=...)
    at /home/srb/programs/gsoc/ebi/vcf-validator/src/vcf/validator.cpp:224
#6  0x000000000043e147 in ebi::vcf::is_valid_vcf_file (input=..., sourceName=..., 
    validationLevel=validationLevel@entry=ebi::vcf::ValidationLevel::warning, outputs=...)
    at /home/srb/programs/gsoc/ebi/vcf-validator/src/vcf/validator.cpp:149
#7  0x0000000000408c53 in main (argc=<optimized out>, argv=<optimized out>)
    at /home/srb/programs/gsoc/ebi/vcf-validator/src/validator_main.cpp:178
(gdb) 

```