### PR TITLE
fixes build issue in aarch64 observed in some builds

### DIFF
--- a/src/vcf/compression.cpp
+++ b/src/vcf/compression.cpp
@@ -91,7 +91,7 @@ namespace ebi
 
     std::string get_compression_from_magic_num(const std::vector<char> &line)
     {
-        std::vector<std::pair<std::vector<char>, std::string>> types = {
+        std::vector<std::pair<std::vector<signed char>, std::string>> types = {
             { { 66, 90, 104 }, BZ2 },
             { { 31, -117 }, GZ },
             { { -3, 55, 122, 88, 90 }, XZ },


### PR DESCRIPTION
observed a build error during check of aarch64 linux on a vm.
from error, it has char as unsigned data type by default and hence couldn't hold -117 in the data.
explicitly made the type as signed char that it builds fine.