### PR TITLE
Detected compression format now a debug message instead of warning

### DIFF
--- a/src/vcf/compression.cpp
+++ b/src/vcf/compression.cpp
@@ -85,7 +85,7 @@ namespace ebi
 
     void compressed_file_warning(std::string const & file_extension)
     {
-        BOOST_LOG_TRIVIAL(warning) << "Detected " << file_extension
+        BOOST_LOG_TRIVIAL(debug) << "Detected " << file_extension
             << " compression";
     }
 


### PR DESCRIPTION
As mentioned in https://github.com/EBIvariation/vcf-validator/pull/117#issuecomment-628762553, compressed files are now read correctly and there is no point in raising that as a warning, but more as a debug message.