### PR TITLE
Option for `outdir` in assembly_checker

### DIFF
--- a/inc/vcf/assembly_report_writer.hpp
+++ b/inc/vcf/assembly_report_writer.hpp
@@ -125,6 +125,7 @@ namespace ebi
 
         ~ValidAssemblyReportWriter()
         {
+            BOOST_LOG_TRIVIAL(info) << "Valid report written to : " + file_name;
             file.close();
         }
 
@@ -156,6 +157,7 @@ namespace ebi
 
         ~TextAssemblyReportWriter()
         {
+            BOOST_LOG_TRIVIAL(info) << "Text report written to : " + file_name;
             file.close();
         }
 

--- a/src/assembly_checker_main.cpp
+++ b/src/assembly_checker_main.cpp
@@ -40,6 +40,7 @@ namespace
             (ebi::vcf::INPUT_OPTION, po::value<std::string>()->default_value(ebi::vcf::STDIN), "Path to the input VCF file, or stdin")
             (ebi::vcf::FASTA_OPTION, po::value<std::string>(), "Path to the input FASTA file; please note that the index file must have the same name as the FASTA file and saved with a .idx extension")
             (ebi::vcf::REPORT_OPTION, po::value<std::string>()->default_value(ebi::vcf::SUMMARY), "Comma separated values for types of reports (summary, text, valid)")
+            (ebi::vcf::OUTDIR_OPTION, po::value<std::string>()->default_value(""), "Output directory")
         ;
 
         return description;
@@ -70,6 +71,23 @@ namespace
         }
 
         return 0;
+    }
+
+    std::string get_output_path(const std::string &outdir, const std::string &file_path)
+    {
+        if (outdir == "") {
+            return file_path;
+        }
+
+        boost::filesystem::path file_boost_path{file_path};
+        boost::filesystem::path outdir_boost_path{outdir};
+        if (!boost::filesystem::is_directory(outdir_boost_path)) {
+            throw std::invalid_argument{"outdir should be a directory, not a file: " + outdir_boost_path.string()};
+        }
+
+        outdir_boost_path /= file_boost_path.filename();
+
+        return outdir_boost_path.string();
     }
 
     std::vector<std::unique_ptr<ebi::vcf::AssemblyReportWriter>> get_outputs(std::string const &output_str,
@@ -144,7 +162,8 @@ int main(int argc, char** argv)
         auto vcf_path = vm[ebi::vcf::INPUT].as<std::string>();
         auto fasta_path = vm[ebi::vcf::FASTA].as<std::string>();
         auto fasta_index_path = fasta_path + ".fai";
-        auto outputs = get_outputs(vm[ebi::vcf::REPORT].as<std::string>(), vcf_path);
+        auto outdir = get_output_path(vm[ebi::vcf::OUTDIR].as<std::string>(), vcf_path);
+        auto outputs = get_outputs(vm[ebi::vcf::REPORT].as<std::string>(), outdir);
 
         BOOST_LOG_TRIVIAL(info) << "Reading from input FASTA file...";
         std::ifstream fasta_input;

--- a/src/assembly_checker_main.cpp
+++ b/src/assembly_checker_main.cpp
@@ -81,6 +81,9 @@ namespace
 
         boost::filesystem::path file_boost_path{file_path};
         boost::filesystem::path outdir_boost_path{outdir};
+        if (!boost::filesystem::exists(outdir_boost_path)) {
+            throw std::invalid_argument{"Directory not found: " + outdir_boost_path.string()};
+        }
         if (!boost::filesystem::is_directory(outdir_boost_path)) {
             throw std::invalid_argument{"outdir should be a directory, not a file: " + outdir_boost_path.string()};
         }

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -100,6 +100,9 @@ namespace
 
         boost::filesystem::path file_boost_path{file_path};
         boost::filesystem::path outdir_boost_path{outdir};
+        if (!boost::filesystem::exists(outdir_boost_path)) {
+            throw std::invalid_argument{"Directory not found: " + outdir_boost_path.string()};
+        }
         if (!boost::filesystem::is_directory(outdir_boost_path)) {
             throw std::invalid_argument{"outdir should be a directory, not a file: " + outdir_boost_path.string()};
         }

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -51,7 +51,7 @@ namespace
             (ebi::vcf::INPUT_OPTION, po::value<std::string>()->default_value(ebi::vcf::STDIN), "Path to the input VCF file, or stdin")
             (ebi::vcf::LEVEL_OPTION, po::value<std::string>()->default_value(ebi::vcf::WARNING_LEVEL), "Validation level (error, warning, stop)")
             (ebi::vcf::REPORT_OPTION, po::value<std::string>()->default_value(ebi::vcf::SUMMARY), "Comma separated values for types of reports (summary, text, database)")
-            (ebi::vcf::OUTDIR_OPTION, po::value<std::string>()->default_value(""), "Directory for the output")
+            (ebi::vcf::OUTDIR_OPTION, po::value<std::string>()->default_value(""), "Output directory")
         ;
 
         return description;


### PR DESCRIPTION
the assembly checker was missing an option to specify the output directory for the output file. This PR aims to add and `-o` option to assembly_checker