### PR TITLE
warn for unused parameters

### DIFF
--- a/inc/util/cli_utils.hpp
+++ b/inc/util/cli_utils.hpp
@@ -24,7 +24,6 @@
 #include <boost/filesystem/operations.hpp>
 
 #include "util/logger.hpp"
-#include "vcf/validator.hpp"
 
 namespace ebi
 {

--- a/inc/util/cli_utils.hpp
+++ b/inc/util/cli_utils.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <boost/program_options.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #include "util/logger.hpp"
 #include "vcf/validator.hpp"
@@ -45,6 +46,27 @@ namespace ebi
         po::notify(vm);
         return vm;
     }
+
+    std::string get_output_path(const std::string &outdir, const std::string &file_path)
+    {
+        if (outdir == "") {
+            return file_path;
+        }
+
+        boost::filesystem::path file_boost_path{file_path};
+        boost::filesystem::path outdir_boost_path{outdir};
+        if (!boost::filesystem::exists(outdir_boost_path)) {
+            throw std::invalid_argument{"Directory not found: " + outdir_boost_path.string()};
+        }
+        if (!boost::filesystem::is_directory(outdir_boost_path)) {
+            throw std::invalid_argument{"outdir should be a directory, not a file: " + outdir_boost_path.string()};
+        }
+
+        outdir_boost_path /= file_boost_path.filename();
+
+        return outdir_boost_path.string();
+    }
+
   }
 }
 

--- a/inc/util/cli_utils.hpp
+++ b/inc/util/cli_utils.hpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UTIL_CLI_UTILS_HPP
+#define UTIL_CLI_UTILS_HPP
+
+#include <string>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+#include "util/logger.hpp"
+#include "vcf/validator.hpp"
+
+namespace ebi
+{
+  namespace util
+  {
+    namespace po = boost::program_options;
+
+    po::variables_map build_variables_map(int argc, char** argv, const po::options_description & desc)
+    {
+        po::variables_map vm;
+        po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
+        po::store(parsed,vm);
+        std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
+
+        for (auto & parameter: unrecognised_parameters) {
+            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << parameter;
+        }
+
+        po::notify(vm);
+        return vm;
+    }
+  }
+}
+
+#endif // UTIL_CLI_UTILS_HPP

--- a/src/assembly_checker_main.cpp
+++ b/src/assembly_checker_main.cpp
@@ -18,10 +18,11 @@
 #include <boost/program_options.hpp>
 
 #include "cmake_config.hpp"
+#include "util/cli_utils.hpp"
+#include "util/logger.hpp"
 #include "vcf/assembly_checker.hpp"
 #include "vcf/assembly_report_writer.hpp"
 #include "vcf/string_constants.hpp"
-#include "util/logger.hpp"
 
 namespace
 {
@@ -44,21 +45,6 @@ namespace
         ;
 
         return description;
-    }
-
-    po::variables_map build_variables_map(int argc, char** argv, const po::options_description & desc)
-    {
-        po::variables_map vm;
-        po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
-        po::store(parsed,vm);
-        std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
-
-        for (auto & parameter: unrecognised_parameters) {
-            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << parameter;
-        }
-
-        po::notify(vm);
-        return vm;
     }
 
     int check_command_line_options(po::variables_map const & vm, po::options_description const & desc)
@@ -169,7 +155,7 @@ int main(int argc, char** argv)
     ebi::util::init_boost_loggers();
 
     po::options_description desc = build_command_line_options();
-    po::variables_map vm = build_variables_map(argc, argv, desc);
+    po::variables_map vm = ebi::util::build_variables_map(argc, argv, desc);
 
     int check_options = check_command_line_options(vm, desc);
     if (check_options < 0) { return 0; }

--- a/src/assembly_checker_main.cpp
+++ b/src/assembly_checker_main.cpp
@@ -53,8 +53,8 @@ namespace
         po::store(parsed,vm);
         std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
 
