### PR TITLE
EVA-1899 - Fix GT handling for CN variants + fix stoi handling in other places

### DIFF
--- a/src/vcf/record.cpp
+++ b/src/vcf/record.cpp
@@ -417,16 +417,16 @@ namespace ebi
                 } else {
                     std::string first_field = alternate_alleles[i].substr(0, 4);
                     if (first_field == "<" + INS || first_field == "<" + DUP) {
-			size_t scanned_value_length;
-			int value = std::stoi(values[i], &scanned_value_length);
-                        if (value < 0 || scanned_value_length != values[i].size()) {
+                    size_t scanned_value_length;
+                    int value = std::stoi(values[i], &scanned_value_length);
+                                if (value < 0 || scanned_value_length != values[i].size()) {
                             throw new InfoBodyError{line, "INFO SVLEN must be a positive integer for longer ALT alleles", "SVLEN="
                                     + field_value + ", ALT allele=" + first_field.substr(1, 3),
                                     ErrorFix::IRRECOVERABLE_VALUE, field_key};
                         }
                     } else if (first_field == "<" + DEL) {
-			size_t scanned_value_length;
-			int value = std::stoi(values[i], &scanned_value_length);
+                        size_t scanned_value_length;
+                        int value = std::stoi(values[i], &scanned_value_length);
                         if (value > 0 || scanned_value_length != values[i].size()) {
                             throw new InfoBodyError{line, "INFO SVLEN must be a negative integer for shorter ALT alleles"
                                     + first_field.substr(1,3), "SVLEN=" + field_value + ", ALT allele=" + first_field.substr(1, 3),
@@ -665,7 +665,7 @@ namespace ebi
         } else {
             // ...specified as a number in range [0, +MAX_LONG)
             try {
-		size_t scanned_number_length;
+                size_t scanned_number_length;
                 expected_cardinality = stoi(number, &scanned_number_length);
                 if (expected_cardinality < 0 || number.size() != scanned_number_length) {
                     expected_cardinality = -1;
@@ -727,9 +727,9 @@ namespace ebi
     void Record::check_value_type(std::string const & type, std::string const & value, std::string & message) const {
         if (type == INTEGER) {
             // ...try to cast to int
-	    std::size_t scanned_value_length;
+            std::size_t scanned_value_length;
             std::stoi(value, &scanned_value_length);
-	    if (value.size() != scanned_value_length) {
+            if (value.size() != scanned_value_length) {
                 message = " (not in integer format)";
                 throw std::invalid_argument(message);
             }
@@ -747,7 +747,7 @@ namespace ebi
                 std::stold(value);
             }
         } else if (type == FLAG) {
-	    size_t scanned_value_length;
+            size_t scanned_value_length;
             int numeric_value = std::stoi(value, &scanned_value_length);
             if (value.size() != scanned_value_length || value.size() > 1 || (numeric_value != 0 && numeric_value != 1)) {
                 message = " (a flag value must be \"0, 1 or none\")";
@@ -788,8 +788,8 @@ namespace ebi
         }
         for (auto & value : values) {
             if (value == MISSING_VALUE) { continue; }
-	    size_t scanned_value_length;
-	    int numeric_value = std::stoi(value, &scanned_value_length);
+            size_t scanned_value_length;
+            int numeric_value = std::stoi(value, &scanned_value_length);
             if (value.size() != scanned_value_length || numeric_value < 0) {
                 raise(std::make_shared<Error>(line, field + " value must be a non-negative integer number"));
             }

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -189,11 +189,11 @@ namespace ebi
             if (it != record.info.end()) {
                 std::vector<std::string> values;
                 util::string_split(it->second, ",", values);
-		size_t scanned_first_value_length, scanned_second_value_length;
-		int first_numeric_value = std::stoi(values[0], &scanned_first_value_length);
-		int second_numeric_value = std::stoi(values[1], &scanned_second_value_length);
-                if (first_numeric_value > 0 || second_numeric_value < 0 || 
-			values[0].size() != scanned_first_value_length || values[1].size() != scanned_second_value_length) {
+                size_t scanned_first_value_length, scanned_second_value_length;
+                int first_numeric_value = std::stoi(values[0], &scanned_first_value_length);
+                int second_numeric_value = std::stoi(values[1], &scanned_second_value_length);
+                if (first_numeric_value > 0 || second_numeric_value < 0 
+                    || values[0].size() != scanned_first_value_length || values[1].size() != scanned_second_value_length) {
                     throw new InfoBodyError{state.n_lines,
                             "INFO " + confidence_interval_tag +
                             " is a confidence interval tag, which should have first value <= 0 and second value >= 0"};

--- a/src/vcf/validate_optional_policy.cpp
+++ b/src/vcf/validate_optional_policy.cpp
@@ -189,7 +189,11 @@ namespace ebi
             if (it != record.info.end()) {
                 std::vector<std::string> values;
                 util::string_split(it->second, ",", values);
-                if (std::stoi(values[0]) > 0 || std::stoi(values[1]) < 0) {
+		size_t scanned_first_value_length, scanned_second_value_length;
+		int first_numeric_value = std::stoi(values[0], &scanned_first_value_length);
+		int second_numeric_value = std::stoi(values[1], &scanned_second_value_length);
+                if (first_numeric_value > 0 || second_numeric_value < 0 || 
+			values[0].size() != scanned_first_value_length || values[1].size() != scanned_second_value_length) {
                     throw new InfoBodyError{state.n_lines,
                             "INFO " + confidence_interval_tag +
                             " is a confidence interval tag, which should have first value <= 0 and second value >= 0"};

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -46,7 +46,7 @@ namespace ebi
                 },
                 source
         });
-           
+	
         source->meta_entries.emplace(vcf::FORMAT,
             vcf::MetaEntry{
                 1,
@@ -581,6 +581,19 @@ namespace ebi
                 },
                 source
         });
+	
+	source->meta_entries.emplace(vcf::FORMAT,
+            vcf::MetaEntry{
+                1,
+                vcf::FORMAT,
+                {
+                    { vcf::ID, vcf::CN },
+                    { vcf::NUMBER, "1" },
+                    { vcf::TYPE, vcf::INTEGER },
+                    { vcf::DESCRIPTION, "Copy Number Genotype" }
+                },
+                source
+        });
            
         source->meta_entries.emplace(vcf::FORMAT,
             vcf::MetaEntry{
@@ -842,6 +855,21 @@ namespace ebi
                             { {vcf::AN, "12"}, { vcf::AF, "0.5,0.3"} },
                             { vcf::GT, vcf::DP },
                             { "0|1:tags" },
+                            source}),
+                        vcf::SamplesFieldBodyError*);
+	    
+	    CHECK_THROWS_AS( (vcf::Record{
+                            1,
+                            "chr1",
+                            123456,
+                            { "id123", "id456" },
+                            "A",
+                            { "AC", "AT" },
+                            1.0,
+                            { vcf::PASS },
+                            { {vcf::AN, "12"}, { vcf::AF, "0.5,0.3"} },
+                            { vcf::CN },
+                            { "0" },
                             source}),
                         vcf::SamplesFieldBodyError*);
 

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -581,8 +581,8 @@ namespace ebi
                 },
                 source
         });
-	
-	source->meta_entries.emplace(vcf::FORMAT,
+
+        source->meta_entries.emplace(vcf::FORMAT,
             vcf::MetaEntry{
                 1,
                 vcf::FORMAT,
@@ -593,7 +593,7 @@ namespace ebi
                     { vcf::DESCRIPTION, "Copy Number Genotype" }
                 },
                 source
-        });
+            });
            
         source->meta_entries.emplace(vcf::FORMAT,
             vcf::MetaEntry{
@@ -857,8 +857,9 @@ namespace ebi
                             { "0|1:tags" },
                             source}),
                         vcf::SamplesFieldBodyError*);
-	    
-	    CHECK_THROWS_AS( (vcf::Record{
+
+            // Copy number genotypes should have a genotype representation with just an Integer
+            CHECK_THROWS_AS((vcf::Record{
                             1,
                             "chr1",
                             123456,
@@ -869,9 +870,10 @@ namespace ebi
                             { vcf::PASS },
                             { {vcf::AN, "12"}, { vcf::AF, "0.5,0.3"} },
                             { vcf::CN },
-                            { "0" },
-                            source}),
-                        vcf::SamplesFieldBodyError*);
+                            { "0|0" },
+                            source }),
+                            vcf::SamplesFieldBodyError*);
+	  
 
             CHECK_THROWS_AS( (vcf::Record{
                             1,

--- a/test/vcf/record_test.cpp
+++ b/test/vcf/record_test.cpp
@@ -46,7 +46,7 @@ namespace ebi
                 },
                 source
         });
-	
+
         source->meta_entries.emplace(vcf::FORMAT,
             vcf::MetaEntry{
                 1,
@@ -873,7 +873,7 @@ namespace ebi
                             { "0|0" },
                             source }),
                             vcf::SamplesFieldBodyError*);
-	  
+
 
             CHECK_THROWS_AS( (vcf::Record{
                             1,


### PR DESCRIPTION
[Fix high-level Integer checking](https://github.com/EBIvariation/vcf-validator/pull/199/files#diff-b7ed7bfe2cd51f747bc5f560a4647ee3R730) to ensure that strings like "1A" parsed by stoi to a number like "1" are not accepted as it is. 

The other stoi code updates are purely from a "defensive coding" perspective because there are other checks like [this](https://github.com/EBIvariation/vcf-validator/pull/199/files#diff-b7ed7bfe2cd51f747bc5f560a4647ee3R420) which are not absolutely necessary because such checks are superseded by the high-level integer checking described above.