### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ cache:
 jobs:
   include:
 
+    - stage: "Compile and Test"
     # OS X Clang
-    - stage: "Supported Platforms and Compilers"
       os: osx
       osx_image: xcode9.3
       env: C_COMPILER=clang CXX_COMPILER=clang++
@@ -128,21 +128,30 @@ jobs:
             - ninja-build
 
     - stage: "Release Builds"
+      # OSX Release
+      os: osx
+      osx_image: xcode9.3
+      env: C_COMPILER=clang CXX_COMPILER=clang++
+      before_install:
+        - brew install ninja
       if: tag IS present
       deploy:
         provider: releases
         api_key: $GITHUB_TOKEN
         file:
-            - bin/vcf_validator_linux
-            - bin/vcf_debugulator_linux
-            - bin/vcf_assembly_checker_linux
+            - bin/vcf_validator_macos
+            - bin/vcf_debugulator_macos
+            - bin/vcf_assembly_checker_macos
         skip_cleanup: true
         on:
             repo: EBIvariation/vcf-validator
             tags: true
-      os: linux
+
+      # Linux Release
+    - os: linux
       compiler: gcc
       env: C_COMPILER=gcc-6 CXX_COMPILER=g++-6
+      if: tag IS present
       addons:
         apt:
           sources:
@@ -158,24 +167,17 @@ jobs:
             - libboost-regex1.55-dev
             - libboost-log1.55-dev
             - ninja-build
-
-    - if: tag IS present
       deploy:
         provider: releases
         api_key: $GITHUB_TOKEN
         file:
-            - bin/vcf_validator_macos
-            - bin/vcf_debugulator_macos
-            - bin/vcf_assembly_checker_macos
+            - bin/vcf_validator_linux
+            - bin/vcf_debugulator_linux
+            - bin/vcf_assembly_checker_linux
         skip_cleanup: true
         on:
             repo: EBIvariation/vcf-validator
             tags: true
-      os: osx
-      osx_image: xcode9.3
-      env: C_COMPILER=clang CXX_COMPILER=clang++
-      before_install:
-        - brew install ninja
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ jobs:
   include:
 
     # OS X Clang
-    - os: osx
+    - stage: "Supported Platforms and Compilers"
+      os: osx
       osx_image: xcode9.3
       env: C_COMPILER=clang CXX_COMPILER=clang++
       before_install:
@@ -126,7 +127,8 @@ jobs:
             - libboost-log1.55-dev
             - ninja-build
 
-    - stage: "Linux release"
+    - stage: "Release Builds"
+      if: tag IS present
       deploy:
         provider: releases
         api_key: $GITHUB_TOKEN
@@ -156,7 +158,8 @@ jobs:
             - libboost-regex1.55-dev
             - libboost-log1.55-dev
             - ninja-build
-    - stage: "Mac release"
+
+    - if: tag IS present
       deploy:
         provider: releases
         api_key: $GITHUB_TOKEN


### PR DESCRIPTION
This PR aims to simplify the travis build. earlier the travis used to run release-builds for non-tagged branches too. After this PR the travis will run release builds only for tagged commits saving lot of time on every build.