-        for (auto & a: unrecognised_parameters) {
-            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
+        for (auto & parameter: unrecognised_parameters) {
+            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << parameter;
         }
 
         po::notify(vm);

--- a/src/assembly_checker_main.cpp
+++ b/src/assembly_checker_main.cpp
@@ -74,26 +74,6 @@ namespace
         return 0;
     }
 
-    std::string get_output_path(const std::string &outdir, const std::string &file_path)
-    {
-        if (outdir == "") {
-            return file_path;
-        }
-
-        boost::filesystem::path file_boost_path{file_path};
-        boost::filesystem::path outdir_boost_path{outdir};
-        if (!boost::filesystem::exists(outdir_boost_path)) {
-            throw std::invalid_argument{"Directory not found: " + outdir_boost_path.string()};
-        }
-        if (!boost::filesystem::is_directory(outdir_boost_path)) {
-            throw std::invalid_argument{"outdir should be a directory, not a file: " + outdir_boost_path.string()};
-        }
-
-        outdir_boost_path /= file_boost_path.filename();
-
-        return outdir_boost_path.string();
-    }
-
     std::vector<std::unique_ptr<ebi::vcf::AssemblyReportWriter>> get_outputs(std::string const &output_str,
                                                                              std::string const &input)
     {
@@ -165,7 +145,7 @@ int main(int argc, char** argv)
         auto vcf_path = vm[ebi::vcf::INPUT].as<std::string>();
         auto fasta_path = vm[ebi::vcf::FASTA].as<std::string>();
         auto fasta_index_path = fasta_path + ".fai";
-        auto outdir = get_output_path(vm[ebi::vcf::OUTDIR].as<std::string>(), vcf_path);
+        auto outdir = ebi::util::get_output_path(vm[ebi::vcf::OUTDIR].as<std::string>(), vcf_path);
         auto outputs = get_outputs(vm[ebi::vcf::REPORT].as<std::string>(), outdir);
 
         BOOST_LOG_TRIVIAL(info) << "Reading from input FASTA file...";

--- a/src/debugulator_main.cpp
+++ b/src/debugulator_main.cpp
@@ -53,6 +53,21 @@ namespace
       return description;
   }
 
