### PR TITLE
mac build issue resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,9 +156,9 @@ elseif (OSX)
     ${EXT_LIB_PATH}/openssl/lib/libssl.a
     ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
     ${EXT_LIB_PATH}/nghttp2/lib/libnghttp2.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc-static.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc.a
     ${EXT_LIB_PATH}/libbz2.a
     ${EXT_LIB_PATH}/libz.a
     ${EXT_LIB_PATH}/libodb-sqlite.a
@@ -276,9 +276,9 @@ elseif (OSX)
     ${EXT_LIB_PATH}/openssl/lib/libssl.a
     ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
     ${EXT_LIB_PATH}/nghttp2/lib/libnghttp2.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc-static.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc.a
     ${Boost_LIBRARIES}
     ${EXT_LIB_PATH}/libbz2.a
     ${EXT_LIB_PATH}/libz.a


### PR DESCRIPTION
Mac build failure, checked with Monterey - arm,  reasons were

1. libodb and libodb_sqlite packages having a file named "version", which is not a c/c++ file, gets included in build instead of the file "version" in c++ sdk include files due to include path specs.
The version files are renamed during installation as version_odb and version_sqlite, that correct version file is included for build.

2. packages brotli and ssl were old and did not support newer Mac platforms.
These packages are updated to versions which support Mac arm 64bit as well.
The min build platform for Mac is set as 12.0, to avoid warnings during build.
Brotli package is built twice to get dynamic and static libraries, required for curl and vcf validator. (earlier version had both built as binaries with different name and new version have both static and dynamic output with same name). vcf-validator's CMakeFile.txt is also updated to work with new brotli output name.

Fixes #226 