### PR TITLE
Valid report

### DIFF
--- a/inc/vcf/assembly_report_writer.hpp
+++ b/inc/vcf/assembly_report_writer.hpp
@@ -112,7 +112,6 @@ namespace ebi
         MatchStats match_stats;
     };
 
-    // TODO: the "valid" report should include the header. this report should not be used until then.
     class ValidAssemblyReportWriter : public AssemblyReportWriter
     {
       public:

--- a/inc/vcf/assembly_report_writer.hpp
+++ b/inc/vcf/assembly_report_writer.hpp
@@ -59,6 +59,11 @@ namespace ebi
 
         }
 
+        virtual void write_meta_info(std::string &meta_info_line)
+        {
+
+        }
+
         virtual void write_warning(std::string &warning)
         {
 
@@ -127,6 +132,11 @@ namespace ebi
         virtual void match(std::string &vcf_line) override
         {
             file << vcf_line;
+        }
+
+        virtual void write_meta_info(std::string &meta_info_line) override
+        {
+            file << meta_info_line;
         }
 
       private:

--- a/src/assembly_checker_main.cpp
+++ b/src/assembly_checker_main.cpp
@@ -39,7 +39,7 @@ namespace
             (ebi::vcf::VERSION_OPTION, "Display version of the assembly checker")
             (ebi::vcf::INPUT_OPTION, po::value<std::string>()->default_value(ebi::vcf::STDIN), "Path to the input VCF file, or stdin")
             (ebi::vcf::FASTA_OPTION, po::value<std::string>(), "Path to the input FASTA file; please note that the index file must have the same name as the FASTA file and saved with a .idx extension")
-            (ebi::vcf::REPORT_OPTION, po::value<std::string>()->default_value(ebi::vcf::SUMMARY), "Comma separated values for types of reports (summary, text)")
+            (ebi::vcf::REPORT_OPTION, po::value<std::string>()->default_value(ebi::vcf::SUMMARY), "Comma separated values for types of reports (summary, text, valid)")
         ;
 
         return description;
@@ -92,7 +92,14 @@ namespace
             auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(epoch).count();
             std::string filetype = ".txt";
 
-            if (out == ebi::vcf::TEXT) {
+            if (out == ebi::vcf::VALID) {
+                std::string filename = input + ".valid_assembly_report." + std::to_string(timestamp) + filetype;
+                boost::filesystem::path file{filename};
+                if (boost::filesystem::exists(file)) {
+                    throw std::runtime_error{"Report file already exists on " + filename + ", please delete it or rename it"};
+                }
+                outputs.emplace_back(new ebi::vcf::TextAssemblyReportWriter(filename));
+            } else if (out == ebi::vcf::TEXT) {
                 std::string filename = input + ".text_assembly_report." + std::to_string(timestamp) + filetype;
                 boost::filesystem::path file{filename};
                 if (boost::filesystem::exists(file)) {

--- a/src/vcf/assembly_checker.cpp
+++ b/src/vcf/assembly_checker.cpp
@@ -60,6 +60,9 @@ namespace ebi
               std::string line{vector_line.begin(), vector_line.end()};
 
               if (boost::starts_with(line, "#")) {
+                  for (auto &output : outputs ) {
+                      output->write_meta_info(line);
+                  }
                   continue;
               }
 


### PR DESCRIPTION
This PR is enable the functionality of valid-report. We had disabled valid report in last PR due to the reason that the valid report was not writing `headers` into the output file. So this PR is to fix that issue.