### PR TITLE
EVA-3674 - Use dynamic libraries from boost in OSX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,6 @@ jobs:
     - name: Compile and test
       run: |
         mkdir build && cd build && cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} ..
-        export LIBRARY_PATH=${LIBRARY_PATH}:/opt/homebrew/opt/icu4c/lib:/opt/homebrew/lib
         make -j2
         cd .. && ./build/bin/test_validation_suite
     - name: Rename release files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if (LINUX)
 elseif (OSX)
   # Mac build not fully static. include system libraries to be dynamic
   set (CMAKE_EXE_LINKER_FLAGS)
-  set (Boost_USE_STATIC_LIBS ON)             # only find static libs
+  set (Boost_USE_STATIC_LIBS OFF)            # only find static libs
 elseif (WINDOWS)
   set (Boost_USE_STATIC_LIBS ON)             # only find static libs
   set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT") # also requires boost with runtime-link=static
@@ -265,11 +265,6 @@ elseif (OSX)
     mod_vcf
     mod_odb
     libcurl.a
-    libbz2.a
-    libz.a
-    libssl.a
-    libcrypto.a
-    libcares.a
     ${Boost_LIBRARIES}
     ${EXT_LIB_PATH}/libodb-sqlite.a
     ${EXT_LIB_PATH}/libodb.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ if (LINUX)
 elseif (OSX)
   # Mac build not fully static. include system libraries to be dynamic
   set (CMAKE_EXE_LINKER_FLAGS)
-  set (Boost_USE_STATIC_LIBS OFF)            # only find static libs
+  set (Boost_USE_STATIC_LIBS OFF)            # use dynamically linked libraries
 elseif (WINDOWS)
   set (Boost_USE_STATIC_LIBS ON)             # only find static libs
   set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT") # also requires boost with runtime-link=static


### PR DESCRIPTION
And reverted the integration of statically linked libraries