### PR TITLE
GA4GHTT-226 - updates for Mac build - 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,57 +60,57 @@ jobs:
 
 
   ### Mac OS build
-#  macos_build:
-#    runs-on: macos-11
-#    strategy:
-#      matrix:
-#        config:
-#          - {cc: "gcc", cxx: "g++"}
-#          - {cc: "clang", cxx: "clang++"}
-#
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Install dependencies
-#      run: |
-#        brew update
-#        brew install boost sqlite3
-#        ./install_dependencies.sh osx
-#    - name: Compile and test
-#      run: |
-#        mkdir build && cd build && cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} ..
-#        export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/icu4c/lib
-#        make -j2
-#        cd .. && ./build/bin/test_validation_suite
-#    - name: Rename release files
-#      if: ${{ matrix.config.cc == 'clang' }}
-#      run: |
-#        mv build/bin/vcf_validator vcf_validator_macos
-#        mv build/bin/vcf_debugulator vcf_debugulator_macos
-#        mv build/bin/vcf_assembly_checker vcf_assembly_checker_macos
-#    - name: Upload vcf-validator
-#      uses: actions/upload-artifact@v3
-#      if: ${{ matrix.config.cc == 'clang' }}
-#      with:
-#        name: vcf_validator_macos
-#        path: vcf_validator_macos
-#    - name: Upload vcf-debugulator
-#      uses: actions/upload-artifact@v3
-#      if: ${{ matrix.config.cc == 'clang' }}
-#      with:
-#        name: vcf_debugulator_macos
-#        path: vcf_debugulator_macos
-#    - name: Upload vcf-assembly-checker
-#      uses: actions/upload-artifact@v3
-#      if: ${{ matrix.config.cc == 'clang' }}
-#      with:
-#        name: vcf_assembly_checker_macos
-#        path: vcf_assembly_checker_macos
+  macos_build:
+    runs-on: macos-12
+    strategy:
+      matrix:
+        config:
+          - {cc: "gcc", cxx: "g++"}
+          - {cc: "clang", cxx: "clang++"}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        #brew update
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install boost sqlite3 automake
+        ./install_dependencies.sh osx
+    - name: Compile and test
+      run: |
+        mkdir build && cd build && cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} ..
+        export LIBRARY_PATH=${LIBRARY_PATH}:/usr/local/opt/icu4c/lib:/usr/local/lib
+        make -j2
+        cd .. && ./build/bin/test_validation_suite
+    - name: Rename release files
+      if: ${{ matrix.config.cc == 'clang' }}
+      run: |
+        mv build/bin/vcf_validator vcf_validator_macos
+        mv build/bin/vcf_debugulator vcf_debugulator_macos
+        mv build/bin/vcf_assembly_checker vcf_assembly_checker_macos
+    - name: Upload vcf-validator
+      uses: actions/upload-artifact@v3
+      if: ${{ matrix.config.cc == 'clang' }}
+      with:
+        name: vcf_validator_macos
+        path: vcf_validator_macos
+    - name: Upload vcf-debugulator
+      uses: actions/upload-artifact@v3
+      if: ${{ matrix.config.cc == 'clang' }}
+      with:
+        name: vcf_debugulator_macos
+        path: vcf_debugulator_macos
+    - name: Upload vcf-assembly-checker
+      uses: actions/upload-artifact@v3
+      if: ${{ matrix.config.cc == 'clang' }}
+      with:
+        name: vcf_assembly_checker_macos
+        path: vcf_assembly_checker_macos
 
 
   ### Release job (tags only)
   create_release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [ linux_build ]
+    needs: [ linux_build, macos_build ]
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,9 @@ elseif (WINDOWS)
 endif ()
 
 include_directories ("${EXT_LIB_PATH}")
-include_directories ("${EXT_LIB_PATH}/curl/include")
+if (NOT OSX)
+  include_directories ("${EXT_LIB_PATH}/curl/include")
+endif ()
 
 # Compiler and linkers flags
 if (LINUX)
