### PR TITLE
Empty warning

### DIFF
--- a/src/vcf/compression.cpp
+++ b/src/vcf/compression.cpp
@@ -100,16 +100,15 @@ namespace ebi
             { { 120, -100 }, ZLIB }
         };
 
-        /*
-         * If the first line of the VCF file is shorter than any magic number string (stored in the variable "types"),
-         * std::equal will cause a segmentation fault, so if the line is shorter than the longest magic number string
-         * (5 characters), then we assume there's no compression.
-         */
-        if (line.size() < 5) {
-            return NO_EXT;
-        }
-
         for (auto & type : types) {
+            /*
+             * If the first line of the VCF file is shorter than the magic number string (stored in the
+             * variable "types"), the std::equal call below will cause a segmentation fault.
+             */
+            if (type.first.size() > line.size()) {
+                continue;
+            }
+
             if (std::equal(type.first.begin(), type.first.end(), line.begin())) {
                 compressed_file_warning(type.second);
                 return type.second;

--- a/src/vcf/compression.cpp
+++ b/src/vcf/compression.cpp
@@ -106,9 +106,6 @@ namespace ebi
          * (5 characters), then we assume there's no compression.
          */
         if (line.size() < 5) {
-            if (line.size() == 0) {
-                BOOST_LOG_TRIVIAL(warning) << "The VCF file provided is empty";
-            }
             return NO_EXT;
         }
 

--- a/src/vcf/compression.cpp
+++ b/src/vcf/compression.cpp
@@ -132,6 +132,10 @@ namespace ebi
     {
         std::string compression_type = ebi::vcf::get_compression_from_magic_num(line);
 
+        if (line.size() == 0) {
+            BOOST_LOG_TRIVIAL(warning) << "The VCF file provided is empty";
+        }
+
         if (compression_type != NO_EXT) {
             throw std::invalid_argument{"Input file should not be compressed twice"};
         }


### PR DESCRIPTION
Vcf validator and assembly checker were showing warning of empty vcf file twice.

```
srb@srb-pc:$ ./vcf_validator < empty.vcf 
[info] Reading from standard input...
[warning] The VCF file provided is empty
[warning] The VCF file provided is empty
[info] Summary report written to : stdin.errors_summary.1536273054595.txt
[info] According to the VCF specification, the input file is not valid
```

This PR will fix that issue.