### PR TITLE
Test failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,9 +156,9 @@ elseif (OSX)
     ${EXT_LIB_PATH}/openssl/lib/libssl.a
     ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
     ${EXT_LIB_PATH}/nghttp2/lib/libnghttp2.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc-static.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc.a
     ${EXT_LIB_PATH}/libbz2.a
     ${EXT_LIB_PATH}/libz.a
     ${EXT_LIB_PATH}/libodb-sqlite.a
@@ -276,9 +276,9 @@ elseif (OSX)
     ${EXT_LIB_PATH}/openssl/lib/libssl.a
     ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
     ${EXT_LIB_PATH}/nghttp2/lib/libnghttp2.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec-static.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc-static.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec.a
+    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc.a
     ${Boost_LIBRARIES}
     ${EXT_LIB_PATH}/libbz2.a
     ${EXT_LIB_PATH}/libz.a

--- a/inc/util/string_utils.hpp
+++ b/inc/util/string_utils.hpp
@@ -79,11 +79,11 @@ namespace ebi
     inline std::string remove_end_of_line(std::string &line)
     {
         bool has_r = false, has_n = false;
-        if (line.back() == '\n') {
+        if (!line.empty() && line.back() == '\n') {
             has_n = true;
             line.pop_back();
         }
-        if (line.back() == '\r') {
+        if (!line.empty() && line.back() == '\r') {
             has_r = true;
             line.pop_back();
         }

--- a/src/vcf/store_parse_policy.cpp
+++ b/src/vcf/store_parse_policy.cpp
@@ -278,7 +278,7 @@ namespace ebi
         // check contigs are contiguous
         auto iterator = finished_contigs.find(m_line_tokens[CHROM][0]);
         bool contig_not_found = iterator == finished_contigs.end();
-        bool contig_already_finished = iterator->second;
+        bool contig_already_finished = contig_not_found ? false : iterator->second;
         if (contig_not_found) {
             // contig not found in the map: finishing the previous contig, and starting a new one
             if (finished_contigs.size() != 0) {


### PR DESCRIPTION
test_validator_v41,.. had failed tests when run after Mac build issue fix. 

They failed with invalid files where no version data was present in ##fileformat header.
It gives access violation as 'back' operation is made on empty string.
Fix is to check whether the string is empty before the operation.

A similar access violation was observed during further check where an iterator was accessed even when it is invalid.
Fix is to check validity of iterator before the access.