### PR TITLE
EVA-3662 - Enable build with dynamically linked dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,11 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libsqlite3-0 libsqlite3-dev cmake wget build-essential
+        sudo apt-get install cmake wget build-essential
         ./install_dependencies.sh linux
     - name: Compile and test
       run: |
-        mkdir build && cd build && cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} ..
+        mkdir build && cd build && cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} -DCMAKE_C_COMPILER=${{ matrix.config.cc }} -DSTATIC_BUILD=1 ..
         make -j2
         cd .. && ./build/bin/test_validation_suite
     - name: Rename release files
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         #brew update
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install boost sqlite3 automake
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install boost automake
         ./install_dependencies.sh osx
     - name: Compile and test
       run: |
@@ -106,7 +106,7 @@ jobs:
     - name: Install dependencies
       run: |
         #brew update
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install boost sqlite3 automake libtool
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install boost automake libtool
         ./install_dependencies.sh osx
     - name: Compile and test
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,17 +27,64 @@ else ()
   message (ERROR "Operating system not recognised. Expected Windows, Linux or Darwin, but found ${CMAKE_SYSTEM_NAME}")
 endif ()
 
-# Include directories
-message("include_directories (inc)")
-message("include_directories (lib)")
+if (DEFINED EXT_LIB_PATH AND NOT EXISTS "${EXT_LIB_PATH}")
+  message (FATAL_ERROR "The provided folder for dependencies (EXT_LIB_PATH=${EXT_LIB_PATH}) doesn't exist. Please, either provide a correct folder or don't provide it (and remove cmake cache) to search in default folders.")
+endif()
 
+# Include directories
 include_directories (inc)
 include_directories (lib)
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-unknown-pragmas") # No unknown pragmas: it's ok that gcc doesn't know about ODB's pragmas
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-unknown-pragmas")
 
