### PR TITLE
Parse assigned molecule in assembly report

### DIFF
--- a/inc/assembly_report/assembly_report.hpp
+++ b/inc/assembly_report/assembly_report.hpp
@@ -164,7 +164,7 @@ namespace ebi
 
         ContigSynonyms extract_synonyms(std::vector<std::string> & synonyms)
         {
-            std::vector<int> synonym_indices{0, 4, 6, 9};
+            std::vector<int> synonym_indices{0, 2, 4, 6, 9};
             ContigSynonyms contig_synonyms;
             for (auto index : synonym_indices) {
                 if (ignore_contig.find(synonyms[index]) != ignore_contig.end()) {

--- a/test/input_files/assembly_report/assembly_report.txt
+++ b/test/input_files/assembly_report/assembly_report.txt
@@ -1,3 +1,4 @@
 # Sequence-Name	Sequence-Role	Assigned-Molecule	Assigned-Molecule-Location/Type	GenBank-Accn	Relationship	RefSeq-Accn	Assembly-Unit	Sequence-Length	UCSC-style-name
 chr1	assembled-molecule	1	Chromosome	CM000072.5	=	NC_005100.4	Primary Assembly	282763074	1
-chr2	assembled-molecule	1	Chromosome	CM000082.5	=	NC_005300.4	Primary Assembly	282763044	2
+chr2	assembled-molecule	2	Chromosome	CM000082.5	=	NC_005300.4	Primary Assembly	282763044	2
+chr2Q	assembled-molecule	2	Chromosome	CM000092.5	=	NC_005500.4	Primary Assembly	282763044	2Q

--- a/test/input_files/assembly_report/assembly_report.txt
+++ b/test/input_files/assembly_report/assembly_report.txt
@@ -1,4 +1,4 @@
 # Sequence-Name	Sequence-Role	Assigned-Molecule	Assigned-Molecule-Location/Type	GenBank-Accn	Relationship	RefSeq-Accn	Assembly-Unit	Sequence-Length	UCSC-style-name
-chr1	assembled-molecule	1	Chromosome	CM000072.5	=	NC_005100.4	Primary Assembly	282763074	1
-chr2	assembled-molecule	2	Chromosome	CM000082.5	=	NC_005300.4	Primary Assembly	282763044	2
-chr2Q	assembled-molecule	2	Chromosome	CM000092.5	=	NC_005500.4	Primary Assembly	282763044	2Q
+Chr1	assembled-molecule	1	Chromosome	CM000072.5	=	NC_005100.4	Primary Assembly	282763074	chr1
+Chr2	assembled-molecule	2	Chromosome	CM000082.5	=	NC_005300.4	Primary Assembly	282763044	chr2
+Chr2Q	assembled-molecule	2	Chromosome	CM000092.5	=	NC_005500.4	Primary Assembly	282763044	chr2Q


### PR DESCRIPTION
Allow the Assembly checker to use assigned molecule as a source of name.