+  po::variables_map build_variables_map(int argc, char** argv, const po::options_description & desc)
+  {
+      po::variables_map vm;
+      po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
+      po::store(parsed,vm);
+      std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
+
+      for (auto & a: unrecognised_parameters) {
+          BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
+      }
+
+      po::notify(vm);
+      return vm;
+  }
+
   int check_command_line_options(po::variables_map const &vm, po::options_description const &desc)
   {
       if (vm.count(ebi::vcf::HELP)) {
@@ -86,12 +101,8 @@ int main(int argc, char **argv)
 {
     ebi::util::init_boost_loggers();
 
-    namespace po = boost::program_options;
-
     po::options_description desc = build_command_line_options();
-    po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+    po::variables_map vm = build_variables_map(argc, argv, desc);
 
     int check_options = check_command_line_options(vm, desc);
     if (check_options < 0) { return 0; }

--- a/src/debugulator_main.cpp
+++ b/src/debugulator_main.cpp
@@ -60,8 +60,8 @@ namespace
         po::store(parsed,vm);
         std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
 
-        for (auto & a: unrecognised_parameters) {
-            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
+        for (auto & parameter: unrecognised_parameters) {
+            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << parameter;
         }
 
         po::notify(vm);

--- a/src/debugulator_main.cpp
+++ b/src/debugulator_main.cpp
@@ -20,10 +20,11 @@
 #include <boost/program_options.hpp>
 
 #include "cmake_config.hpp"
+#include "util/cli_utils.hpp"
 #include "util/logger.hpp"
+#include "vcf/debugulator.hpp"
 #include "vcf/odb_report.hpp"
 #include "vcf/string_constants.hpp"
-#include "vcf/debugulator.hpp"
 
 namespace
 {
@@ -51,21 +52,6 @@ namespace
         ;
 
         return description;
-    }
-
-    po::variables_map build_variables_map(int argc, char** argv, const po::options_description & desc)
-    {
-        po::variables_map vm;
-        po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
-        po::store(parsed,vm);
-        std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
-
-        for (auto & parameter: unrecognised_parameters) {
-            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << parameter;
-        }
-
-        po::notify(vm);
-        return vm;
     }
 
     int check_command_line_options(po::variables_map const &vm, po::options_description const &desc)
@@ -102,7 +88,7 @@ int main(int argc, char **argv)
     ebi::util::init_boost_loggers();
 
     po::options_description desc = build_command_line_options();
-    po::variables_map vm = build_variables_map(argc, argv, desc);
+    po::variables_map vm = ebi::util::build_variables_map(argc, argv, desc);
 
     int check_options = check_command_line_options(vm, desc);
     if (check_options < 0) { return 0; }

--- a/src/debugulator_main.cpp
+++ b/src/debugulator_main.cpp
@@ -27,74 +27,74 @@
 
 namespace
 {
-  namespace po = boost::program_options;
+    namespace po = boost::program_options;
 
-  enum class ValidationLevel
-  {
-      error, warning, stop
-  };
+    enum class ValidationLevel
+    {
+        error, warning, stop
+    };
 
-  const std::string version_info = "vcf-debugulator version " + std::to_string(VERSION_MAJOR) + "."
-                                   + std::to_string(VERSION_MINOR);
+    const std::string version_info = "vcf-debugulator version " + std::to_string(VERSION_MAJOR) + "."
+                                     + std::to_string(VERSION_MINOR);
 
-  po::options_description build_command_line_options()
-  {
-      po::options_description description(version_info + "\n\nUsage: vcf-debugulator [OPTIONS] [< input_file]\nAllowed options");
+    po::options_description build_command_line_options()
+    {
+        po::options_description description(version_info + "\n\nUsage: vcf-debugulator [OPTIONS] [< input_file]\nAllowed options");
 
-      description.add_options()
-              (ebi::vcf::HELP_OPTION, "Display this help")
-              (ebi::vcf::VERSION_OPTION, "Display version of the debugulator")
-              (ebi::vcf::INPUT_OPTION, po::value<std::string>()->default_value(ebi::vcf::STDIN), "Path to the input VCF file, or stdin")
-              (ebi::vcf::ERRORS_OPTION, po::value<std::string>(), "Path to the errors report from the input VCF file")
-              (ebi::vcf::LEVEL_OPTION, po::value<std::string>()->default_value(ebi::vcf::WARNING_LEVEL), "Validation level (error, warning, stop)")
-              (ebi::vcf::OUTPUT_OPTION, po::value<std::string>()->default_value(ebi::vcf::STDOUT), "Write to a file or stdout")
-      ;
+        description.add_options()
+                (ebi::vcf::HELP_OPTION, "Display this help")
+                (ebi::vcf::VERSION_OPTION, "Display version of the debugulator")
+                (ebi::vcf::INPUT_OPTION, po::value<std::string>()->default_value(ebi::vcf::STDIN), "Path to the input VCF file, or stdin")
+                (ebi::vcf::ERRORS_OPTION, po::value<std::string>(), "Path to the errors report from the input VCF file")
+                (ebi::vcf::LEVEL_OPTION, po::value<std::string>()->default_value(ebi::vcf::WARNING_LEVEL), "Validation level (error, warning, stop)")
+                (ebi::vcf::OUTPUT_OPTION, po::value<std::string>()->default_value(ebi::vcf::STDOUT), "Write to a file or stdout")
+        ;
 
-      return description;
-  }
+        return description;
+    }
 
-  po::variables_map build_variables_map(int argc, char** argv, const po::options_description & desc)
-  {
-      po::variables_map vm;
-      po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
-      po::store(parsed,vm);
-      std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
+    po::variables_map build_variables_map(int argc, char** argv, const po::options_description & desc)
+    {
+        po::variables_map vm;
+        po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
+        po::store(parsed,vm);
+        std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
 
-      for (auto & a: unrecognised_parameters) {
-          BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
-      }
+        for (auto & a: unrecognised_parameters) {
+            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
+        }
 
-      po::notify(vm);
-      return vm;
-  }
+        po::notify(vm);
+        return vm;
+    }
 
-  int check_command_line_options(po::variables_map const &vm, po::options_description const &desc)
-  {
-      if (vm.count(ebi::vcf::HELP)) {
-          std::cout << desc << std::endl;
-          return -1;
-      }
+    int check_command_line_options(po::variables_map const &vm, po::options_description const &desc)
+    {
+        if (vm.count(ebi::vcf::HELP)) {
+            std::cout << desc << std::endl;
+            return -1;
+        }
 
-      if (vm.count(ebi::vcf::VERSION)) {
-          std::cout << version_info << std::endl;
-          return -1;
-      }
+        if (vm.count(ebi::vcf::VERSION)) {
+            std::cout << version_info << std::endl;
+            return -1;
+        }
 
-      std::string level = vm[ebi::vcf::LEVEL].as<std::string>();
-      if (level != ebi::vcf::ERROR_LEVEL && level != ebi::vcf::WARNING_LEVEL && level != ebi::vcf::STOP_LEVEL) {
-          std::cout << desc << std::endl;
-          BOOST_LOG_TRIVIAL(error) << "Please choose one of the accepted validation levels";
-          return 1;
-      }
+        std::string level = vm[ebi::vcf::LEVEL].as<std::string>();
+        if (level != ebi::vcf::ERROR_LEVEL && level != ebi::vcf::WARNING_LEVEL && level != ebi::vcf::STOP_LEVEL) {
+            std::cout << desc << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Please choose one of the accepted validation levels";
+            return 1;
+        }
 
-      if (!vm.count(ebi::vcf::ERRORS)) {
-          std::cout << desc << std::endl;
-          BOOST_LOG_TRIVIAL(error) << "Please specify the path to the errors report (--errors)";
-          return 1;
-      }
+        if (!vm.count(ebi::vcf::ERRORS)) {
+            std::cout << desc << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Please specify the path to the errors report (--errors)";
+            return 1;
+        }
 
-      return 0;
-  }
+        return 0;
+    }
 }
 
 int main(int argc, char **argv)

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -62,9 +62,9 @@ namespace
         po::variables_map vm;
         po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
         po::store(parsed,vm);
-        std::vector<std::string> unused_args = collect_unrecognized(parsed.options, po::include_positional);
+        std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
 
-        for (auto a: unused_args) {
+        for (auto & a: unrecognised_parameters) {
             BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
         }
 

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -14,25 +14,26 @@
  * limitations under the License.
  */
 
-#include <iostream>
+#include <chrono>
 #include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <stdexcept>
-#include <chrono>
-#include <iomanip>
 
 #include <boost/program_options.hpp>
 #include <boost/filesystem/operations.hpp>
 
 #include "cmake_config.hpp"
+#include "util/cli_utils.hpp"
 #include "util/logger.hpp"
 #include "vcf/file_structure.hpp"
-#include "vcf/validator.hpp"
-#include "vcf/report_writer.hpp"
 #include "vcf/odb_report.hpp"
+#include "vcf/report_writer.hpp"
 #include "vcf/summary_report_writer.hpp"
+#include "vcf/validator.hpp"
 
 namespace
 {
@@ -55,21 +56,6 @@ namespace
         ;
 
         return description;
-    }
-
-    po::variables_map build_variables_map(int argc, char** argv, const po::options_description & desc)
-    {
-        po::variables_map vm;
-        po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
-        po::store(parsed,vm);
-        std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
-
-        for (auto & parameter: unrecognised_parameters) {
-            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << parameter;
-        }
-
-        po::notify(vm);
-        return vm;
     }
 
     int check_command_line_options(po::variables_map const & vm, po::options_description const & desc)
@@ -175,7 +161,7 @@ int main(int argc, char** argv)
     ebi::util::init_boost_loggers();
 
     po::options_description desc = build_command_line_options();
-    po::variables_map vm = build_variables_map(argc, argv, desc);
+    po::variables_map vm = ebi::util::build_variables_map(argc, argv, desc);
     int check_options = check_command_line_options(vm, desc);
     if (check_options < 0) { return 0; }
     if (check_options > 0) { return check_options; }

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -160,15 +160,20 @@ int main(int argc, char** argv)
 
     po::options_description desc = build_command_line_options();
     po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+    po::parsed_options parsed = po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
+    po::store(parsed,vm);
+    std::vector<std::string> unused_args = collect_unrecognized(parsed.options, po::include_positional);
 
+    for (auto a: unused_args) {
+        BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
+    }
+
+    po::notify(vm);
     int check_options = check_command_line_options(vm, desc);
     if (check_options < 0) { return 0; }
     if (check_options > 0) { return check_options; }
 
     bool is_valid;
-
     try {
         auto path = vm[ebi::vcf::INPUT].as<std::string>();
         auto level = vm[ebi::vcf::LEVEL].as<std::string>();

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -93,26 +93,6 @@ namespace
         throw std::invalid_argument{"Please choose one of the accepted validation levels"};
     }
 
-    std::string get_output_path(const std::string &outdir, const std::string &file_path)
-    {
-        if (outdir == "") {
-            return file_path;
-        }
-
-        boost::filesystem::path file_boost_path{file_path};
-        boost::filesystem::path outdir_boost_path{outdir};
-        if (!boost::filesystem::exists(outdir_boost_path)) {
-            throw std::invalid_argument{"Directory not found: " + outdir_boost_path.string()};
-        }
-        if (!boost::filesystem::is_directory(outdir_boost_path)) {
-            throw std::invalid_argument{"outdir should be a directory, not a file: " + outdir_boost_path.string()};
-        }
-
-        outdir_boost_path /= file_boost_path.filename();
-
-        return outdir_boost_path.string();
-    }
-
     std::vector<std::unique_ptr<ebi::vcf::ReportWriter>> get_outputs(std::string const &output_str, std::string const &input)
     {
         std::vector<std::string> outs;
@@ -171,7 +151,7 @@ int main(int argc, char** argv)
         auto path = vm[ebi::vcf::INPUT].as<std::string>();
         auto level = vm[ebi::vcf::LEVEL].as<std::string>();
         ebi::vcf::ValidationLevel validationLevel = get_validation_level(level);
-        auto outdir = get_output_path(vm[ebi::vcf::OUTDIR].as<std::string>(), path);
+        auto outdir = ebi::util::get_output_path(vm[ebi::vcf::OUTDIR].as<std::string>(), path);
         auto outputs = get_outputs(vm[ebi::vcf::REPORT].as<std::string>(), outdir);
 
         if (path == ebi::vcf::STDIN) {

--- a/src/validator_main.cpp
+++ b/src/validator_main.cpp
@@ -64,8 +64,8 @@ namespace
         po::store(parsed,vm);
         std::vector<std::string> unrecognised_parameters = collect_unrecognized(parsed.options, po::include_positional);
 
-        for (auto & a: unrecognised_parameters) {
-            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << a;
+        for (auto & parameter: unrecognised_parameters) {
+            BOOST_LOG_TRIVIAL(warning) << "unused parameter: " << parameter;
         }
 
         po::notify(vm);


### PR DESCRIPTION
This PR is to fix #165. vcf_validator will show a warning if any of the parameters went unused or unrecognised. 
```
$ ./vcf_validator -i a.vcf -r summary, text
[warning] unused parameter: text
[info] Reading from input file...
[info] Summary report written to : stdin.errors_summary.1537119684362.txt
[info] According to the VCF specification, the input file is not valid

```