### PR TITLE
Add Dockerized build for amd64/arm64 architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ bin/
 *.app
 
 # Construction
-Makefile
 .ninja_*
 *.ninja
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN if [ "$(uname -m)" = "x86_64" ] ; then \
        cd / && patch -p1 < /gcc-x86.patch && rm /gcc-x86.patch; \
     fi
 
-# build2 https://build2.org/install.xhtml#unix
+# build2 fetch https://build2.org/install.xhtml#unix
 # This is required to build the latest version of odb, which has multi-arch support
 RUN set -eux; \
     url="https://download.build2.org/${BUILD2_VERSION}/build2-install-${BUILD2_VERSION}.sh"; \
@@ -65,8 +65,10 @@ RUN set -eux; \
     mkdir -p /build/build2; \
     cd /build/build2; \
     curl -sSfO "$url"; \
-    echo "$sha256  build2-install-${BUILD2_VERSION}.sh" | sha256sum -cw -; \
-    sh build2-install-${BUILD2_VERSION}.sh --local --yes
+    echo "$sha256  build2-install-${BUILD2_VERSION}.sh" | sha256sum -cw -;
+
+# build2 compilation
+RUN cd /build/build2 && sh build2-install-${BUILD2_VERSION}.sh --local --yes
 
 # odb binary https://codesynthesis.com/products/odb/doc/install-build2.xhtml
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,150 @@
+# This is a image for building vcf_validator tool.  The resulting binary is staticly linked,
+# so it is portable to other linux variants.
+#
+# Notable changes from simply using install_dependencie.sh:
+#
+#   + using odb v2.6.0-b.23 as that has adjustments so can compile on arm64
+#   + building odb via build2
+#   + had to add '-Wno-narrowing' to compilation step to avoid errors (doesn't appear to break anything; test pass)
+#   + libz, libbz2, libboost-* installed via apt
+
+FROM debian:11-slim as build
+
+ARG VCF_VALIDATOR_VERSION
+ARG ODB_VERSION=2.5.0-b.23
+ARG BUILD2_VERSION=0.15.0
+
+# Linux tools 
+RUN apt-get update && apt-get upgrade --yes && \
+    apt-get install --yes \
+        bash \
+        binutils-gold \
+        build-essential \
+        bzip2 \
+        cmake \
+        curl \
+        file \
+        findutils \
+        g++ \
+        gcc \
+        gcc-10-plugin-dev \
+        git \
+        libboost-dev \
+        libboost-filesystem-dev \
+        libboost-iostreams-dev \
+        libboost-program-options-dev \
+        libboost-regex-dev \
+        libboost-log-dev \
+        libc-dev \
+        libbz2-dev \
+        libgmp-dev \
+        libffi-dev \
+        libsqlite3-0 \
+        libsqlite3-dev \
+        make \
+        musl-dev \
+        perl \
+        ripgrep \
+        sqlite3 \
+        sudo \
+        vim \
+        wget  \
+        zlib1g-dev
+
+# Patch x86 bug (missing header file) https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=980609
+COPY docker/gcc-x86.patch /gcc-x86.patch
+RUN if [ "$(uname -m)" = "x86_64" ] ; then \
+       cd / && patch -p1 < /gcc-x86.patch && rm /gcc-x86.patch; \
+    fi
+
+# build2 https://build2.org/install.xhtml#unix
+# This is required to build the latest version of odb, which has multi-arch support
+RUN set -eux; \
+    url="https://download.build2.org/${BUILD2_VERSION}/build2-install-${BUILD2_VERSION}.sh"; \
+    sha256='814c4f475b42749dab49c52549ef85899749c20e5c32276b281fd58dad54f47b'; \
+    mkdir -p /build/build2; \
+    cd /build/build2; \
+    curl -sSfO "$url"; \
+    echo "$sha256  build2-install-${BUILD2_VERSION}.sh" | sha256sum -cw -; \
+    sh build2-install-${BUILD2_VERSION}.sh --local --yes
+
+# odb binary https://codesynthesis.com/products/odb/doc/install-build2.xhtml
+RUN set -eux; \
+    mkdir -p /build/odb; \
+    cd /build/odb; \
+    bpkg create -d odb-gcc-10 cc  \
+         config.cxx=g++ \
+         config.cc.coptions=-O3 \
+         config.install.root=/usr/local \
+         config.install.sudo=sudo; \
+    cd odb-gcc-10; \
+    bpkg --trust-yes build odb/${ODB_VERSION}@https://pkg.cppget.org/1/beta --yes; \
+    bpkg install odb
+
+# odb library
+RUN set -eux; \
+    cd /build/odb; \
+    bpkg create -d libodb-gcc-10 cc  \
+         config.cxx=g++ \
+         config.cc.coptions=-O3 \
+         config.install.root=/usr/local \
+         config.install.sudo=sudo; \
+    cd libodb-gcc-10; \
+    bpkg add https://pkg.cppget.org/1/beta ;\
+    bpkg --trust-yes fetch ;\
+    bpkg --trust-yes build libodb/${ODB_VERSION} ;\
+    bpkg --trust-yes build libodb-sqlite/${ODB_VERSION} --yes ;\
+    bpkg --trust-yes build libodb-boost/${ODB_VERSION} ;\
+    bpkg install --all --recursive
+
+# vcf_validator https://github.com/EBIvariation/vcf-validator/tree/v0.9.4
+RUN cd /build && \
+    git clone --depth 1 --branch v${VCF_VALIDATOR_VERSION} https://github.com/EBIvariation/vcf-validator.git
+
+# FYI: Alternative to above - copy current working dir:
+#COPY . /build/vcf-validator
+
+# copy + run our modified install-dependencies-docker.sh script
+COPY docker/install-dependencies-docker.sh /build/vcf-validator/install-dependencies-docker.sh
+RUN cd /build/vcf-validator &&  ./install-dependencies-docker.sh
+
+# Fix path to odb, add -Wno-narrowing to enable build to work
+# we put everything in the root of EXT_LIB_PATH (linux_dependencies)
+RUN sed -i -e 's|${EXT_LIB_PATH}/odb-2.4.0-x86_64-linux-gnu/bin/|/usr/local/bin/|' \
+           -e 's|-Wall -Wno-unknown-pragmas|-Wall -Wno-unknown-pragmas -Wno-narrowing|' \
+        /build/vcf-validator/CMakeLists.txt
+
+# Fix ODB_VERSION since we are using latest
+RUN sed -i -e 's|ODB_VERSION != 20400UL|ODB_VERSION != 20473UL|' \
+        /build/vcf-validator/inc/vcf/error-odb.hpp
+
+# Copy libraries to the place the CMakeLists.txt expects them
+RUN arch=$(uname -m); \
+    cd /build/vcf-validator/linux_dependencies; \
+    cp /usr/local/lib/*.a .; \
+    cp /usr/lib/${arch}-linux-gnu/*.a .;
+
+# Build vcf and validate build worked with 'make test'
+RUN set -eux; \
+    cd /build/vcf-validator; \
+    mkdir build && cd build && cmake -G "Unix Makefiles" ..; \
+    make; \
+    ln -s ../test test; \
+    CTEST_OUTPUT_ON_FAILURE=1 make test;
+
+# Copy binaries to root
+RUN cd /build/vcf-validator/build; \
+    cp bin/vcf_validator /; \
+    cp bin/vcf_debugulator /; \
+    cp bin/vcf_assembly_checker /; \
+    cp bin/test_validation_suite /;
+
+# Since it is statically linked, can have just the executables in the final image
+FROM scratch
+
+COPY --from=build /vcf_validator /
+COPY --from=build /vcf_debugulator /
+COPY --from=build /vcf_assembly_checker /
+COPY --from=build /test_validation_suite /
+
+ENTRYPOINT ["/vcf_validator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Notable changes from simply using install_dependencie.sh:
 #
-#   + using odb v2.6.0-b.23 as that has adjustments so can compile on arm64
+#   + using odb v2.5.0-b.23 as that has adjustments so can compile on arm64
 #   + building odb via build2
 #   + had to add '-Wno-narrowing' to compilation step to avoid errors (doesn't appear to break anything; test pass)
 #   + libz, libbz2, libboost-* installed via apt
@@ -106,7 +106,7 @@ RUN cd /build && \
 
 # copy + run our modified install-dependencies-docker.sh script
 COPY docker/install-dependencies-docker.sh /build/vcf-validator/install-dependencies-docker.sh
-RUN cd /build/vcf-validator &&  ./install-dependencies-docker.sh
+RUN cd /build/vcf-validator && ./install-dependencies-docker.sh
 
 # Fix path to odb, add -Wno-narrowing to enable build to work
 # we put everything in the root of EXT_LIB_PATH (linux_dependencies)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build: require_repo_name
 		--pull --tag $(TAG) .
 
 # common setup for buildx tasks
-buildx-setup: require_repo_name
+buildx-setup:
 	@echo "Current buildx builders:"
 	$(DOCKER) buildx ls
 	@if ! $(DOCKER) buildx inspect --builder $(BUILDER) > /dev/null 2>&1; then \
@@ -48,9 +48,12 @@ buildx-setup: require_repo_name
 ## buildx-publish: build and publish the multi-architecture image (amd64|arm64)
 buildx-publish: require_repo_name buildx-setup
 	@echo '=> Build and publish multi-arch image $(TAG)...'
+	# cache is used to make re-building faster on same machine (useful during development)
 	$(DOCKER) buildx build --file Dockerfile \
 		--platform $(PLATFORMS) \
 		--builder $(BUILDER) \
 		--build-arg VCF_VALIDATOR_VERSION=$(VCF_VALIDATOR_VERSION) \
 		--progress plain \
+		--cache-from type=local,src=/tmp/vcf-validator-docker-cache,mode=max \
+		--cache-to type=local,dest=/tmp/vcf-validator-docker-cache,mode=max \
 		--pull --push --tag $(TAG) .

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+# Makefile for creating vcf-validator Docker image
+#
+
+# 1st item is default, so 'make' with no arguments shows help
+## help: show this help message
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' | sed -e 's/^/ /' | sort
+
+# define docker to run using BUILDKIT features
+DOCKER = DOCKER_BUILDKIT=1 docker
+
+# Platforms defaults to amd64 and arm64, but one can override at runtime (e.g., PLATFORMS=linux/amd64 make xxx)
+PLATFORMS ?= linux/amd64,linux/arm64
+
+# Set buildx builder
+BUILDER ?= builder-local
+
+# vcf-validator version (assumed to be a git tag)
+VCF_VALIDATOR_VERSION ?= 0.9.4
+
+# TAG
+TAG = $(REPO_NAME)/vcf-validator:$(VCF_VALIDATOR_VERSION)
+
+require_repo_name:
+ifndef REPO_NAME
+	$(error REPO_NAME not set)
+endif
+
+## build: build using local architecture
+build: require_repo_name
+	@echo '=> Build $(TAG)...'
+	$(DOCKER) build --file Dockerfile \
+		--build-arg VCF_VALIDATOR_VERSION=$(VCF_VALIDATOR_VERSION) \
+		--pull --tag $(TAG) .
+
+# common setup for buildx tasks
+buildx-setup: require_repo_name
+	@echo "Current buildx builders:"
+	$(DOCKER) buildx ls
+	@if ! $(DOCKER) buildx inspect --builder $(BUILDER) > /dev/null 2>&1; then \
+  		echo "Creating new builder '$(BUILDER)'"; \
+  		$(DOCKER) buildx create --name $(BUILDER); \
+	else \
+		echo "Using existing builder $(BUILDER)"; \
+	fi
+
+## buildx-publish: build and publish the multi-architecture image (amd64|arm64)
+buildx-publish: require_repo_name buildx-setup
+	@echo '=> Build and publish multi-arch image $(TAG)...'
+	$(DOCKER) buildx build --file Dockerfile \
+		--platform $(PLATFORMS) \
+		--builder $(BUILDER) \
+		--build-arg VCF_VALIDATOR_VERSION=$(VCF_VALIDATOR_VERSION) \
+		--progress plain \
+		--pull --push --tag $(TAG) .

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ docker-run-here --entrypoint "/vcf_assembly_checker" my-repo/vcf-validator:0.9.4
 docker-run-here --entrypoint "/test_validation_suite" my-repo/vcf-validator:0.9.4 --help
 ```
 
-**NOTE**: Doug DOnohoe has pushed an image using this `Dockerfile` that you can pull:
+**NOTE**: Doug Donohoe has pushed an image using this `Dockerfile` that you can pull:
 
 ```shell
  docker pull dougdonohoe/vcf-validator:0.9.4

--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ as defined in the Makefile.  You need to define `REPO_NAME` to specify where the
 REPO_NAME=my-repo make buildx-publish
 ```
 
+**NOTE**: This build can take over an hour due to the slowness of building the non-native half of the
+build (e.g., `arm64` is slow on `amd64` and vice-versa).
+
+
 To build and publish for a single platform (e.g., `arm64`):
 
 ```shell
@@ -337,32 +341,32 @@ PLATFORMS=linux/arm64 make buildx-publish
 
 #### Running VCF Validator via Docker
 
+Doug Donohoe has pushed an image using this `Dockerfile` that you can pull:
+
+```shell
+ docker pull dougdonohoe/vcf-validator:0.9.4
+```
+
 This alias is helpful when running docker images:
 
 ```shell
 alias docker-run-here='docker run -it --rm --workdir "$PWD" --volume "$PWD:$PWD"'
 ```
 
-Example usage of Docker image:
+Example usage of Docker image (if you built your own, replace `dougdonohoe` with `my-repo`):
 
 ```shell
 # get help
-docker-run-here my-repo/vcf-validator:0.9.4 --help
+docker-run-here dougdonohoe/vcf-validator:0.9.4 --help
 
 # example using test files
 cd test/input_files/v4.1/passed
-docker-run-here my-repo/vcf-validator:0.9.4 -i passed_meta_sample.vcf -r summary
+docker-run-here dougdonohoe/vcf-validator:0.9.4 -i passed_meta_sample.vcf -r summary
 
 // use --entrypoint to use other executables
-docker-run-here --entrypoint "/vcf_debugulator" my-repo/vcf-validator:0.9.4 --help
-docker-run-here --entrypoint "/vcf_assembly_checker" my-repo/vcf-validator:0.9.4 --help
-docker-run-here --entrypoint "/test_validation_suite" my-repo/vcf-validator:0.9.4 --help
-```
-
-**NOTE**: Doug Donohoe has pushed an image using this `Dockerfile` that you can pull:
-
-```shell
- docker pull dougdonohoe/vcf-validator:0.9.4
+docker-run-here --entrypoint "/vcf_debugulator" dougdonohoe/vcf-validator:0.9.4 --help
+docker-run-here --entrypoint "/vcf_assembly_checker" dougdonohoe/vcf-validator:0.9.4 --help
+docker-run-here --entrypoint "/test_validation_suite" dougdonohoe/vcf-validator:0.9.4 --help
 ```
 
 ## Miscellaneous

--- a/docker/gcc-x86.patch
+++ b/docker/gcc-x86.patch
@@ -1,0 +1,148 @@
+--- a/usr/lib/gcc/x86_64-linux-gnu/10/plugin/include/config/i386/i386.h.orig	2021-01-10 12:35:39.000000000 +0100
++++ b/usr/lib/gcc/x86_64-linux-gnu/10/plugin/include/config/i386/i386.h	2022-01-23 10:22:59.579197064 +0100
+@@ -2497,7 +2497,7 @@
+
+ #include "insn-attr-common.h"
+
+-#include "common/config/i386/i386-cpuinfo.h"
++#include "config/i386/i386-cpuinfo.h"
+
+ class pta
+ {
+--- /dev/null
++++ b/usr/lib/gcc/x86_64-linux-gnu/10/plugin/include/config/i386/i386-cpuinfo.h
+@@ -0,0 +1,134 @@
++/* Get CPU type and Features for x86 processors.
++   Copyright (C) 2012-2020 Free Software Foundation, Inc.
++   Contributed by Sriraman Tallam (tmsriram@google.com)
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify it under
++the terms of the GNU General Public License as published by the Free
++Software Foundation; either version 3, or (at your option) any later
++version.
++
++GCC is distributed in the hope that it will be useful, but WITHOUT ANY
++WARRANTY; without even the implied warranty of MERCHANTABILITY or
++FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++for more details.
++
++Under Section 7 of GPL version 3, you are granted additional
++permissions described in the GCC Runtime Library Exception, version
++3.1, as published by the Free Software Foundation.
++
++You should have received a copy of the GNU General Public License and
++a copy of the GCC Runtime Library Exception along with this program;
++see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
++<http://www.gnu.org/licenses/>.  */
++
++/* Processor Vendor and Models. */
++
++enum processor_vendor
++{
++  VENDOR_INTEL = 1,
++  VENDOR_AMD,
++  VENDOR_OTHER,
++  BUILTIN_VENDOR_MAX = VENDOR_OTHER,
++  VENDOR_MAX
++};
++
++/* Any new types or subtypes have to be inserted at the end. */
++
++enum processor_types
++{
++  INTEL_BONNELL = 1,
++  INTEL_CORE2,
++  INTEL_COREI7,
++  AMDFAM10H,
++  AMDFAM15H,
++  INTEL_SILVERMONT,
++  INTEL_KNL,
++  AMD_BTVER1,
++  AMD_BTVER2,
++  AMDFAM17H,
++  INTEL_KNM,
++  INTEL_GOLDMONT,
++  INTEL_GOLDMONT_PLUS,
++  INTEL_TREMONT,
++  CPU_TYPE_MAX,
++  BUILTIN_CPU_TYPE_MAX = CPU_TYPE_MAX
++};
++
++enum processor_subtypes
++{
++  INTEL_COREI7_NEHALEM = 1,
++  INTEL_COREI7_WESTMERE,
++  INTEL_COREI7_SANDYBRIDGE,
++  AMDFAM10H_BARCELONA,
++  AMDFAM10H_SHANGHAI,
++  AMDFAM10H_ISTANBUL,
++  AMDFAM15H_BDVER1,
++  AMDFAM15H_BDVER2,
++  AMDFAM15H_BDVER3,
++  AMDFAM15H_BDVER4,
++  AMDFAM17H_ZNVER1,
++  INTEL_COREI7_IVYBRIDGE,
++  INTEL_COREI7_HASWELL,
++  INTEL_COREI7_BROADWELL,
++  INTEL_COREI7_SKYLAKE,
++  INTEL_COREI7_SKYLAKE_AVX512,
++  INTEL_COREI7_CANNONLAKE,
++  INTEL_COREI7_ICELAKE_CLIENT,
++  INTEL_COREI7_ICELAKE_SERVER,
++  AMDFAM17H_ZNVER2,
++  INTEL_COREI7_CASCADELAKE,
++  INTEL_COREI7_TIGERLAKE,
++  INTEL_COREI7_COOPERLAKE,
++  CPU_SUBTYPE_MAX
++};
++
++/* Priority of i386 features, greater value is higher priority.   This is
++   used to decide the order in which function dispatch must happen.  For
++   instance, a version specialized for SSE4.2 should be checked for dispatch
++   before a version for SSE3, as SSE4.2 implies SSE3.  */
++enum feature_priority
++{
++  P_NONE = 0,
++  P_MMX,
++  P_SSE,
++  P_SSE2,
++  P_SSE3,
++  P_SSSE3,
++  P_PROC_SSSE3,
++  P_SSE4_A,
++  P_PROC_SSE4_A,
++  P_SSE4_1,
++  P_SSE4_2,
++  P_PROC_SSE4_2,
++  P_POPCNT,
++  P_AES,
++  P_PCLMUL,
++  P_AVX,
++  P_PROC_AVX,
++  P_BMI,
++  P_PROC_BMI,
++  P_FMA4,
++  P_XOP,
++  P_PROC_XOP,
++  P_FMA,
++  P_PROC_FMA,
++  P_BMI2,
++  P_AVX2,
++  P_PROC_AVX2,
++  P_AVX512F,
++  P_PROC_AVX512F,
++  P_PROC_DYNAMIC
++};
++
++/* These are the values for vendor types, cpu types and subtypes.  Cpu
++   types and subtypes should be subtracted by the corresponding start
++   value.  */
++
++#define M_CPU_TYPE_START (BUILTIN_VENDOR_MAX)
++#define M_CPU_SUBTYPE_START \
++  (M_CPU_TYPE_START + BUILTIN_CPU_TYPE_MAX)
++#define M_VENDOR(a) (a)
++#define M_CPU_TYPE(a) (M_CPU_TYPE_START + a)
++#define M_CPU_SUBTYPE(a) (M_CPU_SUBTYPE_START + a)