-# Dynamic libraries for boost
-set (Boost_USE_STATIC_LIBS OFF)
+if (DEFINED STATIC_BUILD)
+  # dependencies from install_dependencies.sh should be in ${PROJECT_SOURCE_DIR}/dependencies/build/
+  set (EXT_LIB_PATH "${PROJECT_SOURCE_DIR}/dependencies/build")
+  message("EXT_LIB_PATH: ${EXT_LIB_PATH}")
+
+  # Set the CMAKE_PREFIX_PATH to search for libraries
+  set (CMAKE_PREFIX_PATH "${EXT_LIB_PATH}")
+  message("CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
+
+  # static libraries for boost
+  set (Boost_USE_STATIC_LIBS ON)
+#  set (BUILD_SHARED_LIBS OFF)
+#  set (CMAKE_EXE_LINKER_FLAGS "-static")
+#  set (CMAKE_FIND_LIBRARY_SUFFIXES .a)
+#  set (CMAKE_EXE_LINK_DYNAMIC_C_FLAGS)       # remove -Wl,-Bdynamic
+#  set (CMAKE_EXE_LINK_DYNAMIC_CXX_FLAGS)
+#  set (CMAKE_SHARED_LIBRARY_C_FLAGS)         # remove -fPIC
+#  set (CMAKE_SHARED_LIBRARY_CXX_FLAGS)
+#  set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)    # remove -rdynamic
+#  set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS)
+  # Hard coded libraries
+  set (HARD_CODED_LIBRARIES
+          ${EXT_LIB_PATH}/lib/libbz2.a
+          ${EXT_LIB_PATH}/lib/libcares.a
+          ${EXT_LIB_PATH}/lib/libz.a
+  )
+  find_package(OpenSSL)
+  if(OPENSSL_FOUND)
+    message("OPENSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
+    include_directories(${OPENSSL_INCLUDE_DIR})
+    message("OPENSSL_LIBRARIES: ${OPENSSL_LIBRARIES}")
+    list (APPEND HARD_CODED_LIBRARIES
+            ${OPENSSL_LIBRARIES}
+            )
+  else()
+    list (APPEND HARD_CODED_LIBRARIES
+            ${EXT_LIB_PATH}/lib/libssl.a
+            ${EXT_LIB_PATH}/lib/libcrypto.a
+            )
+  endif()
+  if(NOT OpenSSL_FOUND)
+    message("CURL_INCLUDE_DIRS: ${CURL_INCLUDE_DIRS}/curl")
+    include_directories(${CURL_INCLUDE_DIRS}/curl)
+  endif()
+else()
+  # Dynamic libraries for boost
+  set (Boost_USE_STATIC_LIBS OFF)
+endif()
 
 find_package (Threads REQUIRED)
 find_package (Boost COMPONENTS filesystem iostreams program_options regex log thread system REQUIRED )
@@ -55,12 +102,13 @@ endif()
 message("Boost_LIBRARIES: ${Boost_LIBRARIES}")
 message("Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
 message("CURL_LIBRARIES: ${CURL_LIBRARIES}")
+message("HARD_CODED_LIBRARIES: ${HARD_CODED_LIBRARIES}")
 message("CMAKE_THREAD_LIBS_INIT: ${CMAKE_THREAD_LIBS_INIT}")
 
 set (THIRD_PARTY_LIBRARIES
         ${Boost_LIBRARIES}
         ${CURL_LIBRARIES}
-        dl
+        ${HARD_CODED_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
         )
 
@@ -118,7 +166,6 @@ set (LIBRARIES_TO_LINK
         ${CMAKE_THREAD_LIBS_INIT}
         )
 
-
 # Build tests
 set (V41_TESTS test/vcf/parser_v41_test.cpp)
 set (V42_TESTS test/vcf/parser_v42_test.cpp)
@@ -161,7 +208,6 @@ add_executable (test_validator_v43 test/main_test.cpp ${V43_TESTS})
 target_link_libraries (test_validator_v43 ${LIBRARIES_TO_LINK})
 enable_testing ()
 add_test (NAME ValidatorTests_v43 COMMAND test_validator_v43)
-
 
 add_executable (test_validator_v44 test/main_test.cpp ${V44_TESTS})
 target_link_libraries (test_validator_v44 ${LIBRARIES_TO_LINK})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,46 +52,14 @@ if(CURL_FOUND)
   include_directories(${CURL_INCLUDE_DIRS})
 endif()
 
-find_package(c-ares REQUIRED)
-if(c-ares_FOUND)
-  message("c-ares_INCLUDE_DIRS: ${c-ares_INCLUDE_DIRS}")
-  include_directories(${c-ares_INCLUDE_DIRS})
-endif()
-
-find_package(OpenSSL REQUIRED)
-if(OPENSSL_FOUND)
-  message("OPENSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
-  include_directories(${OPENSSL_INCLUDE_DIR})
-endif()
-
-find_package(BZIP2 REQUIRED)
-if(BZIP2_FOUND)
-  message("BZIP2_INCLUDE_DIR: ${BZIP2_INCLUDE_DIR}")
-  include_directories(${BZIP2_INCLUDE_DIR})
-endif()
-
-find_package(ZLIB REQUIRED)
-if(ZLIB_FOUND)
-  message("BZIP2_INCLUDE_DIR: ${ZLIB_INCLUDE_DIR}")
-  include_directories(${ZLIB_INCLUDE_DIR})
-endif()
-
 message("Boost_LIBRARIES: ${Boost_LIBRARIES}")
 message("Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
 message("CURL_LIBRARIES: ${CURL_LIBRARIES}")
-message("c-ares_LIBRARIES: ${c-ares_LIBRARIES}")
-message("OPENSSL_LIBRARIES: ${OPENSSL_LIBRARIES}")
-message("ZLIB_LIBRARIES: ${ZLIB_LIBRARIES}")
-message("BZIP2_LIBRARIES: ${BZIP2_LIBRARIES}")
 message("CMAKE_THREAD_LIBS_INIT: ${CMAKE_THREAD_LIBS_INIT}")
 
 set (THIRD_PARTY_LIBRARIES
         ${Boost_LIBRARIES}
         ${CURL_LIBRARIES}
-        ${c-ares_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
-        ${ZLIB_LIBRARIES}
-        ${BZIP2_LIBRARIES}
         dl
         ${CMAKE_THREAD_LIBS_INIT}
         )
@@ -146,9 +114,6 @@ set (LIBRARIES_TO_LINK
         mod_vcf
         ${Boost_LIBRARIES}
         ${CURL_LIBRARIES}
-        ${ZLIB_LIBRARIES}
-        ${BZIP2_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
         dl
         ${CMAKE_THREAD_LIBS_INIT}
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ set (vcf-validator_VERSION_MINOR 9)
 set (vcf-validator_VERSION_PATCH 7)
 
 configure_file (
-  "${PROJECT_SOURCE_DIR}/inc/cmake_config.hpp.in"
-  "${PROJECT_SOURCE_DIR}/inc/cmake_config.hpp"
+        "${PROJECT_SOURCE_DIR}/inc/cmake_config.hpp.in"
+        "${PROJECT_SOURCE_DIR}/inc/cmake_config.hpp"
 )
 
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -27,208 +27,131 @@ else ()
   message (ERROR "Operating system not recognised. Expected Windows, Linux or Darwin, but found ${CMAKE_SYSTEM_NAME}")
 endif ()
 
-
 # Include directories
+message("include_directories (inc)")
+message("include_directories (lib)")
+
 include_directories (inc)
 include_directories (lib)
 
-if (DEFINED EXT_LIB_PATH AND NOT EXISTS "${EXT_LIB_PATH}")
-  message (FATAL_ERROR "The provided folder for dependencies (EXT_LIB_PATH=${EXT_LIB_PATH}) doesn't exist. Please, either provide a correct folder or don't provide it (and remove cmake cache) to search in default folders.")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-unknown-pragmas") # No unknown pragmas: it's ok that gcc doesn't know about ODB's pragmas
+
+# Dynamic libraries for boost
+set (Boost_USE_STATIC_LIBS OFF)
+
+find_package (Threads REQUIRED)
+find_package (Boost COMPONENTS filesystem iostreams program_options regex log thread system REQUIRED )
+if(Boost_FOUND)
+  message("Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
+  include_directories(${Boost_INCLUDE_DIRS})
 endif()
 
-# default folder for dependencies (written by install_dependencies.sh), unless provided by the user
-if (LINUX)
-  set (DEFAULT_EXT_LIB_PATH "${PROJECT_SOURCE_DIR}/linux_dependencies")
-  if (NOT EXISTS "${DEFAULT_EXT_LIB_PATH}")
-    set (EXT_LIB_PATH "/usr/local/bin" CACHE STRING "Absolute path to libraries")
-  else()
-    set (EXT_LIB_PATH "${DEFAULT_EXT_LIB_PATH}" CACHE STRING "Absolute path to libraries") # cached: this instruction is ignored if the user provided the variable
-    if (EXISTS "${EXT_LIB_PATH}/boost")
-      set (SELF_COMPILED_BOOST TRUE)
-    else ()
-      set (SELF_COMPILED_BOOST FALSE)
-    endif()
-  endif()
-elseif (WINDOWS)
-  set (EXT_LIB_PATH "${PROJECT_SOURCE_DIR}/lib/windows_specific" CACHE STRING "Absolute path to libraries")
-  if (NOT EXISTS "${PROJECT_SOURCE_DIR}/windows_dependencies")
-    message(FATAL_ERROR "Please run first install_dependencies.bat")
-  endif ()
-  include_directories (windows_dependencies)
-  include_directories (windows_dependencies/curl/include)
-endif ()
+find_package(CURL REQUIRED)
+if(CURL_FOUND)
+  message("CURL_INCLUDE_DIRS: ${CURL_INCLUDE_DIRS}")
+  include_directories(${CURL_INCLUDE_DIRS})
+endif()
 
-if (NOT OSX)
-  include_directories ("${EXT_LIB_PATH}")
-  include_directories ("${EXT_LIB_PATH}/curl/include")
-endif ()
+find_package(c-ares REQUIRED)
+if(c-ares_FOUND)
+  message("c-ares_INCLUDE_DIRS: ${c-ares_INCLUDE_DIRS}")
+  include_directories(${c-ares_INCLUDE_DIRS})
+endif()
 
-# Compiler and linkers flags
-if (LINUX)
-  # Static Build Extra Flags for Linux Static Build
-  set (BUILD_SHARED_LIBS OFF)
-  set (CMAKE_EXE_LINKER_FLAGS "-static")
-  set (CMAKE_FIND_LIBRARY_SUFFIXES .a)
-  set (CMAKE_EXE_LINK_DYNAMIC_C_FLAGS)       # remove -Wl,-Bdynamic
-  set (CMAKE_EXE_LINK_DYNAMIC_CXX_FLAGS)
-  set (CMAKE_SHARED_LIBRARY_C_FLAGS)         # remove -fPIC
-  set (CMAKE_SHARED_LIBRARY_CXX_FLAGS)
-  set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)    # remove -rdynamic
-  set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS)
-  set (Boost_USE_STATIC_LIBS ON)             # only find static libs
-elseif (OSX)
-  # Mac build not fully static. include system libraries to be dynamic
-  set (CMAKE_EXE_LINKER_FLAGS)
-  set (Boost_USE_STATIC_LIBS OFF)            # use dynamically linked libraries
-elseif (WINDOWS)
-  set (Boost_USE_STATIC_LIBS ON)             # only find static libs
-  set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT") # also requires boost with runtime-link=static
-  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd") # also requires boost with runtime-link=static
-endif ()
+find_package(OpenSSL REQUIRED)
+if(OPENSSL_FOUND)
+  message("OPENSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
+  include_directories(${OPENSSL_INCLUDE_DIR})
+endif()
 
-# Build type
-if (NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE  "RelWithDebInfo" CACHE STRING "Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel." FORCE)
-endif ()
+find_package(BZIP2 REQUIRED)
+if(BZIP2_FOUND)
+  message("BZIP2_INCLUDE_DIR: ${BZIP2_INCLUDE_DIR}")
+  include_directories(${BZIP2_INCLUDE_DIR})
+endif()
 
-message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
-find_package (Threads REQUIRED)
+find_package(ZLIB REQUIRED)
+if(ZLIB_FOUND)
+  message("BZIP2_INCLUDE_DIR: ${ZLIB_INCLUDE_DIR}")
+  include_directories(${ZLIB_INCLUDE_DIR})
+endif()
 
-# Flags
+message("Boost_LIBRARIES: ${Boost_LIBRARIES}")
+message("Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
+message("CURL_LIBRARIES: ${CURL_LIBRARIES}")
+message("c-ares_LIBRARIES: ${c-ares_LIBRARIES}")
+message("OPENSSL_LIBRARIES: ${OPENSSL_LIBRARIES}")
+message("ZLIB_LIBRARIES: ${ZLIB_LIBRARIES}")
+message("BZIP2_LIBRARIES: ${BZIP2_LIBRARIES}")
+message("CMAKE_THREAD_LIBS_INIT: ${CMAKE_THREAD_LIBS_INIT}")
 
-if (LINUX OR OSX)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-unknown-pragmas") # No unknown pragmas: it's ok that gcc doesn't know about ODB's pragmas
-  if (LINUX AND SELF_COMPILED_BOOST)
-    set (BOOST_CUSTOM_INCLUDE_DIR ${EXT_LIB_PATH}/boost)
-    include_directories (${BOOST_CUSTOM_INCLUDE_DIR} )
-    set (BOOST_LIBS_DIR ${BOOST_CUSTOM_INCLUDE_DIR}/stage/lib)
-    set (Boost_LIBRARIES
-            ${BOOST_LIBS_DIR}/libboost_atomic.a
-            ${BOOST_LIBS_DIR}/libboost_chrono.a
-            ${BOOST_LIBS_DIR}/libboost_date_time.a
-            ${BOOST_LIBS_DIR}/libboost_filesystem.a
-            ${BOOST_LIBS_DIR}/libboost_iostreams.a
-            ${BOOST_LIBS_DIR}/libboost_log.a
-            ${BOOST_LIBS_DIR}/libboost_log_setup.a
-            ${BOOST_LIBS_DIR}/libboost_program_options.a
-            ${BOOST_LIBS_DIR}/libboost_regex.a
-            ${BOOST_LIBS_DIR}/libboost_thread.a
-            )
-  else ()
-    find_package (Boost COMPONENTS filesystem iostreams program_options regex log thread system REQUIRED )
-    include_directories (${Boost_INCLUDE_DIR} )
-  endif()
-elseif (WINDOWS)
-  add_definitions(-DCURL_STATICLIB) # Needed to statically link libcurl
-  add_definitions(-DNOMINMAX) # Needed to suppress min and max definitions by Windows
-endif ()
+set (THIRD_PARTY_LIBRARIES
+        ${Boost_LIBRARIES}
+        ${CURL_LIBRARIES}
+        ${c-ares_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        ${BZIP2_LIBRARIES}
+        dl
+        ${CMAKE_THREAD_LIBS_INIT}
+        )
 
-
-# Application modules
-
-if (LINUX)
-  set (THIRD_PARTY_LIBRARIES
-    ${Boost_LIBRARIES}
-    ${EXT_LIB_PATH}/curl/lib/libcurl.a
-    ${EXT_LIB_PATH}/c-ares/lib/libcares.a
-    ${EXT_LIB_PATH}/openssl/lib/libssl.a
-    ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
-    ${EXT_LIB_PATH}/libbz2.a
-    ${EXT_LIB_PATH}/libz.a
-    ${CMAKE_THREAD_LIBS_INIT}
-  )
-elseif (OSX)
-  set (THIRD_PARTY_LIBRARIES
-    ${Boost_LIBRARIES}
-    libcurl.a
-    ${CMAKE_THREAD_LIBS_INIT}
-  )
-elseif (WINDOWS)
-  set (THIRD_PARTY_LIBRARIES
-    windows_dependencies/curl/lib/libcurl
-    ${CMAKE_THREAD_LIBS_INIT}
-  )
-endif ()
 
 set (MOD_VCF_SOURCES
-  inc/fasta/faidx.hpp
-  inc/fasta/fasta.hpp
-  inc/util/curl_easy.hpp
-  inc/vcf/assembly_checker.hpp
-  inc/vcf/assembly_check_report_writer.hpp
-  inc/vcf/compression.hpp
-  inc/vcf/error_policy.hpp
-  inc/vcf/file_structure.hpp
-  inc/vcf/meta_entry_visitor.hpp
-  inc/vcf/normalizer.hpp
-  inc/vcf/optional_policy.hpp
-  inc/vcf/parse_policy.hpp
-  inc/vcf/parsing_state.hpp
-  inc/vcf/record.hpp
-  inc/vcf/record_cache.hpp
-  inc/vcf/report_reader.hpp
-  inc/vcf/report_writer.hpp
-  inc/vcf/string_constants.hpp
-  inc/vcf/summary_report_writer.hpp
-  inc/vcf/validator_detail_v41.hpp
-  inc/vcf/validator_detail_v42.hpp
-  inc/vcf/validator_detail_v43.hpp
-  inc/vcf/validator_detail_v44.hpp
-  inc/vcf/validator.hpp
+        inc/fasta/faidx.hpp
+        inc/fasta/fasta.hpp
+        inc/util/curl_easy.hpp
+        inc/vcf/assembly_checker.hpp
+        inc/vcf/assembly_check_report_writer.hpp
+        inc/vcf/compression.hpp
+        inc/vcf/error_policy.hpp
+        inc/vcf/file_structure.hpp
+        inc/vcf/meta_entry_visitor.hpp
+        inc/vcf/normalizer.hpp
+        inc/vcf/optional_policy.hpp
+        inc/vcf/parse_policy.hpp
+        inc/vcf/parsing_state.hpp
+        inc/vcf/record.hpp
+        inc/vcf/record_cache.hpp
+        inc/vcf/report_reader.hpp
+        inc/vcf/report_writer.hpp
+        inc/vcf/string_constants.hpp
+        inc/vcf/summary_report_writer.hpp
+        inc/vcf/validator_detail_v41.hpp
+        inc/vcf/validator_detail_v42.hpp
+        inc/vcf/validator_detail_v43.hpp
+        inc/vcf/validator_detail_v44.hpp
+        inc/vcf/validator.hpp
 
-  src/fasta/faidx.cpp
-  src/fasta/fasta.cpp
-  src/util/curl_easy.cpp
-  src/vcf/abort_error_policy.cpp
-  src/vcf/assembly_checker.cpp
-  src/vcf/compression.cpp
-  src/vcf/meta_entry.cpp
-  src/vcf/normalizer.cpp
-  src/vcf/parsing_state.cpp
-  src/vcf/record.cpp
-  src/vcf/report_error_policy.cpp
-  src/vcf/source.cpp
-  src/vcf/store_parse_policy.cpp
-  src/vcf/validate_optional_policy.cpp
-  src/vcf/validator.cpp
-)
+        src/fasta/faidx.cpp
+        src/fasta/fasta.cpp
+        src/util/curl_easy.cpp
+        src/vcf/abort_error_policy.cpp
+        src/vcf/assembly_checker.cpp
+        src/vcf/compression.cpp
+        src/vcf/meta_entry.cpp
+        src/vcf/normalizer.cpp
+        src/vcf/parsing_state.cpp
+        src/vcf/record.cpp
+        src/vcf/report_error_policy.cpp
+        src/vcf/source.cpp
+        src/vcf/store_parse_policy.cpp
+        src/vcf/validate_optional_policy.cpp
+        src/vcf/validator.cpp
+        )
 add_library (mod_vcf STATIC ${MOD_VCF_SOURCES})
 target_link_libraries (mod_vcf ${THIRD_PARTY_LIBRARIES})
 
-
-# Libraries to link with executables
-if (LINUX)
-  set (LIBRARIES_TO_LINK
-    mod_vcf
-    ${EXT_LIB_PATH}/curl/lib/libcurl.a
-    ${EXT_LIB_PATH}/c-ares/lib/libcares.a
-    ${EXT_LIB_PATH}/openssl/lib/libssl.a
-    ${EXT_LIB_PATH}/openssl/lib/libcrypto.a
-    ${Boost_LIBRARIES}
-    ${EXT_LIB_PATH}/libbz2.a
-    ${EXT_LIB_PATH}/libz.a
-    dl
-    ${CMAKE_THREAD_LIBS_INIT}
-  )
-elseif (OSX)
-  set (LIBRARIES_TO_LINK
-    mod_vcf
-    libcurl.a
-    ${Boost_LIBRARIES}
-    dl
-    ${CMAKE_THREAD_LIBS_INIT}
-  )
-elseif (WINDOWS)
-  set (LIBRARIES_TO_LINK
-    mod_vcf
-    windows_dependencies/curl/lib/libcurl
-    ws2_32
-    crypt32
-    Wldap32
-    Normaliz
-    ${CMAKE_THREAD_LIBS_INIT}
-  )
-endif ()
+set (LIBRARIES_TO_LINK
+        mod_vcf
+        ${Boost_LIBRARIES}
+        ${CURL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        ${BZIP2_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        dl
+        ${CMAKE_THREAD_LIBS_INIT}
+        )
 
 
 # Build tests
@@ -237,27 +160,27 @@ set (V42_TESTS test/vcf/parser_v42_test.cpp)
 set (V43_TESTS test/vcf/parser_v43_test.cpp)
 set (V44_TESTS test/vcf/parser_v44_test.cpp)
 set (ALL_TESTS
-  test/assembly_report/assembly_report_test.cpp
-  test/fasta/faidx_test.cpp
-  test/fasta/fasta_test.cpp
-  test/vcf/assembly_checker_integration_test.cpp
-  test/vcf/assembly_checker_test.cpp
-  test/vcf/compressed_file_test.cpp
-  test/vcf/metaentry_test.cpp
-  test/vcf/normalize_test.cpp
-  test/vcf/optional_policy_test.cpp
-  test/vcf/parser_test_aux.hpp
-  test/vcf/parser_v41_test.cpp
-  test/vcf/parser_v42_test.cpp
-  test/vcf/parser_v43_test.cpp
-  test/vcf/parser_v44_test.cpp
-  test/vcf/predefined_info_tags_test.cpp
-  test/vcf/predefined_format_tags_test.cpp
-  test/vcf/record_cache_test.cpp
-  test/vcf/record_test.cpp
-  test/vcf/report_writer_test.cpp
-  test/vcf/test_utils.hpp
-)
+        test/assembly_report/assembly_report_test.cpp
+        test/fasta/faidx_test.cpp
+        test/fasta/fasta_test.cpp
+        test/vcf/assembly_checker_integration_test.cpp
+        test/vcf/assembly_checker_test.cpp
+        test/vcf/compressed_file_test.cpp
+        test/vcf/metaentry_test.cpp
+        test/vcf/normalize_test.cpp
+        test/vcf/optional_policy_test.cpp
+        test/vcf/parser_test_aux.hpp
+        test/vcf/parser_v41_test.cpp
+        test/vcf/parser_v42_test.cpp
+        test/vcf/parser_v43_test.cpp
+        test/vcf/parser_v44_test.cpp
+        test/vcf/predefined_info_tags_test.cpp
+        test/vcf/predefined_format_tags_test.cpp
+        test/vcf/record_cache_test.cpp
+        test/vcf/record_test.cpp
+        test/vcf/report_writer_test.cpp
+        test/vcf/test_utils.hpp
+        )
 
 add_executable (test_validator_v41 test/main_test.cpp ${V41_TESTS})
 target_link_libraries (test_validator_v41 ${LIBRARIES_TO_LINK})
@@ -274,6 +197,7 @@ target_link_libraries (test_validator_v43 ${LIBRARIES_TO_LINK})
 enable_testing ()
 add_test (NAME ValidatorTests_v43 COMMAND test_validator_v43)
 
+
 add_executable (test_validator_v44 test/main_test.cpp ${V44_TESTS})
 target_link_libraries (test_validator_v44 ${LIBRARIES_TO_LINK})
 enable_testing ()
@@ -283,7 +207,6 @@ add_executable (test_validation_suite test/main_test.cpp ${ALL_TESTS})
 target_link_libraries (test_validation_suite ${LIBRARIES_TO_LINK})
 enable_testing ()
 add_test (NAME ValidatorTests COMMAND test_validation_suite)
-
 
 # Build application binaries
 add_executable (vcf_validator src/validator_main.cpp)

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -57,66 +57,67 @@ else
   exit
 fi
 
-dependencies_dir=$OS_NAME"_dependencies"
+dependencies_dir="dependencies"
+
 
 #check for already downloaded files
 if [ "$(ls -A $dependencies_dir)" ]; then
   echo "ERROR: Found non-empty directory of a previous installation: \"$dependencies_dir\". Please remove the folder before running this script. Current contents:"
   ls $dependencies_dir
-  exit 0
+  exit 1
 fi
 
 
-# Download ODB runtime library, sqlite DB plugin for ODB, libbz2 and libz.
 echo "creating directory $dependencies_dir"
 mkdir -p $dependencies_dir && cd $dependencies_dir
 
+dependencies_dir_abs_path=`pwd`
+build_dir_abs_path=${dependencies_dir_abs_path}/build
+mkdir $build_dir_abs_path
+
 if [[ "$OS_NAME" != "osx" ]]
 then
-  #linux 
+  #linux
+
+  # Download libbz2 and libz.
   echo "installing libbz2"
   wget http://archive.ubuntu.com/ubuntu/pool/main/b/bzip2/bzip2_1.0.6.orig.tar.bz2 -O ./libbz2.tar.bz2
   tar jxf ./libbz2.tar.bz2
-  cd bzip2-1.0.6 && make
+  cd bzip2-1.0.6 && make && make install PREFIX=$build_dir_abs_path
   cd ..
 
   echo "installing libz"
   wget http://prdownloads.sourceforge.net/libpng/zlib-1.2.11.tar.gz?download -O ./libz.tar.gz
   tar zxf ./libz.tar.gz
-  cd zlib-1.2.11 && cmake . && make
+  cd zlib-1.2.11 && ./configure --prefix=$build_dir_abs_path && make install
   cd ..
 
-  dependencies_dir_abs_path=`pwd`
-
   echo "installing openssl"
-  mkdir openssl
   #using openssl v1.1.1w which supports mac arm as well
   wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz -O ./openssl-1.1.1w.tar.gz
   tar xzf ./openssl-1.1.1w.tar.gz
   cd openssl-1.1.1w
   LIBS="-lcrypto -ldl" \
-  ./config -fPIC no-shared no-threads \
-          --prefix=$dependencies_dir_abs_path/openssl \
-          --openssldir=$dependencies_dir_abs_path/openssl
+  ./config -static --static -fPIC no-shared no-threads \
+          --prefix=$build_dir_abs_path \
+          --openssldir=$build_dir_abs_path
   make && make install_sw
   cd ..
 
   echo "installing c-ares"
-  mkdir c-ares
   wget https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz -O ./c-ares-1.15.0.tar.gz
   tar xzf ./c-ares-1.15.0.tar.gz
   cd c-ares-1.15.0
-  ./configure --prefix=$dependencies_dir_abs_path/c-ares
+  ./configure --prefix=$build_dir_abs_path
   make && make install
   cd ..
 
   echo "installing libcurl"
-  mkdir curl
   wget https://curl.haxx.se/download/curl-7.62.0.tar.gz -O ./curl-7.62.0.tar.gz
   tar zxf ./curl-7.62.0.tar.gz
   cd curl-7.62.0
-  LDFLAGS="-L$dependencies_dir_abs_path/openssl/lib -L$dependencies_dir_abs_path/c-ares/lib" \
-  CPPFLAGS="-I$dependencies_dir_abs_path/openssl/include -I$dependencies_dir_abs_path/c-ares/include" \
+  LDFLAGS="-L$build_dir_abs_path/lib" \
+  CPPFLAGS="-I$build_dir_abs_path/include" \
   ./configure --disable-shared \
               --enable-static \
               --without-librtmp \
@@ -125,9 +126,9 @@ then
               --without-zlib \
               --without-libidn2 \
               --without-nss \
-              --enable-ares=$dependencies_dir_abs_path/c-ares \
-              --with-ssl=$dependencies_dir_abs_path/openssl \
-              --prefix=$dependencies_dir_abs_path/curl
+              --enable-ares=$build_dir_abs_path \
+              --with-ssl=$build_dir_abs_path \
+              --prefix=$build_dir_abs_path
   make && make install
   cd ..
 
@@ -141,30 +142,22 @@ then
   # The next user-config.jam should fix that.
   # Documentation on building iostreams: https://www.boost.org/doc/libs/1_72_0/libs/iostreams/doc/index.html
   # Documentation on specifying zlib and bzip2: https://boostorg.github.io/build/manual/master/index.html#bbv2.reference.tools.libraries.zlib
+#  echo "
+#using zlib : 1.2.11 : <include>${build_dir_abs_path}/zlib-1.2.11 <search>${build_dir_abs_path}/ ;
+#using bzip2 : 1.0.6 : <include>${build_dir_abs_path}/bzip2-1.0.6 <search>${build_dir_abs_path}/ ;
+#" > tools/build/src/user-config.jam
   echo "
-using zlib : 1.2.11 : <include>${dependencies_dir_abs_path}/zlib-1.2.11 <search>${dependencies_dir_abs_path}/ ;
-using bzip2 : 1.0.6 : <include>${dependencies_dir_abs_path}/bzip2-1.0.6 <search>${dependencies_dir_abs_path}/ ;
+using zlib : 1.2.11 : <source>${dependencies_dir_abs_path}/zlib-1.2.11 ;
+using bzip2 : 1.0.6 : <source>${dependencies_dir_abs_path}/bzip2-1.0.6 ;
 " > tools/build/src/user-config.jam
 
-  ./bootstrap.sh --with-libraries=filesystem,iostreams,log,program_options,regex && ./b2 link=static
+  ./bootstrap.sh --prefix=${build_dir_abs_path}  --with-libraries=filesystem,iostreams,log,program_options,regex,system && ./b2 link=static --prefix=${build_dir_abs_path} install
   cd ..
 fi
-
-
-# Make easier to find the static libraries
-
-if [[ "$OS_NAME" != "osx" ]]
-then
-  #linux
-  cp bzip2-1.0.6/libbz2.a .
-  cp zlib-1.2.11/libz.a .
-fi
-
-# copy headers
 
 cd ..
 
 echo "Dependencies folder:"
-ls $dependencies_dir
+ls $build_dir_abs_path
 
 echo -e "\nAutomatic installation completed successfully."


### PR DESCRIPTION
This PR changes the build process so that vcf-validator can be built with dynamically linked libraries in conda.
I also remove the windows build which why it's failing.