@@ -151,16 +153,7 @@ if (LINUX)
 elseif (OSX)
   set (THIRD_PARTY_LIBRARIES
     ${Boost_LIBRARIES}
-    ${EXT_LIB_PATH}/curl/lib/libcurl.a
-    ${EXT_LIB_PATH}/c-ares/lib/libcares.a
-    ${EXT_LIB_PATH}/openssl/lib/libssl.a
-    ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
-    ${EXT_LIB_PATH}/nghttp2/lib/libnghttp2.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc.a
-    ${EXT_LIB_PATH}/libbz2.a
-    ${EXT_LIB_PATH}/libz.a
+    libcurl.a
     ${EXT_LIB_PATH}/libodb-sqlite.a
     ${EXT_LIB_PATH}/libodb.a
     mod_sqlite3
@@ -271,17 +264,8 @@ elseif (OSX)
   set (LIBRARIES_TO_LINK
     mod_vcf
     mod_odb
-    ${EXT_LIB_PATH}/curl/lib/libcurl.a
-    ${EXT_LIB_PATH}/c-ares/lib/libcares.a
-    ${EXT_LIB_PATH}/openssl/lib/libssl.a
-    ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
-    ${EXT_LIB_PATH}/nghttp2/lib/libnghttp2.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlicommon.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlidec.a
-    ${EXT_LIB_PATH}/brotli/lib/libbrotlienc.a
+    libcurl.a
     ${Boost_LIBRARIES}
-    ${EXT_LIB_PATH}/libbz2.a
-    ${EXT_LIB_PATH}/libz.a
     ${EXT_LIB_PATH}/libodb-sqlite.a
     ${EXT_LIB_PATH}/libodb.a
     mod_sqlite3

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -20,14 +20,12 @@ it installs the given dependencies:
   - odb compiler                            odb-2.4.0
   - odb common runtime library              libodb-2.4.0
   - odb sqlite runtime library              libodb-sqlite-2.4.0
-  - bzip library                            bzip2-1.0.6
-  - zlib library                            zlib-1.2.11
-  - curl library                            curl-7.62.0
-  - openssl library                         openssl-1.1.1w
-  - c-ares library                          c-ares-1.15.0
-  - boost library                           boost-1.72.0
-  - nghttp2 library (osx only)              nghttp2-1.47.0
-  - brotli library (osx only)               brotli-1.1.0
+  - bzip library (linux only)               bzip2-1.0.6
+  - zlib library (linux only)               zlib-1.2.11
+  - curl library (linux only)               curl-7.62.0
+  - openssl library (linux only)            openssl-1.1.1w
+  - c-ares library (linux only)             c-ares-1.15.0
+  - boost library (linux only)              boost-1.72.0
 
 for linux:
 ./install_dependencies.sh linux
@@ -106,83 +104,56 @@ fi
 ./configure --with-libodb=../libodb-2.4.0 && make
 cd ..
 
-echo "installing libbz2"
-# This is commented till the bzip.org site is recovered.
-# wget http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz -O ./libbz2.tar.gz
-# tar zxf ./libbz2.tar.gz
-# Till then we can trust ubuntu archives.
-wget http://archive.ubuntu.com/ubuntu/pool/main/b/bzip2/bzip2_1.0.6.orig.tar.bz2 -O ./libbz2.tar.bz2
-tar jxf ./libbz2.tar.bz2
-cd bzip2-1.0.6 && make
-cd ..
-
-echo "installing libz"
-wget http://prdownloads.sourceforge.net/libpng/zlib-1.2.11.tar.gz?download -O ./libz.tar.gz
-tar zxf ./libz.tar.gz
-cd zlib-1.2.11 && cmake . && make
-cd ..
-
-dependencies_dir_abs_path=`pwd`
-
-echo "installing openssl"
-mkdir openssl
-#using latest openssl which supports mac arm as well
-wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz -O ./openssl-1.1.1w.tar.gz
-tar xzf ./openssl-1.1.1w.tar.gz
-cd openssl-1.1.1w
-LIBS="-lcrypto -ldl" \
-./config -fPIC no-shared no-threads \
-        --prefix=$dependencies_dir_abs_path/openssl \
-        --openssldir=$dependencies_dir_abs_path/openssl
-make && make install_sw
-cd ..
-
-echo "installing c-ares"
-mkdir c-ares
-wget https://c-ares.haxx.se/download/c-ares-1.15.0.tar.gz -O ./c-ares-1.15.0.tar.gz
-tar xzf ./c-ares-1.15.0.tar.gz
-cd c-ares-1.15.0
-./configure --prefix=$dependencies_dir_abs_path/c-ares
-make && make install
-cd ..
-
-if [[ "$OS_NAME" == "osx" ]]
+if [[ "$OS_NAME" != "osx" ]]
 then
-  echo "installing nghttp2"
-  mkdir nghttp2
-  wget https://github.com/nghttp2/nghttp2/releases/download/v1.47.0/nghttp2-1.47.0.tar.gz -O ./nghttp2-1.47.0.tar.gz
-  tar xzf ./nghttp2-1.47.0.tar.gz
-  cd nghttp2-1.47.0
-  ./configure --prefix=$dependencies_dir_abs_path/nghttp2
+  #linux 
+  echo "installing libbz2"
+  # This is commented till the bzip.org site is recovered.
+  # wget http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz -O ./libbz2.tar.gz
+  # tar zxf ./libbz2.tar.gz
+  # Till then we can trust ubuntu archives.
+  wget http://archive.ubuntu.com/ubuntu/pool/main/b/bzip2/bzip2_1.0.6.orig.tar.bz2 -O ./libbz2.tar.bz2
+  tar jxf ./libbz2.tar.bz2
+  cd bzip2-1.0.6 && make
+  cd ..
+
+  echo "installing libz"
+  wget http://prdownloads.sourceforge.net/libpng/zlib-1.2.11.tar.gz?download -O ./libz.tar.gz
+  tar zxf ./libz.tar.gz
+  cd zlib-1.2.11 && cmake . && make
+  cd ..
+
+  dependencies_dir_abs_path=`pwd`
+
+  echo "installing openssl"
+  mkdir openssl
+  #using latest openssl which supports mac arm as well
+  wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz -O ./openssl-1.1.1w.tar.gz
+  tar xzf ./openssl-1.1.1w.tar.gz
+  cd openssl-1.1.1w
+  LIBS="-lcrypto -ldl" \
+  ./config -fPIC no-shared no-threads \
+          --prefix=$dependencies_dir_abs_path/openssl \
+          --openssldir=$dependencies_dir_abs_path/openssl
+  make && make install_sw
+  cd ..
+
+  echo "installing c-ares"
+  mkdir c-ares
+  wget https://c-ares.haxx.se/download/c-ares-1.15.0.tar.gz -O ./c-ares-1.15.0.tar.gz
+  tar xzf ./c-ares-1.15.0.tar.gz
+  cd c-ares-1.15.0
+  ./configure --prefix=$dependencies_dir_abs_path/c-ares
   make && make install
   cd ..
 
-  echo "installing brotli"
-  mkdir brotli
-  #using brotli 1.1.0
-  wget https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz -O ./brotli-1.1.0.tar.gz
-  tar xzf ./brotli-1.1.0.tar.gz
-  cd brotli-1.1.0
-  #for curl build, which uses dylib
-  cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$dependencies_dir_abs_path/brotli -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 -DBUILD_SHARED_LIBS=ON
-  make && make install
-  #for validator, which uses static lib
-  cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=$dependencies_dir_abs_path/brotli -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 -DBUILD_SHARED_LIBS=OFF
-  make && make install
-  cd ..
-fi
-
-echo "installing libcurl"
-mkdir curl
-wget https://curl.haxx.se/download/curl-7.62.0.tar.gz -O ./curl-7.62.0.tar.gz
-tar zxf ./curl-7.62.0.tar.gz
-cd curl-7.62.0
-if [[ "$OS_NAME" == "osx" ]]
-then
-  #set min mac version as 12.0 as all other dependencies have it, to avoid warning during link
-  LDFLAGS="-L$dependencies_dir_abs_path/openssl/lib -L$dependencies_dir_abs_path/c-ares/lib -L$dependencies_dir_abs_path/nghttp2/lib -L$dependencies_dir_abs_path/brotli/lib" \
-  CPPFLAGS="-I$dependencies_dir_abs_path/openssl/include -I$dependencies_dir_abs_path/c-ares/include -I$dependencies_dir_abs_path/nghttp2/include -I$dependencies_dir_abs_path/brotli/include" \
-  CFLAGS="-mmacosx-version-min=12.0" \
+  echo "installing libcurl"
+  mkdir curl
+  wget https://curl.haxx.se/download/curl-7.62.0.tar.gz -O ./curl-7.62.0.tar.gz
+  tar zxf ./curl-7.62.0.tar.gz
+  cd curl-7.62.0
+  LDFLAGS="-L$dependencies_dir_abs_path/openssl/lib -L$dependencies_dir_abs_path/c-ares/lib" \
+  CPPFLAGS="-I$dependencies_dir_abs_path/openssl/include -I$dependencies_dir_abs_path/c-ares/include" \
   ./configure --disable-shared \
               --enable-static \
               --without-librtmp \
@@ -194,27 +165,9 @@ then
               --enable-ares=$dependencies_dir_abs_path/c-ares \
               --with-ssl=$dependencies_dir_abs_path/openssl \
               --prefix=$dependencies_dir_abs_path/curl
-else
-  #linux
-  LDFLAGS="-L$dependencies_dir_abs_path/openssl/lib -L$dependencies_dir_abs_path/c-ares/lib -L$dependencies_dir_abs_path/nghttp2/lib -L$dependencies_dir_abs_path/brotli/lib" \
-  CPPFLAGS="-I$dependencies_dir_abs_path/openssl/include -I$dependencies_dir_abs_path/c-ares/include -I$dependencies_dir_abs_path/nghttp2/include -I$dependencies_dir_abs_path/brotli/include" \
-  ./configure --disable-shared \
-              --enable-static \
-              --without-librtmp \
-              --without-ca-bundle \
-              --disable-ldap \
-              --without-zlib \
-              --without-libidn2 \
-              --without-nss \
-              --enable-ares=$dependencies_dir_abs_path/c-ares \
-              --with-ssl=$dependencies_dir_abs_path/openssl \
-              --prefix=$dependencies_dir_abs_path/curl
-fi
-make && make install
-cd ..
+  make && make install
+  cd ..
 
-if [[ "$OS_NAME" == "linux" ]]
-then
   echo "installing  boost"
   wget https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz -O ./boost.tar.gz
   tar zxf ./boost.tar.gz
@@ -238,8 +191,13 @@ fi
 # Make easier to find the static libraries
 cp libodb-2.4.0/odb/.libs/libodb.a .
 cp libodb-sqlite-2.4.0/odb/sqlite/.libs/libodb-sqlite.a .
-cp bzip2-1.0.6/libbz2.a .
-cp zlib-1.2.11/libz.a .
+
+if [[ "$OS_NAME" != "osx" ]]
+then
+  #linux
+  cp bzip2-1.0.6/libbz2.a .
+  cp zlib-1.2.11/libz.a .
+fi
 
 # copy headers
 cp -r libodb-2.4.0/odb ./
@@ -266,4 +224,3 @@ echo "Dependencies folder:"
 ls $dependencies_dir
 
 echo -e "\nAutomatic installation completed successfully."
-

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -127,7 +127,7 @@ then
 
   echo "installing openssl"
   mkdir openssl
-  #using latest openssl which supports mac arm as well
+  #using openssl v1.1.1w which supports mac arm as well
   wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz -O ./openssl-1.1.1w.tar.gz
   tar xzf ./openssl-1.1.1w.tar.gz
   cd openssl-1.1.1w

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -108,10 +108,6 @@ if [[ "$OS_NAME" != "osx" ]]
 then
   #linux 
   echo "installing libbz2"
-  # This is commented till the bzip.org site is recovered.
-  # wget http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz -O ./libbz2.tar.gz
-  # tar zxf ./libbz2.tar.gz
-  # Till then we can trust ubuntu archives.
   wget http://archive.ubuntu.com/ubuntu/pool/main/b/bzip2/bzip2_1.0.6.orig.tar.bz2 -O ./libbz2.tar.bz2
   tar jxf ./libbz2.tar.bz2
   cd bzip2-1.0.6 && make


### PR DESCRIPTION
Changes to have Mac build - part 2.

Uses Mac version 12 instead of 11 for build.
Update of home-brew is disabled as build fails at times on environment setup.
zstd path added along with icu on library path export.
Enabled Mac build configuration in build.yml and added to release job as well.
Mac build uses libcurl provided by OS instead of building from source, as the build fails due to home-brew python installation issues.
 