--- a/docker/install-dependencies-docker.sh
+++ b/docker/install-dependencies-docker.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# NOTE: this is a modified version of install-dependencies.sh, where we strip out the things we
+# either install via apt (i.e., libz, libbz2, libboost) or build via build2 (i.e., odb).
+#
+
+# stop the script if any command fails
+set -e
+
+# keep track of the last executed command
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+# echo an error message before exiting
+trap 'if [ $? -ne 0 ]; then echo "******ERROR******: \"${last_command}\" command failed with exit code $?." && echo "Installation of dependencies failed!"; fi' EXIT
+
+help_install_dependencies="Usage:
+./install_dependencies.sh [os_name]         default OS is linux
+./install_dependencies.sh --help            displays help
+
+os_name can be:
+  - linux
+  - osx
+
+it installs the given dependencies:
+  - odb compiler                            odb-2.4.0
+  - odb common runtime library              libodb-2.4.0
+  - odb sqlite runtime library              libodb-sqlite-2.4.0
+  - bzip library                            bzip2-1.0.6
+  - zlib library                            zlib-1.2.11
+  - curl library                            curl-7.62.0
+  - openssl library                         openssl-1.1.1f
+  - c-ares library                          c-ares-1.15.0
+  - boost library                           boost-1.72.0
+  - nghttp2 library (osx only)              nghttp2-1.47.0
+  - brotli library (osx only)               brotli-1.0.9
+
+for linux:
+./install_dependencies.sh linux
+
+for mac os:
+./install_dependencies.sh osx
+"
+
+
+if [ "$#" -eq 0 ]
+then
+    OS_NAME="linux"
+elif [ "$#" -eq 1 ]
+then
+  if [[ "$1" == "--help" ]]
+  then
+      echo "$help_install_dependencies"
+      exit
+  elif [[ "$1" == "linux" ]]
+  then
+      OS_NAME="linux"
+  elif [[ "$1" == "osx" ]]
+  then
+      OS_NAME="osx"
+  else
+    echo "$help_install_dependencies"
+    exit
+  fi
+else
+  echo "requires 1 argument at max"
+  echo "$help_install_dependencies"
+  exit
+fi
+
+dependencies_dir=$OS_NAME"_dependencies"
+
+# Download ODB runtime library, sqlite DB plugin for ODB, libbz2 and libz.
+echo "creating directory $dependencies_dir"
+mkdir -p $dependencies_dir && cd $dependencies_dir
+
+dependencies_dir_abs_path=`pwd`
+
+echo "installing openssl"
+mkdir openssl
+wget https://www.openssl.org/source/openssl-1.1.1f.tar.gz -O ./openssl-1.1.1f.tar.gz
+tar xzf ./openssl-1.1.1f.tar.gz
+cd openssl-1.1.1f
+LIBS="-lcrypto -ldl" \
+./config -fPIC no-shared no-threads \
+        --prefix=$dependencies_dir_abs_path/openssl \
+        --openssldir=$dependencies_dir_abs_path/openssl
+make && make install_sw
+cd ..
+
+echo "installing c-ares"
+mkdir c-ares
+wget https://c-ares.haxx.se/download/c-ares-1.15.0.tar.gz -O ./c-ares-1.15.0.tar.gz
+tar xzf ./c-ares-1.15.0.tar.gz
+cd c-ares-1.15.0
+./configure --prefix=$dependencies_dir_abs_path/c-ares
+make && make install
+cd ..
+
+echo "installing libcurl"
+mkdir curl
+wget https://curl.haxx.se/download/curl-7.62.0.tar.gz -O ./curl-7.62.0.tar.gz
+tar zxf ./curl-7.62.0.tar.gz
+cd curl-7.62.0
+LDFLAGS="-L$dependencies_dir_abs_path/openssl/lib -L$dependencies_dir_abs_path/c-ares/lib" \
+CPPFLAGS="-I$dependencies_dir_abs_path/openssl/include -I$dependencies_dir_abs_path/c-ares/include" \
+./configure --disable-shared \
+            --enable-static \
+            --without-librtmp \
+            --without-ca-bundle \
+            --disable-ldap \
+            --without-zlib \
+            --without-libidn2 \
+            --without-nss \
+            --enable-ares=$dependencies_dir_abs_path/c-ares \
+            --with-ssl=$dependencies_dir_abs_path/openssl \
+            --prefix=$dependencies_dir_abs_path/curl
+make && make install


### PR DESCRIPTION
At my current job, we use the Linux build of `vcf_validator` in  Docker.  This is a limitation because the image is for the `amd64` architecture, and with the advent of Apple Silicon, we need `arm64` images for the M1 /M2 chipset.

After much trial and error, I managed to get a Dockerized build working.  

There are some notable changes from simply using `install_dependencies.sh`:

+ using `odb` `v2.5.0-b.23` (instead of `v2.4.0`) as that has adjustments so it can compile on arm64 (according to [Code Synthesis](https://codesynthesis.com/products/odb/doc/install-build2.xhtml), maker of ODB, even though it is beta, it is stable).
+ building `odb` via `build2` (instead of downloading a binary)
+ building `libodb` via `build2` (instead of building it in `install_dependencies.sh`)
+ had to add `-Wno-narrowing` to compilation step to avoid errors (doesn't appear to break anything; test pass) 
+ `libz`, `libbz2`, `libboost-*` installed via `apt`

Contributing this as it may be useful to someone else.

One can test out my image:

```
docker pull dougdonohoe/vcf-validator:0.9.4
```

I updated the `README.md` with more detail and example usage.