### PR TITLE
EVA-1731 - Fix/validate assembly checker parameters

### DIFF
--- a/inc/util/curl_easy.hpp
+++ b/inc/util/curl_easy.hpp
@@ -43,6 +43,19 @@ namespace ebi
         CURL* curlHandle;
         void processCurlRequest(const std::string &basicString, long &code);
       };
+
+      class URLRetrievalException : public std::exception {
+      private:
+        std::string message = " ";
+      public:
+        URLRetrievalException(const std::string &url, long &httpReturnCode) {
+            message = "HTTP " + std::to_string(httpReturnCode) + " returned when downloading: " + url;
+        }
+
+        const char *what() const noexcept override {
+            return message.c_str();
+        }
+      };
     }
   }
 }

--- a/inc/util/curl_easy.hpp
+++ b/inc/util/curl_easy.hpp
@@ -36,11 +36,12 @@ namespace ebi
         Easy& operator=(const Easy&) = delete;
         ~Easy();
 
-        std::string request(const std::string& url);
-        std::ostream& request(std::ostream& stream, const std::string& url);
+        std::string request(const std::string& url, long& httpReturnCode);
+        std::ostream& request(std::ostream& stream, const std::string& url, long& httpReturnCode);
 
       private:
         CURL* curlHandle;
+        void processCurlRequest(const std::string &basicString, long &code);
       };
     }
   }

--- a/inc/util/file_utils.hpp
+++ b/inc/util/file_utils.hpp
@@ -31,19 +31,6 @@ namespace ebi
 {
   namespace util
   {
-    class URLRetrievalException : public std::exception {
-          private:
-              std::string message = " ";
-          public:
-              URLRetrievalException(const std::string& url, long& httpReturnCode)
-              {
-                  message = "HTTP " + std::to_string(httpReturnCode) + " returned when downloading: " + url;
-              }
-              const char* what() const noexcept override
-              {
-                  return message.c_str();
-              }
-    };
     inline void open_file(std::ifstream & input,
                           std::string path,
                           std::ios_base::openmode mode = std::ios_base::in)
@@ -67,7 +54,7 @@ namespace ebi
         long httpReturnCode;
         curl.request(stream, url, httpReturnCode);
         if (httpReturnCode != 200) {
-            throw ebi::util::URLRetrievalException(url, httpReturnCode);
+            throw ebi::util::curl::URLRetrievalException(url, httpReturnCode);
         }
         return stream;
     }

--- a/inc/util/file_utils.hpp
+++ b/inc/util/file_utils.hpp
@@ -31,7 +31,19 @@ namespace ebi
 {
   namespace util
   {
-
+    class ContigNotFoundInENAException : public std::exception {
+          private:
+              std::string message = " ";
+          public:
+              ContigNotFoundInENAException(const std::string& url, long& httpReturnCode)
+              {
+                  message = "HTTP " + std::to_string(httpReturnCode) + " returned when downloading: " + url;
+              }
+              const char* what() const noexcept override
+              {
+                  return message.c_str();
+              }
+    };
     inline void open_file(std::ifstream & input,
                           std::string path,
                           std::ios_base::openmode mode = std::ios_base::in)
@@ -52,7 +64,12 @@ namespace ebi
         }
 
         ebi::util::curl::Easy curl;
-        return curl.request(stream, url);
+        long httpReturnCode;
+        curl.request(stream, url, httpReturnCode);
+        if (httpReturnCode != 200) {
+            throw ebi::util::ContigNotFoundInENAException(url, httpReturnCode);
+        }
+        return stream;
     }
 
   }

--- a/inc/util/file_utils.hpp
+++ b/inc/util/file_utils.hpp
@@ -31,11 +31,11 @@ namespace ebi
 {
   namespace util
   {
-    class ContigNotFoundInENAException : public std::exception {
+    class URLRetrievalException : public std::exception {
           private:
               std::string message = " ";
           public:
-              ContigNotFoundInENAException(const std::string& url, long& httpReturnCode)
+              URLRetrievalException(const std::string& url, long& httpReturnCode)
               {
                   message = "HTTP " + std::to_string(httpReturnCode) + " returned when downloading: " + url;
               }
@@ -67,7 +67,7 @@ namespace ebi
         long httpReturnCode;
         curl.request(stream, url, httpReturnCode);
         if (httpReturnCode != 200) {
-            throw ebi::util::ContigNotFoundInENAException(url, httpReturnCode);
+            throw ebi::util::URLRetrievalException(url, httpReturnCode);
         }
         return stream;
     }

--- a/src/vcf/assembly_checker.cpp
+++ b/src/vcf/assembly_checker.cpp
@@ -233,7 +233,7 @@ namespace ebi
                   try {
                       fasta->sequence(contig_name, 0, 1); // trigger download
                   }
-                  catch(ebi::util::ContigNotFoundInENAException ex) {
+                  catch(ebi::util::URLRetrievalException ex) {
                       report_missing_chromosome_in_ENA(line_num, ex.what(), record_core, outputs);
                       is_valid = false;
                       continue;

--- a/test/fasta/fasta_test.cpp
+++ b/test/fasta/fasta_test.cpp
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "catch/catch.hpp"
-
+#include "util/curl_easy.hpp"
 #include "fasta/fasta.hpp"
 
 namespace ebi
@@ -114,7 +114,7 @@ namespace ebi
       {
           std::unique_ptr<ebi::vcf::fasta::IFasta> fasta(new ebi::vcf::fasta::RemoteContig());
           CHECK_NOTHROW(fasta->sequence("DQ083950", 0, 1));
-          CHECK_NOTHROW(fasta->sequence("Non-existing", 0, 1));
+          CHECK_THROWS_AS(fasta->sequence("Non-existing", 0, 1), ebi::util::curl::URLRetrievalException);
 
           CHECK(fasta->sequence_exists("DQ083950"));
           CHECK(fasta->sequence_exists("Non-existing"));


### PR DESCRIPTION
This PR addresses 2 issues:

- Report an error if an ENA contig could not be retrieved
- Report errors if compressed FASTA files or assembly reports are passed as parameters